### PR TITLE
Redirect buyer to 3-D Secure auth page and prepare callback uri.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -265,13 +265,18 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
     }
 
     /**
+     * @param  array $params
+     *
      * @return string
      */
-    public function getThreeDSecureCallbackUri()
+    public function getThreeDSecureCallbackUri($params = array())
     {
         return Mage::getUrl(
             'omise/callback_validatethreedsecure',
-            array('_secure' => Mage::app()->getStore()->isCurrentlySecure())
+            array(
+                '_secure' => Mage::app()->getStore()->isCurrentlySecure(),
+                '_query'  => $params
+            )
         );
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -141,4 +141,23 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
 
         return $amount;
     }
+
+    /**
+     * @return bool
+     */
+    public function isThreeDSecureNeeded()
+    {
+        return Mage::getStoreConfig('payment/omise_gateway/threedsecure') ? true : false;
+    }
+
+    /**
+     * @return string
+     */
+    public function getThreeDSecureCallbackUri()
+    {
+        return Mage::getUrl(
+            'omise/callback_validatethreedsecure',
+            array('_secure' => Mage::app()->getStore()->isCurrentlySecure())
+        );
+    }
 }

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -96,6 +96,8 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $amount
         );
 
+        $payment->setIsTransactionPending(true);
+
         Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
 
         Mage::log('The transaction was created, processing 3-D Secure authentication.');
@@ -163,6 +165,8 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $payment,
             $amount
         );
+
+        $payment->setIsTransactionPending(true);
 
         Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
 

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -96,6 +96,10 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $amount
         );
 
+        if (isset($result['authorize_uri'])) {
+            Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
+        }
+
         Mage::log('The transaction was created, processing 3-D Secure authentication.');
         return $result;
     }
@@ -159,6 +163,10 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $amount
         );
 
+        if (isset($result['authorize_uri'])) {
+            Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
+        }
+
         Mage::log('The transaction was created, processing 3-D Secure authentication by Omise payment gateway.');
         return $result;
     }
@@ -213,6 +221,20 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
         }
 
         return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Sales/Model/Quote/Payment.php
+     */
+    public function getOrderPlaceRedirectUrl()
+    {
+        if ($this->isThreeDSecureNeeded()) {
+            return Mage::getSingleton('checkout/session')->getOmiseAuthorizeUri();
+        }
+
+        return '';
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -6,9 +6,11 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
      *
      * @var string
      */
-    const STRATEGY_AUTHORIZE         = 'AuthorizeStrategy';
-    const STRATEGY_AUTHORIZE_CAPTURE = 'CaptureStrategy';
-    const STRATEGY_MANUAL_CAPTURE    = 'ManualCaptureStrategy';
+    const STRATEGY_AUTHORIZE                        = 'AuthorizeStrategy';
+    const STRATEGY_AUTHORIZE_THREE_D_SECURE         = 'AuthorizeThreeDSecureStrategy';
+    const STRATEGY_AUTHORIZE_CAPTURE                = 'CaptureStrategy';
+    const STRATEGY_AUTHORIZE_CAPTURE_THREE_D_SECURE = 'CaptureThreeDSecureStrategy';
+    const STRATEGY_MANUAL_CAPTURE                   = 'ManualCaptureStrategy';
 
     /**
      * @var string

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -122,6 +122,9 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $result = $this->performCapture($payment, $amount);
         }
 
+        $this->getInfoInstance()->setAdditionalInformation('omise_charge_id', $result['id']);
+        Mage::log('Assigned charge id ' . $result['id'] . ' to the transaction');
+
         return $this;
     }
 

--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -96,9 +96,7 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $amount
         );
 
-        if (isset($result['authorize_uri'])) {
-            Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
-        }
+        Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
 
         Mage::log('The transaction was created, processing 3-D Secure authentication.');
         return $result;
@@ -163,9 +161,7 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
             $amount
         );
 
-        if (isset($result['authorize_uri'])) {
-            Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
-        }
+        Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
 
         Mage::log('The transaction was created, processing 3-D Secure authentication by Omise payment gateway.');
         return $result;

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -29,12 +29,29 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
      */
     public function validate($charge)
     {
-        if (! isset($charge['authorize_uri'])) {
-            $this->message = 'Payment process failed, cannot retrieve a 3-D Secure authorize uri. Please contact our support to confirm the payment.';
+        if (! isset($charge['object'])) {
+            $this->message = 'Cannot retrieve a payment result, please contact our support to confirm the payment.';
             return false;
         }
 
-        $this->message = 'dump error.';
+        if ($charge['object'] === 'error') {
+            $this->message = $charge['message'];
+            return false;
+        }
+
+        if ($charge['failure_code'] || $charge['failure_message']) {
+            $this->message = 'Payment authorization failed, ' . $charge['failure_message'] . ' (code: ' . $charge['failure_code'] . ')';
+            return false;
+        }
+
+        if ($charge['object'] === 'charge'
+            && $charge['status'] === 'pending'
+            && $charge['authorized'] === false
+            && $charge['captured'] === false) {
+            return true;
+        }
+
+        $this->message = 'Error payment result validation, please contact our support to confirm the payment.';
         return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -29,6 +29,11 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
      */
     public function validate($charge)
     {
+        if (! isset($charge['authorize_uri'])) {
+            $this->message = 'Payment process failed, cannot retrieve a 3-D Secure authorize uri. Please contact our support to confirm the payment.';
+            return false;
+        }
+
         $this->message = 'dump error.';
         return false;
     }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -46,8 +46,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
 
         if ($charge['object'] === 'charge'
             && $charge['status'] === 'pending'
-            && $charge['authorized'] === false
-            && $charge['captured'] === false) {
+            && $charge['authorize_uri']) {
             return true;
         }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -6,7 +6,16 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
      */
     public function perform($payment, $amount)
     {
-        // ...
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => false,
+            'card'        => $info->getAdditionalInformation('omise_token'),
+            'return_uri'  => $payment->getThreeDSecureCallbackUri()
+        ));
     }
 
     /**
@@ -20,6 +29,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
      */
     public function validate($charge)
     {
-        // ...
+        $this->message = 'dump error.';
+        return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -14,7 +14,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
             'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
             'capture'     => false,
             'card'        => $info->getAdditionalInformation('omise_token'),
-            'return_uri'  => $payment->getThreeDSecureCallbackUri()
+            'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
         ));
     }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -1,0 +1,25 @@
+<?php
+class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function perform($payment, $amount)
+    {
+        // ...
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        // ...
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -1,0 +1,25 @@
+<?php
+class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function perform($payment, $amount)
+    {
+        // ...
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        // ...
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -46,8 +46,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
 
         if ($charge['object'] === 'charge'
             && $charge['status'] === 'pending'
-            && $charge['authorized'] === false
-            && $charge['captured'] === false) {
+            && $charge['authorize_uri']) {
             return true;
         }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -6,7 +6,16 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
      */
     public function perform($payment, $amount)
     {
-        // ...
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'capture'     => true,
+            'card'        => $info->getAdditionalInformation('omise_token'),
+            'return_uri'  => $payment->getThreeDSecureCallbackUri()
+        ));
     }
 
     /**
@@ -20,6 +29,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
      */
     public function validate($charge)
     {
-        // ...
+        $this->message = 'dump error.';
+        return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -29,6 +29,11 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
      */
     public function validate($charge)
     {
+        if (! isset($charge['authorize_uri'])) {
+            $this->message = 'Payment process failed, cannot retrieve a 3-D Secure authorize uri. Please contact our support to confirm the payment.';
+            return false;
+        }
+
         $this->message = 'dump error.';
         return false;
     }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -14,7 +14,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
             'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
             'capture'     => true,
             'card'        => $info->getAdditionalInformation('omise_token'),
-            'return_uri'  => $payment->getThreeDSecureCallbackUri()
+            'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
         ));
     }
 

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -1,0 +1,8 @@
+<?php
+class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Controller_Front_Action
+{
+    public function indexAction()
+    {
+        // Callback validation.
+    }
+}

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -4,5 +4,6 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
     public function indexAction()
     {
         // Callback validation.
+        echo "validating!";
     }
 }

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -82,6 +82,18 @@
         </routers>
     </admin>
 
+    <frontend>
+        <routers>
+            <omise_gateway>
+                <use>standard</use>
+                <args>
+                    <module>Omise_Gateway</module>
+                    <frontName>omise</frontName>
+                </args>
+            </omise_gateway>
+        </routers>
+    </frontend>
+
     <!--
     /**
      * Payment Method configuration for front-end


### PR DESCRIPTION
> ⚠️ This PR required PR #43 to be merged first.

> This PR is a part of the 3-D Secure implementation plan.
> For the detail, please check PR #41.

#### 1. Objective

To pass a `return_uri` param when create a charge (with authorize or auto capture actions) and redirect buyer to the 3-D Secure authentication page, then prepare callback uri for validate the payment result if the 3-D Secure setting is enabled.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2318

#### 2. Description of change

- Add a new callback route, `omise/callback_validatethreedsecure`.
    see, `Omise/Gateway/Callback/ValidateThreeDSecureController.php` to validate a 3-D Secure payment process's result.

- Implement `AuthorizeThreeDSecureStrategy` and `CaptureThreeDSecureStrategy` strategies.
- Assign `return_uri` parameter when create new charge (auth/auto capture) if the 3-D Secure setting is enabled.

- Redirect buyer to `authorize_uri`.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6.
- **PHP version**: 5.6.28.

**✏️ Details:**

**Tested with `3-D Secure enabled Omise account`.**

1. Test enable the 3-D Secure option and make a charge with `authorize only` payment action.
    1.1. Go to payment setting page.
    1.2. At the Omise section, set `3-D Secure support` to `Yes`.
    1.3. Do checkout as normal.
    1.4. After place an order, a store will redirect buyer to Omise's `authorize_uri` page.
    1.5. **If you use test key**, Omise will redirect buyer back to the `return_uri` and considered as `payment success`.

    **Result**
    Can make charge, `authorized = true, paid = false` 
    ![screen shot 2560-02-09 at 3 50 33 am](https://cloud.githubusercontent.com/assets/2154669/22756841/11c4fba4-ee7b-11e6-86f6-8f446b207668.png)

    Requested log.
    ![screen shot 2560-02-09 at 3 42 20 am](https://cloud.githubusercontent.com/assets/2154669/22756475/d1a2a43c-ee79-11e6-9e57-42127f91e274.png)

    At Magento order detail page, it says that the authorize action is pending and waiting for approval from payment gateway.
    ![screen shot 2560-02-09 at 4 55 10 am](https://cloud.githubusercontent.com/assets/2154669/22759185/0ed5cf28-ee84-11e6-95ff-bacf5f9f2874.png)

    Magento will set an order status to `payment review`. (because it (callback) didn't validate the payment result yet.)
    ![screen shot 2560-02-09 at 4 58 58 am](https://cloud.githubusercontent.com/assets/2154669/22759348/b74daab8-ee84-11e6-87f6-56897cbf1bd4.png)

2. Test enable the 3-D Secure option and make a charge with `authorize and capture` payment action.
    Same as the first test, but `payment action = authorize and capture`

    **Result**
    Can make charge, `authorized = true, paid = true` 
    ![screen shot 2560-02-09 at 3 50 46 am](https://cloud.githubusercontent.com/assets/2154669/22757106/1b0f614e-ee7c-11e6-9a27-d341e063da15.png)

    Requested log.
    ![screen shot 2560-02-09 at 3 51 06 am](https://cloud.githubusercontent.com/assets/2154669/22757105/1b07b2be-ee7c-11e6-9f3b-cde5389ecf5b.png)

    At Magento order detail page, it says that the capture action is pending and waiting for approval from payment gateway.
    ![screen shot 2560-02-09 at 4 49 59 am](https://cloud.githubusercontent.com/assets/2154669/22759010/780d9648-ee83-11e6-9df6-8eb9189782b9.png)

    Magento will set an order status to `payment review`. (because it (callback) didn't validate the payment result yet.)
    ![screen shot 2560-02-09 at 4 58 58 am](https://cloud.githubusercontent.com/assets/2154669/22759348/b74daab8-ee84-11e6-87f6-56897cbf1bd4.png)

3. Test disable the 3-D Secure option and make a charge with `authorize only` payment action.
4. Test disable the 3-D Secure option and make a charge with `authorize and capture` payment action.
    Both will raise an error as below.
    <img width="1204" alt="screen shot 2560-02-09 at 4 07 50 am" src="https://cloud.githubusercontent.com/assets/2154669/22757446/5bb0c426-ee7d-11e6-8c64-c1f4646ad035.png">

**Tested with `3-D Secure disabled Omise account`.**

5. Test enable the 3-D Secure option and make a charge with `authorize only` payment action.
6. Test enable the 3-D Secure option and make a charge with `authorize and capture` payment action.
    The payment behaviour will be the same as the first and second test.
    - Redirect buyer to `authorize_uri`.
    - Then, because that merchant account doesn't enable the 3-D Secure feature, so, Omise API will consider it as charge without 3-D Secure and process as normal.
    - Then, redirect buyer back to the `return_uri`.

    **Note** because this PR haven't implemented 3-D Secure callback validator yet, so, this test will be stuck at the screen
    <img width="1230" alt="screen shot 2560-02-09 at 3 30 27 am" src="https://cloud.githubusercontent.com/assets/2154669/22756045/63f55534-ee78-11e6-8129-6ee7edff7d2a.png">
    But at the end, it will just only check if a charge transaction is successful or not and then, update order status as normal.

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- `Omise/Gateway/Callback/ValidateThreeDSecureController.php` still have no-implementation yet.
    It will be implemented in other PR (that the topic is related with `Validate the 3-D Secure payment result and update order status`).

- A screen after the 3-D Secure authorization redirect buyer back to a store.
    <img width="1230" alt="screen shot 2560-02-09 at 3 30 27 am" src="https://cloud.githubusercontent.com/assets/2154669/22756045/63f55534-ee78-11e6-8129-6ee7edff7d2a.png">
