### PR TITLE
Add the description for using with One Page Checkout (OPC) extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,102 @@ Then click the **Continue** button.
 
 6. Now head back to your admin dashboard orders section: `Sales` > `Orders`. You will see your order with `Pending` or `Processing` status (depends on your configuration).  
   ![Admin's order page](https://cdn.omise.co/assets/omise-magento/checkout-with-omise-05.png)  
+
+## Using omise-magento with One Page Checkout (OPC) extension
+By default, the checkout process of Magento has many steps and it have been displayed step by step. This default checkout process can be adjusted by the merchant.
+
+One of the adjustment is the merchant will find and install an extension to reduce the checkout steps or change the display of checkout process to be in one page.
+
+There are so many third-party extensions that delivered this feature. But most of those extensions are not compatible with omise-magento. Because omise-magento has a secure step at the client side (the JavaScript at the web browser of the payer) to create a token to be the representative of the card information of the payer. That token is used to be the representative between merchant server and Omise API for process the payment.
+
+Most of extensions have no any procedure to trigger this step of omise-magento. So the merchant who use the OPC need to modify their extension.
+
+## Prerequisites ##
+1. omise-magento must be succesfully installed on your Magento server.
+2. Your selected OPC extension must be successfully installed on your Magento server.
+3. You need to have privilege to access and modify your files on the server.
+4. You need to have the technical knowledge about JavaScript and PHP, if not please contact your technical staff.
+
+#### Disclaimer about the example of third-party extension ####
+- The reason that we use the iwd One Page Checkout free version because we found it available for download, use and modify.
+- Please contact the third-party about their product or service information.
+
+**Note:**
+With the invalid modification, it may adversely affect to the normal process. So, please do the backup before the modification.
+
+The steps below are an example of modifying the OPC extension, iwd One Page Checkout free version, to work with omise-magento.
+
+1. Add a HTML element, hidden, to be the referece within the checkout page and across the extension
+
+  - Open file app/design/frontend/base/default/template/payment/form/omisecc.phtml from the root path and then add an HTML element
+
+  ```HTML
+  <input type="hidden" id="omise-public-key" value="<?php echo $this->getOmiseKeys('public_key'); ?>" />
+  ```
+
+2. Insert the steps of create Omise token to the checkout process of the OPC extionsion
+
+  - Open file skin/frontend/base/default/js/iwd/opc/checkout.js from the root path
+  - Locate to the condition of save payment after validation has success
+
+  ```PHP
+  if (paymentMethodForm.validate()) {
+    IWD.OPC.savePayment();
+  } else {
+      ...
+  }
+  ```
+
+  - Insert the steps of create Omise token as the example below
+
+  ```PHP
+  if (paymentMethodForm.validate()) {
+
+      // Begin of the modification
+      // Check a condition to create the Omise token only the payment method is omise_gateway
+      if (payment.currentMethod == "omise_gateway") {
+
+          // Use an external script, omise.js, by using the Omise utility function
+          getScript("https://cdn.omise.co/omise.min.js.gz", function() {
+              // Set the public key
+              Omise.setPublicKey(document.getElementById("omise-public-key").value);
+
+              // Create the card information for submit to create Omise token
+              var card = {
+                  "name"             : document.getElementById("omise_gateway_cc_name").value,
+                  "number"           : document.getElementById("omise_gateway_cc_number").value,
+                  "expiration_month" : document.getElementById("omise_gateway_expiration").value,
+                  "expiration_year"  : document.getElementById("omise_gateway_expiration_yr").value,
+                  "security_code"    : document.getElementById("omise_gateway_cc_cid").value
+              };
+
+              // Create Omise token
+              Omise.createToken("card", card, function(statusCode, response) {
+                  if (statusCode == 200) {
+                      // Handle the success case
+
+                      // Set the token value from the response to the HTML element, omise_gateway_token, for submit the checkout process
+                      document.getElementById("omise_gateway_token").value = response.id;
+
+                      // Perform the checkout process of the extension normally
+                      IWD.OPC.savePayment();
+                  } else {
+                      // Handle the error case
+
+                      // For an example, display the popup with the error message
+                      alert(response.message);
+                  }
+              });
+          });
+      } else {
+          // Remain the same process of the extension before modification
+          IWD.OPC.savePayment();
+      }
+      // End of the modification
+
+  } else {
+      ...
+  }
+  ```
+
+Make sure to store the modified files to your server. The checkout process with omise-magento should be work successfully.

--- a/README.md
+++ b/README.md
@@ -84,13 +84,14 @@ Most of extensions have no any procedure to trigger this step of omise-magento. 
 4. You need to have the technical knowledge about JavaScript and PHP, if not please contact your technical staff.
 
 #### Disclaimer about the example of third-party extension ####
-- The reason that we use the iwd One Page Checkout free version because we found it available for download, use and modify.
+- The reason that we use the IWD One Page Checkout free version because we found it available for download, use and modify.
 - Please contact the third-party about their product or service information.
+- To download the IWD One Page Checkout extension, please go to this [link](https://www.iwdagency.com/extensions/one-step-page-checkout.html).
 
 **Note:**
 With the invalid modification, it may adversely affect to the normal process. So, please do the backup before the modification.
 
-The steps below are an example of modifying the OPC extension, iwd One Page Checkout free version, to work with omise-magento.
+The steps below are an example of modifying the OPC extension, IWD One Page Checkout free version, to work with omise-magento.
 
 1. Add a HTML element, hidden, to be the referece within the checkout page and across the extension
 


### PR DESCRIPTION
**1. Objective reason**

According to the problem that the payer has input the card information correctly but the system display the popup with the error message "Need Omise's keys", the cause of the problem is omise-magento has not been support or work with the extension One Page Checkout (OPC) that the merchant installed.

Most of the OPC extensions have no any procedure to trigger the omise-magento to create the Omise token normally.

Currently, to use omise-magento with OPC, the merchant need to modify their extension by themselves.

Related ticket: [Issue #26 ](https://github.com/omise/omise-magento/issues/26), T1000

**2. Description of change**

Add the description at the README.md for using omise-magento with the extension, One Page Checkout or One Step Checkout.

The source code has not been altered or modified.

**3. Users affected by the change**

All

**4. Impact of the change**

`-`

**5. Priority of change**

Normal

**6. Alternate solution**

Merchant use the normal checkout process without OPC.