### PR TITLE
Remove jQuery lib and update code according to new JS checkout form function

### DIFF
--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -1,77 +1,119 @@
 <script type="text/javascript">
-    Payment.prototype.save = Payment.prototype.save.wrap(function(superMethod) {
-        var paymentMethod = jQuery("#co-payment-form").find("input[name='payment[method]']:checked").val();
+    if ((typeof jQuery === 'undefined') && ! window.jQuery) {
 
-        if (typeof paymentMethod == "undefined") {
-            alert('Please select one method');
+        if (typeof $ == 'function') {
+            var dlSignIsUsing = true;
+        } else {
+            var dlSignIsUsing = false;
+        }
 
-            return false;
-        } else if (paymentMethod == "omise_gateway") {
-            var omiseValidation = new Validation('co-payment-form');
+        function getScript(url, success) {
+            var script     = document.createElement('script');
+                script.src = url;
 
-            // If validate pass
-            if (omiseValidation.validate()) {
-                jQuery.getScript("https://cdn.omise.co/omise.min.js.gz", function() {
+            var head = document.getElementsByTagName('head')[0],
+                done = false;
 
-                    // Set Omise key
-                    Omise.setPublicKey("<?php echo $this->getOmiseKeys('public_key'); ?>");
+            // Attach handlers for all browsers
+            script.onload = script.onreadystatechange = function() {
+                if (! done && (!this.readyState || this.readyState == 'loaded' || this.readyState == 'complete')) {
+                    done = true;
 
-                    var form                = jQuery("#payment_form_omise_gateway"),
-                        formValidation      = form.find('.omise-validation-advice'),
-                        formValidationMsg   = formValidation.find('.validation-advice');
+                    // callback function provided as param
+                    success();
 
-                    jQuery("#payment-buttons-container").find("button").prop("disabled", true);
+                    script.onload = script.onreadystatechange = null;
+                    head.removeChild(script);
+                };
+            };
 
-                    // Serialize the form fields into a valid card object.
-                    var card = {
-                        "name": form.find("[data-omise=holder_name]").val(),
-                        "number": form.find("[data-omise=number]").val(),
-                        "expiration_month": form.find("[data-omise=expiration_month]").val(),
-                        "expiration_year": form.find("[data-omise=expiration_year]").val(),
-                        "security_code": form.find("[data-omise=security_code]").val()
-                    };
+            head.appendChild(script);
+        };
 
-                    formValidation.css({'opacity': 0, 'display': 'none'});
+        getScript('https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js', function() {
+            $nj = jQuery.noConflict();
+            hookPaymentSave($nj);
+        });
+    } else {
+        $nj = jQuery.noConflict();
+        hookPaymentSave($nj);
+    }
 
-                    // Send a request to create a token
-                    // then trigger the callback function once a response is received from Omise.
-                    // * Note that the response could be an error and this needs to be handled
-                    // * within the callback.
-                    Omise.createToken("card", card, function (statusCode, response) {
-                        // If has an error (can not create a card's token).
-                        if (response.object == "error") {
-                            // Display an error message - "Omise Response: "+response.message.
-                            formValidation.css({'opacity': 1, 'display': 'block'});
-                            formValidationMsg.html("Omise Response: "+response.message);
+    function hookPaymentSave(jQuery) {
+        Payment.prototype.save = Payment.prototype.save.wrap(function(superMethod) {
+            var paymentMethod = jQuery("#co-payment-form").find("input[name='payment[method]']:checked").val();
 
-                            jQuery("#payment-buttons-container").find("button").prop("disabled", false);
-                        } else if (typeof response.card != 'undefined' && !response.card.security_code_check) {
-                            // Display an error message - "Omise Response: Card authorization failure.".
-                            formValidation.css({'opacity': 1, 'display': 'block'});
-                            formValidationMsg.html("Omise Response: Card authorization failure.");
-
-                            jQuery("#payment-buttons-container").find("button").prop("disabled", false);
-                        } else {
-                            form.find("[data-omise=holder_name]").prop("disabled", true);
-                            form.find("[data-omise=number]").prop("disabled", true);
-                            form.find("[data-omise=expiration_month]").prop("disabled", true);
-                            form.find("[data-omise=expiration_year]").prop("disabled", true);
-                            form.find("[data-omise=security_code]").prop("disabled", true);
-
-                            form.find("[data-omise=omise_token]").val(response.id);
-
-                            return superMethod();
-                        };
-                    });
-
-                });
+            if (typeof paymentMethod == "undefined") {
+                alert('Please select one method');
 
                 return false;
+            } else if (paymentMethod == "omise_gateway") {
+                var omiseValidation = new Validation('co-payment-form');
+
+                // If validate pass
+                if (omiseValidation.validate()) {
+                    jQuery.getScript("https://cdn.omise.co/omise.min.js.gz", function() {
+
+                        // Set Omise key
+                        Omise.setPublicKey("<?php echo $this->getOmiseKeys('public_key'); ?>");
+
+                        var form                = jQuery("#payment_form_omise_gateway"),
+                            formValidation      = form.find('.omise-validation-advice'),
+                            formValidationMsg   = formValidation.find('.validation-advice');
+
+                        jQuery("#payment-buttons-container").find("button").prop("disabled", true);
+
+                        // Serialize the form fields into a valid card object.
+                        var card = {
+                            "name": form.find("[data-omise=holder_name]").val(),
+                            "number": form.find("[data-omise=number]").val(),
+                            "expiration_month": form.find("[data-omise=expiration_month]").val(),
+                            "expiration_year": form.find("[data-omise=expiration_year]").val(),
+                            "security_code": form.find("[data-omise=security_code]").val()
+                        };
+
+                        formValidation.css({'opacity': 0, 'display': 'none'});
+
+                        // Send a request to create a token
+                        // then trigger the callback function once a response is received from Omise.
+                        // * Note that the response could be an error and this needs to be handled
+                        // * within the callback.
+                        Omise.createToken("card", card, function (statusCode, response) {
+                            // If has an error (can not create a card's token).
+                            if (response.object == "error") {
+                                // Display an error message - "Omise Response: "+response.message.
+                                formValidation.css({'opacity': 1, 'display': 'block'});
+                                formValidationMsg.html("Omise Response: "+response.message);
+
+                                jQuery("#payment-buttons-container").find("button").prop("disabled", false);
+                            } else if (typeof response.card != 'undefined' && !response.card.security_code_check) {
+                                // Display an error message - "Omise Response: Card authorization failure.".
+                                formValidation.css({'opacity': 1, 'display': 'block'});
+                                formValidationMsg.html("Omise Response: Card authorization failure.");
+
+                                jQuery("#payment-buttons-container").find("button").prop("disabled", false);
+                            } else {
+                                form.find("[data-omise=holder_name]").prop("disabled", true);
+                                form.find("[data-omise=number]").prop("disabled", true);
+                                form.find("[data-omise=expiration_month]").prop("disabled", true);
+                                form.find("[data-omise=expiration_year]").prop("disabled", true);
+                                form.find("[data-omise=security_code]").prop("disabled", true);
+
+                                form.find("[data-omise=omise_token]").val(response.id);
+
+                                return superMethod();
+                            };
+                        });
+
+                    });
+
+                    return false;
+                }
+            } else {
+                return superMethod();
             }
-        } else {
-            return superMethod();
-        }
-    }, jQuery);
+        }, jQuery);
+    }
 </script>
 
 <?php

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -1,119 +1,93 @@
 <script type="text/javascript">
-    if ((typeof jQuery === 'undefined') && ! window.jQuery) {
+    function getScript(url, success) {
+        var script     = document.createElement("script");
+            script.src = url;
 
-        if (typeof $ == 'function') {
-            var dlSignIsUsing = true;
-        } else {
-            var dlSignIsUsing = false;
-        }
+        var head = document.getElementsByTagName("head")[0],
+            done = false;
 
-        function getScript(url, success) {
-            var script     = document.createElement('script');
-                script.src = url;
+        // Attach handlers for all browsers
+        script.onload = script.onreadystatechange = function() {
+            if (! done && (!this.readyState || this.readyState == "loaded" || this.readyState == "complete")) {
+                done = true;
 
-            var head = document.getElementsByTagName('head')[0],
-                done = false;
+                // callback function provided as param
+                success();
 
-            // Attach handlers for all browsers
-            script.onload = script.onreadystatechange = function() {
-                if (! done && (!this.readyState || this.readyState == 'loaded' || this.readyState == 'complete')) {
-                    done = true;
-
-                    // callback function provided as param
-                    success();
-
-                    script.onload = script.onreadystatechange = null;
-                    head.removeChild(script);
-                };
+                script.onload = script.onreadystatechange = null;
+                head.removeChild(script);
             };
-
-            head.appendChild(script);
         };
 
-        getScript('https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js', function() {
-            $nj = jQuery.noConflict();
-            hookPaymentSave($nj);
-        });
-    } else {
-        $nj = jQuery.noConflict();
-        hookPaymentSave($nj);
-    }
+        head.appendChild(script);
+    };
 
-    function hookPaymentSave(jQuery) {
-        Payment.prototype.save = Payment.prototype.save.wrap(function(superMethod) {
-            var paymentMethod = jQuery("#co-payment-form").find("input[name='payment[method]']:checked").val();
+    // Hook Payment.save function by wrapping Omise logic on top of the 'Payment.prototype.save'
+    Payment.prototype.save = Payment.prototype.save.wrap(function(superMethod) {
+        var omisePayment = document.getElementById("p_method_omise_gateway");
 
-            if (typeof paymentMethod == "undefined") {
-                alert('Please select one method');
+        if (! omisePayment.checked) {
+            return superMethod();
+        }
 
-                return false;
-            } else if (paymentMethod == "omise_gateway") {
-                var omiseValidation = new Validation('co-payment-form');
+        var validator = new Validation("co-payment-form");
 
-                // If validate pass
-                if (omiseValidation.validate()) {
-                    jQuery.getScript("https://cdn.omise.co/omise.min.js.gz", function() {
+        if (validator.validate()) {
+            checkout.setLoadWaiting('payment');
 
-                        // Set Omise key
-                        Omise.setPublicKey("<?php echo $this->getOmiseKeys('public_key'); ?>");
+            getScript("https://cdn.omise.co/omise.min.js.gz", function() {
+                // Set Omise key
+                Omise.setPublicKey("<?php echo $this->getOmiseKeys('public_key'); ?>");
 
-                        var form                = jQuery("#payment_form_omise_gateway"),
-                            formValidation      = form.find('.omise-validation-advice'),
-                            formValidationMsg   = formValidation.find('.validation-advice');
+                var form                  = document.getElementById("payment_form_omise_gateway"),
+                    formInput             = {
+                        "name"             : document.getElementById("omise_gateway_cc_name"),
+                        "number"           : document.getElementById("omise_gateway_cc_number"),
+                        "expiration_month" : document.getElementById("omise_gateway_expiration"),
+                        "expiration_year"  : document.getElementById("omise_gateway_expiration_yr"),
+                        "security_code"    : document.getElementById("omise_gateway_cc_cid"),
+                        "omise_token"      : document.getElementById("omise_gateway_token")
+                    },
+                    omiseValidationAdvice = document.getElementById("omise-validation-advice");
 
-                        jQuery("#payment-buttons-container").find("button").prop("disabled", true);
+                var card = {
+                    "name"             : formInput.name.value,
+                    "number"           : formInput.number.value,
+                    "expiration_month" : formInput.expiration_month.value,
+                    "expiration_year"  : formInput.expiration_year.value,
+                    "security_code"    : formInput.security_code.value
+                };
 
-                        // Serialize the form fields into a valid card object.
-                        var card = {
-                            "name": form.find("[data-omise=holder_name]").val(),
-                            "number": form.find("[data-omise=number]").val(),
-                            "expiration_month": form.find("[data-omise=expiration_month]").val(),
-                            "expiration_year": form.find("[data-omise=expiration_year]").val(),
-                            "security_code": form.find("[data-omise=security_code]").val()
-                        };
+                /** 
+                 * Send a request to create a token then trigger the callback function once
+                 * a response is received from Omise.
+                 *
+                 * Note that the response could be an error and this needs to be handled within
+                 * the callback.
+                 */
+                Omise.createToken("card", card, function(statusCode, response) {
+                    if (response.object == "error") {
+                        omiseValidationAdvice.innerHTML = response.message;
+                        checkout.setLoadWaiting(false);
+                    } else if (typeof response.card != 'undefined' && !response.card.security_code_check) {
+                        omiseValidationAdvice.innerHTML = 'This card cannot authorize, please contact our support.';
+                        checkout.setLoadWaiting(false);
+                    } else {
+                        formInput.omise_token.value         = response.id;
 
-                        formValidation.css({'opacity': 0, 'display': 'none'});
+                        formInput.name.disabled             = true;
+                        formInput.number.disabled           = true;
+                        formInput.expiration_month.disabled = true;
+                        formInput.expiration_year.disabled  = true;
+                        formInput.security_code.disabled    = true;
 
-                        // Send a request to create a token
-                        // then trigger the callback function once a response is received from Omise.
-                        // * Note that the response could be an error and this needs to be handled
-                        // * within the callback.
-                        Omise.createToken("card", card, function (statusCode, response) {
-                            // If has an error (can not create a card's token).
-                            if (response.object == "error") {
-                                // Display an error message - "Omise Response: "+response.message.
-                                formValidation.css({'opacity': 1, 'display': 'block'});
-                                formValidationMsg.html("Omise Response: "+response.message);
-
-                                jQuery("#payment-buttons-container").find("button").prop("disabled", false);
-                            } else if (typeof response.card != 'undefined' && !response.card.security_code_check) {
-                                // Display an error message - "Omise Response: Card authorization failure.".
-                                formValidation.css({'opacity': 1, 'display': 'block'});
-                                formValidationMsg.html("Omise Response: Card authorization failure.");
-
-                                jQuery("#payment-buttons-container").find("button").prop("disabled", false);
-                            } else {
-                                form.find("[data-omise=holder_name]").prop("disabled", true);
-                                form.find("[data-omise=number]").prop("disabled", true);
-                                form.find("[data-omise=expiration_month]").prop("disabled", true);
-                                form.find("[data-omise=expiration_year]").prop("disabled", true);
-                                form.find("[data-omise=security_code]").prop("disabled", true);
-
-                                form.find("[data-omise=omise_token]").val(response.id);
-
-                                return superMethod();
-                            };
-                        });
-
-                    });
-
-                    return false;
-                }
-            } else {
-                return superMethod();
-            }
-        }, jQuery);
-    }
+                        checkout.setLoadWaiting(false);
+                        return superMethod();
+                    };
+                });
+            });
+        }
+    });
 </script>
 
 <?php
@@ -145,7 +119,7 @@
 <?php $_code=$this->getMethodCode() ?>
 <ul class="form-list" id="payment_form_<?php echo $_code ?>" style="display:none;">
 
-    <li class="omise-validation-advice"><div class="validation-advice"></div></li>
+    <li><div id="omise-validation-advice" class="validation-advice"></div></li>
 
     <li>
         <label for="<?php echo $_code ?>_cc_type" class="required"><em>*</em><?php echo $this->__('Credit Card Type') ?></label>
@@ -159,7 +133,7 @@
             </select>
         </div>
 
-        <input data-omise="omise_token" type="hidden" name="payment[omise_token]">
+        <input id="<?php echo $_code ?>_token" data-omise="omise_token" type="hidden" name="payment[omise_token]">
     </li>
 
     <!-- Credit Card Holder Name -->

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -57,7 +57,7 @@
                     "security_code"    : formInput.security_code.value
                 };
 
-                /** 
+                /**
                  * Send a request to create a token then trigger the callback function once
                  * a response is received from Omise.
                  *
@@ -137,7 +137,7 @@
 
     <!-- Credit Card Holder Name -->
     <li>
-        <label for="<?php echo $_code ?>_cc_owner" class="required"><em>*</em><?php echo $this->__('Credit Card Holder Name') ?></label>
+        <label for="<?php echo $_code ?>_cc_name" class="required"><em>*</em><?php echo $this->__('Credit Card Holder Name') ?></label>
         <div class="input-box">
             <input type="text" data-omise="holder_name" id="<?php echo $_code ?>_cc_name" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name') ?>" class="input-text required-entry" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
         </div>

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -151,7 +151,7 @@ $_code = $this->getMethodCode();
             <em>*</em><?php echo $this->__('Credit Card Holder Name'); ?>
         </label>
         <div class="input-box">
-            <input id="<?php echo $_code; ?>_cc_name" type="text" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name'); ?>" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" class="input-text required-entry" />
+            <input id="<?php echo $_code; ?>_cc_name" type="text" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name'); ?>" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')); ?>" class="input-text required-entry" />
         </div>
     </li>
 
@@ -220,13 +220,13 @@ $_code = $this->getMethodCode();
                         <?php echo $this->__('Issue Number'); ?>:
                     </label>
                     <span class="input-box">
-                        <input id="<?php echo $_code; ?>_cc_issue" type="text" name="payment[cc_ss_issue]" title="<?php echo $this->__('Issue Number') ?>" value="" class="input-text validate-cc-ukss cvv" />
+                        <input id="<?php echo $_code; ?>_cc_issue" type="text" name="payment[cc_ss_issue]" title="<?php echo $this->__('Issue Number'); ?>" value="" class="input-text validate-cc-ukss cvv" />
                     </span>
                 </li>
 
                 <li>
                     <label for="<?php echo $_code; ?>_start_month">
-                        <?php echo $this->__('Start Date') ?>:
+                        <?php echo $this->__('Start Date'); ?>:
                     </label>
                     <div class="input-box">
                         <div class="v-fix">

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -132,14 +132,14 @@
             </select>
         </div>
 
-        <input id="<?php echo $_code ?>_token" data-omise="omise_token" type="hidden" name="payment[omise_token]">
+        <input id="<?php echo $_code ?>_token" type="hidden" name="payment[omise_token]">
     </li>
 
     <!-- Credit Card Holder Name -->
     <li>
         <label for="<?php echo $_code ?>_cc_name" class="required"><em>*</em><?php echo $this->__('Credit Card Holder Name') ?></label>
         <div class="input-box">
-            <input type="text" data-omise="holder_name" id="<?php echo $_code ?>_cc_name" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name') ?>" class="input-text required-entry" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
+            <input type="text" id="<?php echo $_code ?>_cc_name" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name') ?>" class="input-text required-entry" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
         </div>
     </li>
 
@@ -147,7 +147,7 @@
     <li>
         <label for="<?php echo $_code ?>_cc_number" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
         <div class="input-box">
-            <input autocomplete="off" type="text" data-omise="number" id="<?php echo $_code ?>_cc_number" name="payment[cc_number]" title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" />
+            <input autocomplete="off" type="text" id="<?php echo $_code ?>_cc_number" name="payment[cc_number]" title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" />
         </div>
     </li>
 
@@ -156,7 +156,7 @@
         <label for="<?php echo $_code ?>_expiration" class="required"><em>*</em><?php echo $this->__('Expiration Date') ?></label>
         <div class="input-box">
             <div class="v-fix">
-                <select data-omise="expiration_month" id="<?php echo $_code ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
+                <select id="<?php echo $_code ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
                 <?php $_ccExpMonth = $this->getInfoData('cc_exp_month') ?>
                 <?php foreach ($this->getCcMonths() as $k=>$v): ?>
                     <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpMonth): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
@@ -165,7 +165,7 @@
             </div>
             <div class="v-fix">
                 <?php $_ccExpYear = $this->getInfoData('cc_exp_year') ?>
-                <select data-omise="expiration_year" id="<?php echo $_code ?>_expiration_yr" name="payment[cc_exp_year]" class="year required-entry">
+                <select id="<?php echo $_code ?>_expiration_yr" name="payment[cc_exp_year]" class="year required-entry">
                 <?php foreach ($this->getCcYears() as $k=>$v): ?>
                     <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpYear): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
                 <?php endforeach ?>
@@ -181,7 +181,7 @@
         <label for="<?php echo $_code ?>_cc_cid" class="required"><em>*</em><?php echo $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
-                <input autocomplete="off" data-omise="security_code" type="password" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-cc-cvn" id="<?php echo $_code ?>_cc_cid" name="payment[cc_cid]" value="" />
+                <input autocomplete="off" type="password" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-cc-cvn" id="<?php echo $_code ?>_cc_cid" name="payment[cc_cid]" value="" />
             </div>
             <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
         </div>

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -39,8 +39,7 @@
                 // Set Omise key
                 Omise.setPublicKey("<?php echo $this->getOmiseKeys('public_key'); ?>");
 
-                var form                  = document.getElementById("payment_form_omise_gateway"),
-                    formInput             = {
+                var formInput             = {
                         "name"             : document.getElementById("omise_gateway_cc_name"),
                         "number"           : document.getElementById("omise_gateway_cc_number"),
                         "expiration_month" : document.getElementById("omise_gateway_expiration"),

--- a/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omisecc.phtml
@@ -114,127 +114,155 @@
  * @copyright   Copyright (c) 2006-2014 X.commerce, Inc. (http://www.magento.com)
  * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+$_code = $this->getMethodCode();
 ?>
-<?php $_code=$this->getMethodCode() ?>
-<ul class="form-list" id="payment_form_<?php echo $_code ?>" style="display:none;">
 
-    <li><div id="omise-validation-advice" class="validation-advice"></div></li>
+<ul id="payment_form_<?php echo $_code; ?>" class="form-list" style="display:none;">
 
+    <!-- Omise's validation advice -->
     <li>
-        <label for="<?php echo $_code ?>_cc_type" class="required"><em>*</em><?php echo $this->__('Credit Card Type') ?></label>
+        <div id="omise-validation-advice" class="validation-advice"></div>
+    </li>
+
+    <!-- Card Type -->
+    <li>
+        <label for="<?php echo $_code; ?>_cc_type" class="required">
+            <em>*</em><?php echo $this->__('Credit Card Type'); ?>
+        </label>
         <div class="input-box">
-            <select id="<?php echo $_code ?>_cc_type" name="payment[cc_type]" class="required-entry validate-cc-type-select">
-                <option value=""><?php echo $this->__('--Please Select--')?></option>
-            <?php $_ccType = $this->getInfoData('cc_type') ?>
-            <?php foreach ($this->getCcAvailableTypes() as $_typeCode => $_typeName): ?>
-                <option value="<?php echo $_typeCode ?>"<?php if($_typeCode==$_ccType): ?> selected="selected"<?php endif ?>><?php echo $_typeName ?></option>
-            <?php endforeach ?>
+            <select id="<?php echo $_code; ?>_cc_type" name="payment[cc_type]" class="required-entry validate-cc-type-select">
+                <option value=""><?php echo $this->__('--Please Select--'); ?></option>
+
+                <?php $_ccType = $this->getInfoData('cc_type'); ?>
+                <?php foreach ($this->getCcAvailableTypes() as $_typeCode => $_typeName): ?>
+                    <option value="<?php echo $_typeCode; ?>"<?php if($_typeCode == $_ccType): ?> selected="selected"<?php endif; ?>><?php echo $_typeName; ?></option>
+                <?php endforeach; ?>
             </select>
         </div>
 
-        <input id="<?php echo $_code ?>_token" type="hidden" name="payment[omise_token]">
+        <!-- For keep Omise's token -->
+        <input id="<?php echo $_code; ?>_token" type="hidden" name="payment[omise_token]">
     </li>
 
-    <!-- Credit Card Holder Name -->
+    <!-- Card Holder Name -->
     <li>
-        <label for="<?php echo $_code ?>_cc_name" class="required"><em>*</em><?php echo $this->__('Credit Card Holder Name') ?></label>
+        <label for="<?php echo $_code; ?>_cc_name" class="required">
+            <em>*</em><?php echo $this->__('Credit Card Holder Name'); ?>
+        </label>
         <div class="input-box">
-            <input type="text" id="<?php echo $_code ?>_cc_name" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name') ?>" class="input-text required-entry" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" />
+            <input id="<?php echo $_code; ?>_cc_name" type="text" name="payment[cc_name]" title="<?php echo $this->__('Credit Card Holder Name'); ?>" value="<?php echo $this->escapeHtml($this->getInfoData('cc_owner')) ?>" class="input-text required-entry" />
         </div>
     </li>
 
-    <!-- Credit Card Number -->
+    <!-- Card Number -->
     <li>
-        <label for="<?php echo $_code ?>_cc_number" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
+        <label for="<?php echo $_code; ?>_cc_number" class="required">
+            <em>*</em><?php echo $this->__('Credit Card Number'); ?>
+        </label>
         <div class="input-box">
-            <input autocomplete="off" type="text" id="<?php echo $_code ?>_cc_number" name="payment[cc_number]" title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" />
+            <input id="<?php echo $_code; ?>_cc_number" type="text" name="payment[cc_number]" title="<?php echo $this->__('Credit Card Number'); ?>" autocomplete="off" value="" class="input-text validate-cc-number validate-cc-type" />
         </div>
     </li>
 
     <!-- Expiration Date -->
-    <li id="<?php echo $_code ?>_cc_type_exp_div">
-        <label for="<?php echo $_code ?>_expiration" class="required"><em>*</em><?php echo $this->__('Expiration Date') ?></label>
+    <li id="<?php echo $_code; ?>_cc_type_exp_div">
+        <label for="<?php echo $_code; ?>_expiration" class="required">
+            <em>*</em><?php echo $this->__('Expiration Date'); ?>
+        </label>
         <div class="input-box">
             <div class="v-fix">
-                <select id="<?php echo $_code ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
-                <?php $_ccExpMonth = $this->getInfoData('cc_exp_month') ?>
-                <?php foreach ($this->getCcMonths() as $k=>$v): ?>
-                    <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpMonth): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
-                <?php endforeach ?>
+                <select id="<?php echo $_code; ?>_expiration" name="payment[cc_exp_month]" class="month validate-cc-exp required-entry">
+                    <?php $_ccExpMonth = $this->getInfoData('cc_exp_month'); ?>
+                    <?php foreach ($this->getCcMonths() as $k=>$v): ?>
+                        <option value="<?php echo $k ? $k : ''; ?>"<?php if($k == $_ccExpMonth): ?> selected="selected"<?php endif; ?>><?php echo $v; ?></option>
+                    <?php endforeach; ?>
                 </select>
             </div>
             <div class="v-fix">
-                <?php $_ccExpYear = $this->getInfoData('cc_exp_year') ?>
-                <select id="<?php echo $_code ?>_expiration_yr" name="payment[cc_exp_year]" class="year required-entry">
-                <?php foreach ($this->getCcYears() as $k=>$v): ?>
-                    <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpYear): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
-                <?php endforeach ?>
+                <?php $_ccExpYear = $this->getInfoData('cc_exp_year'); ?>
+                <select id="<?php echo $_code; ?>_expiration_yr" name="payment[cc_exp_year]" class="year required-entry">
+                    <?php foreach ($this->getCcYears() as $k=>$v): ?>
+                        <option value="<?php echo $k ? $k : ''; ?>"<?php if($k == $_ccExpYear): ?> selected="selected"<?php endif; ?>><?php echo $v; ?></option>
+                    <?php endforeach; ?>
                 </select>
             </div>
         </div>
     </li>
 
     <!-- Security Code -->
-    <?php echo $this->getChildHtml() ?>
+    <?php echo $this->getChildHtml(); ?>
+
     <?php if($this->hasVerification()): ?>
-    <li id="<?php echo $_code ?>_cc_type_cvv_div">
-        <label for="<?php echo $_code ?>_cc_cid" class="required"><em>*</em><?php echo $this->__('Card Verification Number') ?></label>
-        <div class="input-box">
-            <div class="v-fix">
-                <input autocomplete="off" type="password" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-cc-cvn" id="<?php echo $_code ?>_cc_cid" name="payment[cc_cid]" value="" />
+        <li id="<?php echo $_code; ?>_cc_type_cvv_div">
+            <label for="<?php echo $_code; ?>_cc_cid" class="required">
+                <em>*</em><?php echo $this->__('Card Verification Number'); ?>
+            </label>
+            <div class="input-box">
+                <div class="v-fix">
+                    <input id="<?php echo $_code; ?>_cc_cid" type="password" name="payment[cc_cid]" title="<?php echo $this->__('Card Verification Number'); ?>" autocomplete="off" value="" class="input-text cvv required-entry validate-cc-cvn" />
+                </div>
+                <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?'); ?></a>
             </div>
-            <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
-        </div>
-    </li>
+        </li>
     <?php endif; ?>
 
     <?php if ($this->hasSsCardType()): ?>
-    <li id="<?php echo $_code ?>_cc_type_ss_div">
-        <ul class="inner-form">
-            <li class="form-alt"><label for="<?php echo $_code ?>_cc_issue" class="required"><em>*</em><?php echo $this->__('Switch/Solo/Maestro Only') ?></label></li>
-            <li>
-                <label for="<?php echo $_code ?>_cc_issue"><?php echo $this->__('Issue Number') ?>:</label>
-                <span class="input-box">
-                    <input type="text" title="<?php echo $this->__('Issue Number') ?>" class="input-text validate-cc-ukss cvv" id="<?php echo $_code ?>_cc_issue" name="payment[cc_ss_issue]" value="" />
-                </span>
-            </li>
+        <li id="<?php echo $_code; ?>_cc_type_ss_div">
+            <ul class="inner-form">
+                <li class="form-alt">
+                    <label for="<?php echo $_code; ?>_cc_issue" class="required">
+                        <em>*</em><?php echo $this->__('Switch/Solo/Maestro Only'); ?>
+                    </label>
+                </li>
+                <li>
+                    <label for="<?php echo $_code; ?>_cc_issue">
+                        <?php echo $this->__('Issue Number'); ?>:
+                    </label>
+                    <span class="input-box">
+                        <input id="<?php echo $_code; ?>_cc_issue" type="text" name="payment[cc_ss_issue]" title="<?php echo $this->__('Issue Number') ?>" value="" class="input-text validate-cc-ukss cvv" />
+                    </span>
+                </li>
 
-            <li>
-                <label for="<?php echo $_code ?>_start_month"><?php echo $this->__('Start Date') ?>:</label>
-                <div class="input-box">
-                    <div class="v-fix">
-                        <select id="<?php echo $_code ?>_start_month" name="payment[cc_ss_start_month]" class="validate-cc-ukss month">
-                        <?php foreach ($this->getCcMonths() as $k=>$v): ?>
-                            <option value="<?php echo $k?$k:'' ?>"<?php if($k==$this->getInfoData('cc_ss_start_month')): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
-                        <?php endforeach ?>
-                        </select>
+                <li>
+                    <label for="<?php echo $_code; ?>_start_month">
+                        <?php echo $this->__('Start Date') ?>:
+                    </label>
+                    <div class="input-box">
+                        <div class="v-fix">
+                            <select id="<?php echo $_code; ?>_start_month" name="payment[cc_ss_start_month]" class="validate-cc-ukss month">
+                                <?php foreach ($this->getCcMonths() as $k=>$v): ?>
+                                    <option value="<?php echo $k ? $k : ''; ?>"<?php if($k == $this->getInfoData('cc_ss_start_month')): ?> selected="selected"<?php endif; ?>><?php echo $v; ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
+                        <div class="v-fix">
+                            <select id="<?php echo $_code; ?>_start_year" name="payment[cc_ss_start_year]" class="validate-cc-ukss year">
+                                <?php foreach ($this->getSsStartYears() as $k=>$v): ?>
+                                    <option value="<?php echo $k ? $k : ''; ?>"<?php if($k==$this->getInfoData('cc_ss_start_year')): ?> selected="selected"<?php endif; ?>><?php echo $v; ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                        </div>
                     </div>
-                    <div class="v-fix">
-                        <select id="<?php echo $_code ?>_start_year" name="payment[cc_ss_start_year]" class="validate-cc-ukss year">
-                        <?php foreach ($this->getSsStartYears() as $k=>$v): ?>
-                            <option value="<?php echo $k?$k:'' ?>"<?php if($k==$this->getInfoData('cc_ss_start_year')): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
-                        <?php endforeach ?>
-                        </select>
-                    </div>
-                </div>
-            </li>
-            <li class="adv-container">&nbsp;</li>
-        </ul>
-        <script type="text/javascript">
-        //<![CDATA[
-        var SSChecked<?php echo $_code ?> = function() {
-            var elm = $('<?php echo $_code ?>_cc_type');
-            if (['SS','SM','SO'].indexOf(elm.value) != -1) {
-                $('<?php echo $_code ?>_cc_type_ss_div').show();
-            } else {
-                $('<?php echo $_code ?>_cc_type_ss_div').hide();
-            }
-        };
+                </li>
+                <li class="adv-container">&nbsp;</li>
+            </ul>
 
-        Event.observe($('<?php echo $_code ?>_cc_type'), 'change', SSChecked<?php echo $_code ?>);
-        SSChecked<?php echo $_code ?>();
-        //]]>
-        </script>
-    </li>
+            <script type="text/javascript">
+                //<![CDATA[
+                var SSChecked<?php echo $_code; ?> = function() {
+                    var elm = $('<?php echo $_code; ?>_cc_type');
+                    if (['SS','SM','SO'].indexOf(elm.value) != -1) {
+                        $('<?php echo $_code; ?>_cc_type_ss_div').show();
+                    } else {
+                        $('<?php echo $_code; ?>_cc_type_ss_div').hide();
+                    }
+                };
+
+                Event.observe($('<?php echo $_code; ?>_cc_type'), 'change', SSChecked<?php echo $_code; ?>);
+                SSChecked<?php echo $_code; ?>();
+                //]]>
+            </script>
+        </li>
     <?php endif; ?>
 </ul>


### PR DESCRIPTION
**1. Objective reason**

Some users could't use Omise's checkout form because their theme/template doesn't include/import `jQuery` library to the project at the initial step that our plugin required. 

So, this PR's gonna provide another way to detach the jQuery lib out from the project and implement pure JS function to handle checkout form instead.

**2. Description of change**

- Implement pure JS to handle checkout form
- Remove jQuery & update code according to new checkout form handler functions

**3. Users affected by the change**

`-`

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

`-`

**7. Tested on**
- Magento (community version) 1.9.2.4

checkout form
![screen shot 2559-08-09 at 4 28 53 pm](https://cloud.githubusercontent.com/assets/2154669/17511816/eefdb884-5e4e-11e6-9ee6-3ac83d9ff2f6.png)

checkout form with validation failed
![screen shot 2559-08-09 at 4 28 08 pm](https://cloud.githubusercontent.com/assets/2154669/17511828/fc37ff28-5e4e-11e6-986f-23bd0778657e.png)

checkout form with `checkout.setLoadWaiting('payment');`
![screen shot 2559-08-09 at 4 28 56 pm](https://cloud.githubusercontent.com/assets/2154669/17511848/14272636-5e4f-11e6-8fdd-c9ce7f90f4b4.png)

checkout form with Omise's error (this one I bypassed a card's number value to Omise to let them throw an error, so from the image 👇 usually, it'll not pass to Omise server because validator gonna throw an validate error instead.)
![screen shot 2559-08-09 at 4 36 12 pm](https://cloud.githubusercontent.com/assets/2154669/17511966/b058d4c8-5e4f-11e6-98cb-b51aff93aeaa.png)
