### PR TITLE
Import Exception class to AbstractOmiseClient

### DIFF
--- a/Gateway/Http/Client/AbstractOmiseClient.php
+++ b/Gateway/Http/Client/AbstractOmiseClient.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omise\Payment\Gateway\Http\Client;
 
+use Exception;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Module\ModuleListInterface;
 use Magento\Payment\Gateway\Http\ClientInterface;


### PR DESCRIPTION
> This PR requires PR #33 to be merged first.

#### 1. Objective

To fix `Namespace for Exception class is not specified.` issue from https://github.com/omise/omise-magento/pull/33#issuecomment-268703544.

![screen shot 2559-12-22 at 12 30 46 pm](https://cloud.githubusercontent.com/assets/2154669/21417647/a73e7906-c84e-11e6-8e55-1ef49d39cfc2.png)

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2130

#### 2. Description of change

• Import `Exception` class to `Gateway/Http/Client/AbstractOmiseClient.php`

Because currently, `AbstractOmiseClient::placeRequest()` use `Exception` class without proper import.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.2.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.14.

**✏️ Details:**

After fix the issue:
<img width="759" alt="screen shot 2559-12-22 at 2 00 29 pm" src="https://cloud.githubusercontent.com/assets/2154669/21417730/26859b72-c84f-11e6-9c1b-ceb5a3f29759.png">

To prove that this changed work, go to `Gateway/Http/Client/AbstractOmiseClient.php`
About line 126, (`placeRequest()` method).

**Before fix**
I broke the charge service by random use `secret key` to raise some error that I could check if error be thrown into the `Exception` block or not.

Also, changed error message to `xxx`.
<img width="643" alt="screen shot 2559-12-22 at 2 36 26 pm" src="https://cloud.githubusercontent.com/assets/2154669/21418482/26d514a4-c854-11e6-8366-b4bb4879902a.png">

**Expectation**: It should raise `xxx` as an error message.
**Result**:  Got `authentication failed` error
![screen shot 2559-12-22 at 4 34 03 pm](https://cloud.githubusercontent.com/assets/2154669/21421346/f175db98-c864-11e6-8e8c-7283133f55e4.png)

It means, `Exception` block couldn't catch error properly. Instead, it threw an error out to another exception class.

**After fix**
<img width="625" alt="screen shot 2559-12-22 at 4 32 18 pm" src="https://cloud.githubusercontent.com/assets/2154669/21421413/51f43776-c865-11e6-9538-64039674630c.png">

The error alert could raise proper message as I fixed in the code.




#### 4. Impact of the change

No.

#### 5. Priority of change

High

#### 6. Additional Notes

- Use https://github.com/magento/marketplace-eqp to check code quality.
- Because Magento CE 2.1.2 had issue that it can't display a proper error message that receive from payment module, to test this case, I have to go to `/vendor/magento/module-checkout/Model/GuestPaymentInformationManagement.php::savePaymentInformationAndPlaceOrder()` to hard-code show an error message by myself.
<img width="993" alt="screen shot 2559-12-22 at 4 46 47 pm" src="https://cloud.githubusercontent.com/assets/2154669/21421596/44b34c5e-c866-11e6-8221-27bd6893cc67.png">
