### PR TITLE
[1.x series] Introduce 3-D Secure payment feature 

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Omise.php
+++ b/src/app/code/community/Omise/Gateway/Model/Omise.php
@@ -1,25 +1,24 @@
 <?php
-// Define 'OMISE_USER_AGENT_SUFFIX'
-if (! defined('OMISE_USER_AGENT_SUFFIX')) {
-    define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.9.0.6 Magento/' . Mage::getVersion());
-}
-
-// Define 'OMISE_API_VERSION'
-if (! defined('OMISE_API_VERSION')) {
-    define('OMISE_API_VERSION', '2014-07-27');
-}
-
 class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
 {
     /**
+     * @deprecated use $this->getPublicKey(); instead.
+     *
      * @var string  Omise public key
      */
     protected $_public_key;
 
     /**
+     * @deprecated use $this->getSecretKey(); instead.
+     *
      * @var string  Omise secret key
      */
     protected $_secret_key;
+
+    /**
+     * @var \Omise_Gateway_Model_Config
+     */
+    protected $config;
 
     /**
      * Load necessary file and setup Omise keys
@@ -32,14 +31,91 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
         require_once(Mage::getBaseDir('lib') . '/omise-php/lib/Omise.php');
 
         // Retrieve Omise's keys from table.
-        $omise = Mage::getModel('omise_gateway/config')->load(1);
-        $this->_public_key = $omise->public_key;
-        $this->_secret_key = $omise->secret_key;
+        $this->config = Mage::getModel('omise_gateway/config')->load(1);
 
-        // Replace keys with test keys if test mode was enabled.
-        if ($omise->test_mode) {
-            $this->_public_key = $omise->public_key_test;
-            $this->_secret_key = $omise->secret_key_test;
+        // @deprecated use $this->getPublicKey() and $this->getSecretKey() instead.
+        $this->_public_key = $this->getPublicKey();
+        $this->_secret_key = $this->getSecretKey();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTestMode()
+    {
+        return $this->config->test_mode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPublicKey()
+    {
+        if ($this->isTestMode()) {
+            return $this->config->public_key_test;
         }
+
+        return $this->config->public_key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecretKey()
+    {
+        if ($this->isTestMode()) {
+            return $this->config->secret_key_test;
+        }
+
+        return $this->config->secret_key;
+    }
+
+    /**
+     * @param  string $public_key
+     * @param  string $secret_key
+     *
+     * @return void
+     */
+    public function defineApiKeys($public_key = '', $secret_key = '')
+    {
+        if (! defined('OMISE_PUBLIC_KEY')) {
+            define('OMISE_PUBLIC_KEY', $public_key ? $public_key : $this->getPublicKey());
+        }
+
+        if (! defined('OMISE_SECRET_KEY')) {
+            define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->getSecretKey());
+        }
+    }
+
+    /**
+     * @param  string $version
+     *
+     * @return void
+     */
+    public function defineApiVersion($version = '2014-07-27')
+    {
+        if (! defined('OMISE_API_VERSION')) {
+            define('OMISE_API_VERSION', $version);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function defineUserAgent()
+    {
+        if (! defined('OMISE_USER_AGENT_SUFFIX')) {
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.9.0.6 Magento/' . Mage::getVersion());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function initNecessaryConstant()
+    {
+        $this->defineApiKeys();
+        $this->defineApiVersion();
+        $this->defineUserAgent();
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/OmiseAccount.php
+++ b/src/app/code/community/Omise/Gateway/Model/OmiseAccount.php
@@ -8,6 +8,8 @@ class Omise_Gateway_Model_OmiseAccount extends Omise_Gateway_Model_Omise
      */
     public function retrieveOmiseAccount()
     {
+        $this->initNecessaryConstant();
+
         try {
             return OmiseAccount::retrieve($this->_public_key, $this->_secret_key);
         } catch (Exception $e) {

--- a/src/app/code/community/Omise/Gateway/Model/OmiseBalance.php
+++ b/src/app/code/community/Omise/Gateway/Model/OmiseBalance.php
@@ -8,6 +8,8 @@ class Omise_Gateway_Model_OmiseBalance extends Omise_Gateway_Model_Omise
      */
     public function retrieveOmiseBalance()
     {
+        $this->initNecessaryConstant();
+
         try {
             return OmiseBalance::retrieve($this->_public_key, $this->_secret_key);
         } catch (Exception $e) {

--- a/src/app/code/community/Omise/Gateway/Model/OmiseCharge.php
+++ b/src/app/code/community/Omise/Gateway/Model/OmiseCharge.php
@@ -10,6 +10,8 @@ class Omise_Gateway_Model_OmiseCharge extends Omise_Gateway_Model_Omise
      */
     public function createOmiseCharge($params)
     {
+        $this->initNecessaryConstant();
+
         try {
             return OmiseCharge::create($params, $this->_public_key, $this->_secret_key);
         } catch (Exception $e) {
@@ -26,6 +28,8 @@ class Omise_Gateway_Model_OmiseCharge extends Omise_Gateway_Model_Omise
      */
     public function captureOmiseCharge($id)
     {
+        $this->initNecessaryConstant();
+
         try {
             $charge = OmiseCharge::retrieve($id, $this->_public_key, $this->_secret_key);
             return $charge->capture();

--- a/src/app/code/community/Omise/Gateway/Model/OmiseTransfer.php
+++ b/src/app/code/community/Omise/Gateway/Model/OmiseTransfer.php
@@ -8,6 +8,8 @@ class Omise_Gateway_Model_OmiseTransfer extends Omise_Gateway_Model_Omise
      */
     public function retrieveOmiseTransfer($id = '')
     {
+        $this->initNecessaryConstant();
+
         try {
             return OmiseTransfer::retrieve('', $this->_public_key, $this->_secret_key);
         } catch (Exception $e) {
@@ -22,6 +24,8 @@ class Omise_Gateway_Model_OmiseTransfer extends Omise_Gateway_Model_Omise
      */
     public function createOmiseTransfer($params)
     {
+        $this->initNecessaryConstant();
+
         try {
             // Validate $params
             // If it not contain `amount` key.
@@ -49,6 +53,8 @@ class Omise_Gateway_Model_OmiseTransfer extends Omise_Gateway_Model_Omise
      */
     public function deleteOmiseTransfer($id = '')
     {
+        $this->initNecessaryConstant();
+
         try {
             if ($id == '') {
                 throw new Exception("Id was required", 1);

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -7,18 +7,9 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     protected $config;
 
     /**
-     * Omise's public key
-     *
-     * @var string
+     * @var \Omise_Gateway_Model_Omise
      */
-    protected $public_key;
-
-    /**
-     * Omise's secret key
-     *
-     * @var string
-     */
-    protected $secret_key;
+    protected $omise;
 
     /**
      * @var \Mage_Sales_Model_Order_Payment
@@ -32,26 +23,8 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     public function __construct()
     {
-        // Load Omise-PHP library
-        require_once(Mage::getBaseDir('lib') . '/omise-php/lib/Omise.php');
-
         $this->config = Mage::getModel('omise_gateway/config')->load(1);
-
-        if ($this->isTestMode()) {
-            $this->public_key = $this->config->public_key_test;
-            $this->secret_key = $this->config->secret_key_test;
-        } else {
-            $this->public_key = $this->config->public_key;
-            $this->secret_key = $this->config->secret_key;
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public function isTestMode()
-    {
-        return $this->config->test_mode;
+        $this->omise  = Mage::getModel('omise_gateway/omise');
     }
 
     /**
@@ -74,9 +47,9 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
         Mage_Sales_Model_Order_Payment $payment,
         $amount
     ) {
-        $this->defineOmiseKeys();
-        $this->defineOmiseApiVersion();
-        $this->defineOmiseUserAgent();
+        $this->omise->defineApiKeys();
+        $this->omise->defineApiVersion();
+        $this->omise->defineUserAgent();
 
         $this->payment_information = $payment;
 
@@ -91,44 +64,5 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
         }    
 
         return $result;
-    }
-
-    /**
-     * @param  string $public_key
-     * @param  string $secret_key
-     *
-     * @return void
-     */
-    protected function defineOmiseKeys($public_key = '', $secret_key = '')
-    {
-        if (! defined('OMISE_PUBLIC_KEY')) {
-            define('OMISE_PUBLIC_KEY', $public_key ? $public_key : $this->public_key);
-        }
-
-        if (! defined('OMISE_SECRET_KEY')) {
-            define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->secret_key);
-        }
-    }
-
-    /**
-     * @param  string $version
-     *
-     * @return void
-     */
-    protected function defineOmiseApiVersion($version = '2014-07-27')
-    {
-        if (! defined('OMISE_API_VERSION')) {
-            define('OMISE_API_VERSION', $version);
-        }
-    }
-
-    /**
-     * @return void
-     */
-    protected function defineOmiseUserAgent()
-    {
-        if (! defined('OMISE_USER_AGENT_SUFFIX')) {
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.9.0.6 Magento/' . Mage::getVersion());
-        }
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -32,9 +32,10 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
      *
      * @var bool
      */
-    protected $_isGateway     = true;
-    protected $_canAuthorize  = true;
-    protected $_canCapture    = true;
+    protected $_isGateway        = true;
+    protected $_canAuthorize     = true;
+    protected $_canCapture       = true;
+    protected $_canReviewPayment = true;
 
     /**
      * Authorize payment method
@@ -192,6 +193,38 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
 
         Mage::log('The transaction was performed manual capture by Omise payment gateway and successful.');
         return $result;
+    }
+
+    /**
+     * Attempt to accept a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function acceptPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::acceptPayment($payment);
+
+        return true;
+    }
+
+    /**
+     * Attempt to deny a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function denyPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::denyPayment($payment);
+
+        return true;
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -1,0 +1,56 @@
+<?php
+class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function perform($payment, $amount)
+    {
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => false,
+            'card'        => $info->getAdditionalInformation('omise_token'),
+            'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
+        ));
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        if (! isset($charge['object'])) {
+            $this->message = 'Cannot retrieve a payment result, please contact our support to confirm the payment.';
+            return false;
+        }
+
+        if ($charge['object'] === 'error') {
+            $this->message = $charge['message'];
+            return false;
+        }
+
+        if ($charge['failure_code'] || $charge['failure_message']) {
+            $this->message = 'Payment authorization failed, ' . $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')';
+            return false;
+        }
+
+        if ($charge['object'] === 'charge'
+            && $charge['status'] === 'pending'
+            && $charge['authorize_uri']) {
+            return true;
+        }
+
+        $this->message = 'Error payment result validation, please contact our support to confirm the payment.';
+        return false;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
         }
 
         if ($charge['object'] === 'charge'
-            && $charge['status'] === 'pending'
+            && $charge['status'] !== 'failed'
             && $charge['authorize_uri']) {
             return true;
         }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
         }
 
         if ($charge['object'] === 'charge'
-            && $charge['status'] === 'pending'
+            && $charge['status'] !== 'failed'
             && $charge['authorize_uri']) {
             return true;
         }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -1,0 +1,56 @@
+<?php
+class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function perform($payment, $amount)
+    {
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => true,
+            'card'        => $info->getAdditionalInformation('omise_token'),
+            'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
+        ));
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        if (! isset($charge['object'])) {
+            $this->message = 'Cannot retrieve a payment result, please contact our support to confirm the payment.';
+            return false;
+        }
+
+        if ($charge['object'] === 'error') {
+            $this->message = $charge['message'];
+            return false;
+        }
+
+        if ($charge['failure_code'] || $charge['failure_message']) {
+            $this->message = 'Payment process failed, ' . $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')';
+            return false;
+        }
+
+        if ($charge['object'] === 'charge'
+            && $charge['status'] === 'pending'
+            && $charge['authorize_uri']) {
+            return true;
+        }
+
+        $this->message = 'Error payment result validation, please contact our support to confirm the payment.';
+        return false;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -3,7 +3,90 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
 {
     public function indexAction()
     {
+        $omise = Mage::getModel('omise_gateway/omise');
+        $omise->initNecessaryConstant();
+
         // Callback validation.
-        echo "validating!";
+        $order = $this->getOrder();
+
+        if (! $payment = $order->getPayment()) {
+            Mage::getSingleton('core/session')->addError(
+                $this->__('3-D Secure validation was invalid, cannot retrieve your payment information. Please contact our support to confirm the payment.')
+            );
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        try {
+            $charge_id = $payment->getMethodInstance()->getInfoInstance()->getAdditionalInformation('omise_charge_id');
+            $charge    = OmiseCharge::retrieve($charge_id);
+
+            if (! $this->validate($charge)) {
+                return $this->considerFail(
+                    $order,
+                    $this->__('The payment was invalid, ' . $charge['failure_message'] . ' (' . $charge['failure_code'] . ').')
+                );
+            }
+
+            $payment->accept();
+            $order->save();
+            return $this->_redirect('checkout/onepage/success');
+        } catch (Exception $e) {
+            return $this->considerFail(
+                $order,
+                $this->__($e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @return \Mage_Sales_Model_Order
+     */
+    protected function getOrder()
+    {
+        $order_increment_id = $this->getRequest()->getParam('order_id');
+
+        if ($order_increment_id) {
+            return Mage::getModel('sales/order')->loadByIncrementId($order_increment_id);
+        }
+
+        return Mage::getModel('sales/order')->load(Mage::getSingleton('checkout/session')->getLastOrderId());
+    }
+
+    /**
+     * @param  \Mage_Sales_Model_Order $order
+     * @param  string                  $message
+     *
+     * @return self
+     */
+    protected function considerFail($order, $message)
+    {
+        $order->getPayment()
+            ->setPreparedMessage($message)
+            ->deny();
+        $order->save();
+
+        Mage::getSingleton('core/session')->addError($message);
+        return $this->_redirect('checkout/cart');
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     *
+     * @return bool
+     */
+    protected function validate($charge)
+    {
+        // check for auto capture.
+        if ($charge['capture'] && $charge['status'] === 'successful' && $charge['authorized'] && $charge['captured']) {
+            return true;
+        }
+
+        // Check for authorize only.
+        if (! $charge['capture'] && $charge['status'] === 'pending' && $charge['authorized']) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -1,0 +1,9 @@
+<?php
+class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Controller_Front_Action
+{
+    public function indexAction()
+    {
+        // Callback validation.
+        echo "validating!";
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -82,6 +82,18 @@
         </routers>
     </admin>
 
+    <frontend>
+        <routers>
+            <omise_gateway>
+                <use>standard</use>
+                <args>
+                    <module>Omise_Gateway</module>
+                    <frontName>omise</frontName>
+                </args>
+            </omise_gateway>
+        </routers>
+    </frontend>
+
     <!--
     /**
      * Payment Method configuration for front-end

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -30,11 +30,30 @@
                             <show_in_store>0</show_in_store>
                         </payment_action>
 
+                        <advance_settings translate="label">
+                            <label>Advance Settings</label>
+                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </advance_settings>
+
+                        <threedsecure translate="label">
+                            <label>3-D Secure support</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>4</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </threedsecure>
+
                         <order_status translate="label">
                             <label>New order status</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
-                            <sort_order>3</sort_order>
+                            <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>


### PR DESCRIPTION
> This PR required PR #46 to be merged first. 

#### 1. Objective

To support 3-D Secure feature.
Merchant will be able to enable 3-D Secure config and process a 3-D Secure payment through the plugin.

> This changes support for payment "Authorize only" & "Authorize and Capture" actions.

**Related information**:
Related issue(s): #18 
Related ticket(s): 🙅

#### 2. Description of change

Task list:

- [x] Add `3-D Secure` option to the setting page (see PR #43).
- [x] Redirect buyer to the 3-D Secure page if the setting is enabled (see PR #47).
- [x] Implement `callback` url/function to validate charge (see PR #53).
- [x] Update Magento's order status (see PR #53).

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6.
- **PHP version**: 5.6.14.

**✏️ Details:**

Please check at all sub-tasks (PR #43, #47, #53).

#### 4. Impact of the change

Please check at all sub-tasks (PR #43, #47, #53).

#### 5. Priority of change

Normal

#### 6. Additional Notes

Nothing.
