### PR TITLE
Introduce payment strategy classes to handle payment action.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -60,7 +60,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
         $this->defineOmiseKeys();
 
         try {
-            $result = $strategy->process($this, $params);
+            $result = $strategy->perform($this, $params);
         } catch (Exception $e) {
             Mage::throwException(Mage::helper('payment')->__($e->getMessage()));
         }

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -58,6 +58,8 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     public function perform(Omise_Gateway_Model_Strategies_StrategyInterface $strategy, $params)
     {
         $this->defineOmiseKeys();
+        $this->defineOmiseApiVersion();
+        $this->defineOmiseUserAgent();
 
         try {
             $result = $strategy->perform($this, $params);
@@ -86,6 +88,28 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
 
         if (! defined('OMISE_SECRET_KEY')) {
             define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->secret_key);
+        }
+    }
+
+    /**
+     * @param  string $version
+     *
+     * @return void
+     */
+    protected function defineOmiseApiVersion($version = '2014-07-27')
+    {
+        if (! defined('OMISE_API_VERSION')) {
+            define('OMISE_API_VERSION', $version);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function defineOmiseUserAgent()
+    {
+        if (! defined('OMISE_USER_AGENT_SUFFIX')) {
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.9.0.6 Magento/' . Mage::getVersion());
         }
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -21,6 +21,11 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     protected $secret_key;
 
     /**
+     * @var \Mage_Sales_Model_Order_Payment
+     */
+    protected $payment_information;
+
+    /**
      * Load necessary file and setup Omise keys
      *
      * @return void
@@ -50,19 +55,33 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     }
 
     /**
+     * @return \Mage_Sales_Model_Order_Payment
+     */
+    public function getPaymentInformation()
+    {
+        return $this->payment_information;
+    }
+
+    /**
      * @param  \Omise_Gateway_Model_Strategies_StrategyInterface $strategy
-     * @param  mixed                                             $payment
+     * @param  \Mage_Sales_Model_Order_Payment                   $payment
+     * @param  int|float                                         $amount
      *
      * @return Mage_Payment_Model_Abstract
      */
-    public function perform(Omise_Gateway_Model_Strategies_StrategyInterface $strategy, $params)
-    {
+    public function perform(
+        Omise_Gateway_Model_Strategies_StrategyInterface $strategy,
+        Mage_Sales_Model_Order_Payment $payment,
+        $amount
+    ) {
         $this->defineOmiseKeys();
         $this->defineOmiseApiVersion();
         $this->defineOmiseUserAgent();
 
+        $this->payment_information = $payment;
+
         try {
-            $result = $strategy->perform($this, $params);
+            $result = $strategy->perform($this, $amount);
         } catch (Exception $e) {
             Mage::throwException(Mage::helper('payment')->__($e->getMessage()));
         }

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -1,0 +1,91 @@
+<?php
+abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abstract
+{
+    /**
+     * @var \Omise_Gateway_Model_Config
+     */
+    protected $config;
+
+    /**
+     * Omise's public key
+     *
+     * @var string
+     */
+    protected $public_key;
+
+    /**
+     * Omise's secret key
+     *
+     * @var string
+     */
+    protected $secret_key;
+
+    /**
+     * Load necessary file and setup Omise keys
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        // Load Omise-PHP library
+        require_once(Mage::getBaseDir('lib') . '/omise-php/lib/Omise.php');
+
+        $this->config = Mage::getModel('omise_gateway/config')->load(1);
+
+        if ($this->isTestMode()) {
+            $this->public_key = $this->config->public_key_test;
+            $this->secret_key = $this->config->secret_key_test;
+        } else {
+            $this->public_key = $this->config->public_key;
+            $this->secret_key = $this->config->secret_key;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTestMode()
+    {
+        return $this->config->test_mode;
+    }
+
+    /**
+     * @param  \Omise_Gateway_Model_Strategies_StrategyInterface $strategy
+     * @param  mixed                                             $payment
+     *
+     * @return Mage_Payment_Model_Abstract
+     */
+    public function perform(Omise_Gateway_Model_Strategies_StrategyInterface $strategy, $params)
+    {
+        $this->defineOmiseKeys();
+
+        try {
+            $result = $strategy->process($this, $params);
+        } catch (Exception $e) {
+            Mage::throwException(Mage::helper('payment')->__($e->getMessage()));
+        }
+
+        if (! $strategy->validate($result)) {
+            Mage::throwException(Mage::helper('payment')->__($strategy->getMessage()));
+        }    
+
+        return $result;
+    }
+
+    /**
+     * @param  string $public_key
+     * @param  string $secret_key
+     *
+     * @return void
+     */
+    protected function defineOmiseKeys($public_key = '', $secret_key = '')
+    {
+        if (! defined('OMISE_PUBLIC_KEY')) {
+            define('OMISE_PUBLIC_KEY', $public_key ? $public_key : $this->public_key);
+        }
+
+        if (! defined('OMISE_SECRET_KEY')) {
+            define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->secret_key);
+        }
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -43,7 +43,7 @@ class Omise_Gateway_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
      */
     public function authorize(Varien_Object $payment, $amount)
     {
-        Mage::log('Start authorize with OmiseCharge API!');
+        Mage::log('Start authorizing with Omise Payment Gateway.');
 
         $payment_data = $payment->getData('additional_information');
         $result       = $this->request(
@@ -74,6 +74,8 @@ class Omise_Gateway_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
      */
     public function capture(Varien_Object $payment, $amount)
     {
+        Mage::log('Start capturing with Omise Payment Gateway.');
+
         $additional_information = $payment->getData('additional_information');
         $authorized             = isset($additional_information['omise_charge_id']) ? $additional_information['omise_charge_id'] : false;
         if ($authorized) {

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -2,6 +2,14 @@
 class Omise_Gateway_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstract
 {
     /**
+     * Payment strategies
+     *
+     * @var string
+     */
+    const STRATEGY_AUTHORIZE  = 'Authorize';
+    const STRATEGY_CAPTURE    = 'Capture';
+
+    /**
      * @var string
      */
     protected $_code          = 'omise_gateway';

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
@@ -4,9 +4,17 @@ class Omise_Gateway_Model_Strategies_AuthorizeStrategy extends Omise_Gateway_Mod
     /**
      * {@inheritDoc}
      */
-    public function perform($payment, $params = array())
+    public function perform($payment, $amount)
     {
-        return OmiseCharge::create($params);
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => false,
+            'card'        => $info->getAdditionalInformation('omise_token')
+        ));
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
@@ -2,13 +2,9 @@
 class Omise_Gateway_Model_Strategies_AuthorizeStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
 {
     /**
-     * Process a payment.
-     *
-     * @param  array|mixed $params
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
-    public function process($params = array())
+    public function perform($payment, $params = array())
     {
         return OmiseCharge::create($params);
     }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
@@ -1,0 +1,52 @@
+<?php
+class Omise_Gateway_Model_Strategies_AuthorizeStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * Process a payment.
+     *
+     * @param  array|mixed $params
+     *
+     * @return mixed
+     */
+    public function process($params = array())
+    {
+        return OmiseCharge::create($params);
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        if (! isset($charge['object'])) {
+            $this->message = 'Cannot retrieve a payment result, please contact our support to confirm the payment.';
+            return false;
+        }
+
+        if ($charge['object'] === 'error') {
+            $this->message = $charge['message'];
+            return false;
+        }
+
+        if (! $charge['authorized']) {
+            $this->message = 'Your authorize failed:: (' . $charge['failure_code'] . ') - ' . $charge['failure_code'];
+            return false;
+        }
+
+        if ($charge['object'] === 'charge'
+            && $charge['status'] === 'pending'
+            && $charge['capture'] === false
+            && $charge['authorized'] === true) {
+            return true;
+        }
+
+        $this->message = 'Error payment result validation, please contact our support to confirm the payment.';
+        return false;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
@@ -35,7 +35,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeStrategy extends Omise_Gateway_Mod
         }
 
         if (! $charge['authorized']) {
-            $this->message = 'Your authorize failed:: (' . $charge['failure_code'] . ') - ' . $charge['failure_code'];
+            $this->message = 'Payment authorization failed, ' . $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')';
             return false;
         }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
@@ -1,0 +1,57 @@
+<?php
+class Omise_Gateway_Model_Strategies_CaptureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * Process a payment.
+     *
+     * @param  array|mixed $params
+     *
+     * @return mixed
+     */
+    public function process($params = array())
+    {
+        if (isset($params['id'])) {
+            $charge = OmiseCharge::retrieve($params['id']);
+            return $charge->capture();
+        }
+
+        return OmiseCharge::create($params);
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        if (! isset($charge['object'])) {
+            $this->message = 'Cannot retrieve a payment result, please contact our support to confirm the payment.';
+            return false;
+        }
+
+        if ($charge['object'] === 'error') {
+            $this->message = $charge['message'];
+            return false;
+        }
+
+        if (! $charge['authorized'] || ! $charge['captured']) {
+            $this->message = 'Your payment failed:: (' . $charge['failure_code'] . ') - ' . $charge['failure_code'];
+            return false;
+        }
+
+        if ($charge['object'] === 'charge'
+            && $charge['status'] === 'successful'
+            && $charge['authorized'] === true
+            && $charge['captured'] === true) {
+            return true;
+        }
+
+        $this->message = 'Error payment result validation, please contact our support to confirm the payment.';
+        return false;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
@@ -4,9 +4,17 @@ class Omise_Gateway_Model_Strategies_CaptureStrategy extends Omise_Gateway_Model
     /**
      * {@inheritDoc}
      */
-    public function perform($payment, $params = array())
+    public function perform($payment, $amount)
     {
-        return OmiseCharge::create($params);
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => true,
+            'card'        => $info->getAdditionalInformation('omise_token')
+        ));
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
@@ -40,7 +40,7 @@ class Omise_Gateway_Model_Strategies_CaptureStrategy extends Omise_Gateway_Model
         }
 
         if (! $charge['authorized'] || ! $charge['captured']) {
-            $this->message = 'Your payment failed:: (' . $charge['failure_code'] . ') - ' . $charge['failure_code'];
+            $this->message = 'Payment process failed, ' . $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')';
             return false;
         }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/ManualCaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/ManualCaptureStrategy.php
@@ -1,12 +1,14 @@
 <?php
-class Omise_Gateway_Model_Strategies_CaptureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+class Omise_Gateway_Model_Strategies_ManualCaptureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
 {
     /**
      * {@inheritDoc}
      */
     public function perform($payment, $params = array())
     {
-        return OmiseCharge::create($params);
+        $charge = OmiseCharge::retrieve($params['id']);
+
+        return $charge->capture();
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/ManualCaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/ManualCaptureStrategy.php
@@ -4,9 +4,10 @@ class Omise_Gateway_Model_Strategies_ManualCaptureStrategy extends Omise_Gateway
     /**
      * {@inheritDoc}
      */
-    public function perform($payment, $params = array())
+    public function perform($payment, $amount)
     {
-        $charge = OmiseCharge::retrieve($params['id']);
+        $info   = $payment->getPaymentInformation();
+        $charge = OmiseCharge::retrieve($info->getAdditionalInformation('omise_charge_id'));
 
         return $charge->capture();
     }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
@@ -8,14 +8,15 @@ abstract class Omise_Gateway_Model_Strategies_StrategyAbstract implements
     protected $message;
 
     /**
-     * Process a payment.
+     * Perform a payment action.
+     * i.e. authorize a payment, capture a charge, etc.
      *
      * @param  \Omise_Gateway_Model_Payment $payment
      * @param  array                        $params
      *
      * @return mixed
      */
-    abstract public function process($payment, $params = array());
+    abstract public function perform($payment, $params = array());
 
     /**
      * Validate a payment process result.

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
@@ -10,7 +10,7 @@ abstract class Omise_Gateway_Model_Strategies_StrategyAbstract implements
     /**
      * {@inheritDoc}
      */
-    abstract public function perform($payment, $params = array());
+    abstract public function perform($payment, $amount);
 
     /**
      * {@inheritDoc}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
@@ -1,0 +1,72 @@
+<?php
+abstract class Omise_Gateway_Model_Strategies_StrategyAbstract extends Omise_Gateway_Model_Omise implements
+    Omise_Gateway_Model_Strategies_StrategyInterface
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @param  string $public_key
+     * @param  string $secret_key
+     *
+     * @return void
+     */
+    protected function defineOmiseKeys($public_key = '', $secret_key = '')
+    {
+        if (! defined('OMISE_PUBLIC_KEY')) {
+            define('OMISE_PUBLIC_KEY', $public_key ? $public_key : $this->_public_key);
+        }
+
+        if (! defined('OMISE_SECRET_KEY')) {
+            define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->_secret_key);
+        }
+    }
+
+    /**
+     * Execute a payment command.
+     *
+     * @param  array|mixed $params
+     *
+     * @return mixed
+     */
+    public function execute($params = array())
+    {
+        try {
+            $this->defineOmiseKeys();
+            return $this->process($params);
+        } catch (Exception $e) {
+            return array(
+                'object'  => 'error',
+                'message' => $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * Process a payment.
+     *
+     * @param  array|mixed $params
+     *
+     * @return mixed
+     */
+    abstract public function process($params = array());
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  mixed $data
+     *
+     * @return boolean
+     */
+    abstract public function validate($data);
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
@@ -1,5 +1,5 @@
 <?php
-abstract class Omise_Gateway_Model_Strategies_StrategyAbstract extends Omise_Gateway_Model_Omise implements
+abstract class Omise_Gateway_Model_Strategies_StrategyAbstract implements
     Omise_Gateway_Model_Strategies_StrategyInterface
 {
     /**
@@ -8,50 +8,14 @@ abstract class Omise_Gateway_Model_Strategies_StrategyAbstract extends Omise_Gat
     protected $message;
 
     /**
-     * @param  string $public_key
-     * @param  string $secret_key
-     *
-     * @return void
-     */
-    protected function defineOmiseKeys($public_key = '', $secret_key = '')
-    {
-        if (! defined('OMISE_PUBLIC_KEY')) {
-            define('OMISE_PUBLIC_KEY', $public_key ? $public_key : $this->_public_key);
-        }
-
-        if (! defined('OMISE_SECRET_KEY')) {
-            define('OMISE_SECRET_KEY', $secret_key ? $secret_key : $this->_secret_key);
-        }
-    }
-
-    /**
-     * Execute a payment command.
-     *
-     * @param  array|mixed $params
-     *
-     * @return mixed
-     */
-    public function execute($params = array())
-    {
-        try {
-            $this->defineOmiseKeys();
-            return $this->process($params);
-        } catch (Exception $e) {
-            return array(
-                'object'  => 'error',
-                'message' => $e->getMessage()
-            );
-        }
-    }
-
-    /**
      * Process a payment.
      *
-     * @param  array|mixed $params
+     * @param  \Omise_Gateway_Model_Payment $payment
+     * @param  array                        $params
      *
      * @return mixed
      */
-    abstract public function process($params = array());
+    abstract public function process($payment, $params = array());
 
     /**
      * Validate a payment process result.

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyAbstract.php
@@ -8,22 +8,12 @@ abstract class Omise_Gateway_Model_Strategies_StrategyAbstract implements
     protected $message;
 
     /**
-     * Perform a payment action.
-     * i.e. authorize a payment, capture a charge, etc.
-     *
-     * @param  \Omise_Gateway_Model_Payment $payment
-     * @param  array                        $params
-     *
-     * @return mixed
+     * {@inheritDoc}
      */
     abstract public function perform($payment, $params = array());
 
     /**
-     * Validate a payment process result.
-     *
-     * @param  mixed $data
-     *
-     * @return boolean
+     * {@inheritDoc}
      */
     abstract public function validate($data);
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
@@ -2,13 +2,15 @@
 interface Omise_Gateway_Model_Strategies_StrategyInterface
 {
     /**
-     * Process a payment.
+     * Perform a payment action.
+     * i.e. authorize a payment, capture a charge, etc.
      *
-     * @param  array|mixed $params
+     * @param  \Omise_Gateway_Model_Payment $payment
+     * @param  array                        $params
      *
      * @return mixed
      */
-    public function process($params = array());
+    public function perform($payment, $params = array());
 
     /**
      * Validate a payment process result.
@@ -18,9 +20,4 @@ interface Omise_Gateway_Model_Strategies_StrategyInterface
      * @return boolean
      */
     public function validate($data);
-
-    /**
-     * @return string
-     */
-    public function getMessage();
 }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
@@ -5,12 +5,12 @@ interface Omise_Gateway_Model_Strategies_StrategyInterface
      * Perform a payment action.
      * i.e. authorize a payment, capture a charge, etc.
      *
-     * @param  \Omise_Gateway_Model_Payment $payment
-     * @param  array                        $params
+     * @param  object    $payment
+     * @param  int|float $amount
      *
      * @return mixed
      */
-    public function perform($payment, $params = array());
+    public function perform($payment, $amount);
 
     /**
      * Validate a payment process result.

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/StrategyInterface.php
@@ -1,0 +1,26 @@
+<?php
+interface Omise_Gateway_Model_Strategies_StrategyInterface
+{
+    /**
+     * Process a payment.
+     *
+     * @param  array|mixed $params
+     *
+     * @return mixed
+     */
+    public function process($params = array());
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  mixed $data
+     *
+     * @return boolean
+     */
+    public function validate($data);
+
+    /**
+     * @return string
+     */
+    public function getMessage();
+}


### PR DESCRIPTION
> ⚠️ This PR required PR #44 to be merged first.

#### 1. Objective

Refactor the PaymentMethod class for the extensibility, polymorphism and reduce code complexity that usually, will keep maintain in only one file (Omise_Gateway_Model_PaymentMethod).

- Before:
  All of logics have to be in `Model/PaymentMethod.php` since this class is the main class that Magento will import and execute the commands (authorize, capture, refund, etc).

- After:
  All of logics were moved to each of sub-classes (`Model/Strategies/*Strategy.php`).
  So, `Model/PaymentMethod.php` will just only trigger a proper `payment strategy` class instead (not handle logic/validation by itself).

This approach would also be helpful for `3-D Secure` & `Internet Banking` methods, even for another features (i.e. Refund). By introducing `Strategy` classes. (for more detail, please check `6. Additional Notes`).

_Note, to create new payment method 'Internet Banking', Magento doesn't allow to have 2 payment method at the same class, we have to separate it between `CreditCard` and `InternetBanking`_

<img width="1440" alt="screen shot 2560-02-06 at 1 21 04 pm" src="https://cloud.githubusercontent.com/assets/2154669/22636622/3b46eec8-ec6f-11e6-968f-92f462e24225.png">

**Related information**:
Related issue(s): 🙅
Related ticket(s): 🙅

#### 2. Description of change

- Introduce `Omise_Gateway_Model_Payment` (`Model/Payment.php`) as a main-base class for `payment method`.
- Introduce payment strategy approach, `Model/Strategies/StrategyInterface` & `Model/Strategies/StrategyAbstract`
- Introduce concrete strategy classes, `AuthorizeStrategy` and `CaptureStrategy`, `ManualCaptureStrategy`.
- Update `Model/PaymentMethod.php` corresponding to the changes, use the strategy approaches to make a charge/capture.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6
- **Omise PHP version**: 2.4.0
- **PHP version**: 5.6.28

**✏️ Details:**

1. ✅ Test checkout an order with `authorize only` action.
    _**expectation**: success as normal, charge will be created, order will be created_

    1.1. At plugin setting page, set `payment action = authorize only`.

    1.2. Do normal checkout process, it must success (redirect to success page).

    1.3. Check at Omise dashboard, you will see a new charge transaction in the charge list, with pending status.
    ![screen shot 2560-02-01 at 6 17 17 am](https://cloud.githubusercontent.com/assets/2154669/22495823/e968d1ee-e876-11e6-9f7b-3bf3a8535804.png)

    1.4. All of request parameters should be the same as before.
    ![screen shot 2560-02-01 at 6 17 41 am](https://cloud.githubusercontent.com/assets/2154669/22495840/008a747c-e877-11e6-9d7b-56d281a00593.png)

2. ✅ Test checkout an order with `authorize only` action and use [failed card test](https://www.omise.co/api-testing#failed-charge)
    _**expectation**: charge will be failed and show error message on a screen as normal_

    2.1. Do normal checkout process, but test checkout with [failed card test].

    2.2. Error will be shown in a popup box.
    <img width="1134" alt="screen shot 2560-02-01 at 12 24 54 pm" src="https://cloud.githubusercontent.com/assets/2154669/22496140/dfa4e028-e879-11e6-97e7-da2194d751d2.png">

    _note, this tests were tested with cards, `Invalid Account Number`, `Payment Rejected`, `Insufficient Fund`. See [failed card test document](https://www.omise.co/api-testing#failed-charge)_

3. ✅ Test checkout with `authorize and capture` action
    _**expectation**: success as normal, charge will be created, order will be created_

    3.1. At plugin setting page, set `payment action = authorize and capture`.

    3.2. Do normal checkout process, it must success (redirect to success page).

    3.3. Check at Omise dashboard, you will see a new charge transaction in the charge list, with successful status.
    ![screen shot 2560-02-01 at 1 14 20 pm](https://cloud.githubusercontent.com/assets/2154669/22496927/77bcb66e-e880-11e6-8c28-722bd658b33f.png)

    3.4. All of request parameters should be the same as before.
    ![screen shot 2560-02-01 at 1 14 40 pm](https://cloud.githubusercontent.com/assets/2154669/22496928/783484e6-e880-11e6-8eef-2d03ac12c52d.png)

4. ✅ Test checkout an order with `authorize and capture` action and use [failed card test]
    4.1. Same as second test but error message is slightly different,
    <img width="1118" alt="screen shot 2560-02-01 at 1 22 54 pm" src="https://cloud.githubusercontent.com/assets/2154669/22497099/af3c7e34-e881-11e6-8052-99f6c99a6477.png">

5. ✅ Test manual capture
    5.1. Go to admin, order list page. (`Sales > Orders`)

    5.2. Choose one order and click `Invoice` to capture a transaction.
    ![screen shot 2560-02-01 at 6 19 57 am copy](https://cloud.githubusercontent.com/assets/2154669/22497222/9e1532b2-e882-11e6-8268-3a8d729c7fe9.jpg)

    5.3. Check Omise dashboard, charge log, the dashboard shows, `capture (manual)` with `requested capture` log.
    ![screen shot 2560-02-01 at 1 31 41 pm](https://cloud.githubusercontent.com/assets/2154669/22497267/fc10e51e-e882-11e6-8b88-75c9b966daf3.jpg)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

**Known issues:**
- Note, https://github.com/omise/omise-magento/pull/46/files#diff-252896e00d37e3f160a971e0827a3ef2R35
    Ideally, this class shouldn't take care about how to set `public_key` and `secret_key` (and shouldn't contains `protected $public_key` & `protected $secret_key` by itself).
    These should be provided at `Configuration` class.

- `Omise_Gateway_Model_Omise` will be deprecated in the future.
    For payment gateway methods, use `Omise_Gateway_Model_Payment` instead.

- This PR is preparing for `3-D Secure` & `Internet Banking`.
    `Model/Strategies/OffsiteInternetBankingStrategy` will be provided for Internet Banking feature in another PR.

- `Omise_Gateway_Model_PaymentMethod` will be renamed to `Omise_Gateway_Model_CreditCardPayment` in the future, to separate between `Credit Card` payment behaviour and `Internet Banking` payment behaviour.

- Continue from above, then we can have `Omise_Gateway_Model_OffsiteInternetBankingPayment` to handle only `Internet Banking` payment behaviour.