### PR TITLE
Add Internet Banking payment option to the setting page.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -1,0 +1,44 @@
+<?php
+class Omise_Gateway_Block_Adminhtml_System_Config_Fieldset_Payment extends Mage_Adminhtml_Block_System_Config_Form_Fieldset
+{
+    /**
+     * Return header title part of html for fieldset.
+     *
+     * @param  Varien_Data_Form_Element_Abstract $element
+     *
+     * @return string
+     *
+     * @see    Mage_Adminhtml_Block_System_Config_Form_Fieldset::_getHeaderTitleHtml()
+     */
+    protected function _getHeaderTitleHtml($element)
+    {
+        $html  = '<div class="config-heading entry-edit-head collapseable">';
+        $html .= '  <a  id="' . $element->getHtmlId() . '-head"
+                        href="#"
+                        onclick="Fieldset.toggleCollapse(\'' . $element->getHtmlId() . '\', \'' . $this->getUrl('*/*/state') . '\'); return false;">';
+        $html .=        $element->getLegend();
+        $html .= '  </a>';
+
+        if ($element->getComment()) {
+            $html .= '<span class="heading-intro">' . $element->getComment() . '</span>';
+        }
+
+        $html .= '</div>';
+
+        return $html;
+    }
+
+    /**
+     * Return header comment part of html for fieldset.
+     *
+     * @param  Varien_Data_Form_Element_Abstract $element
+     *
+     * @return string
+     *
+     * @see    Mage_Adminhtml_Block_System_Config_Form_Fieldset::_getHeaderCommentHtml()
+     */
+    protected function _getHeaderCommentHtml($element)
+    {
+        return '';
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -13,7 +13,7 @@
                     <fields>
                         <omise_gateway type="group">
                             <label>Credit Card</label>
-                            <sort_order>670</sort_order>
+                            <sort_order>680</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -49,6 +49,27 @@
                                 </order_status>
                             </fields>
                         </omise_gateway>
+
+                        <omise_offsite_internet_banking type="group">
+                            <label>Internet Banking</label>
+                            <comment>Enables customers of a bank to easily conduct financial transactions through a bank-operated website (only available in Thailand).</comment>
+                            <sort_order>690</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
+                            <fields>
+                                <active translate="label">
+                                    <label>Module Enabled</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                                    <sort_order>1</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </active>
+                            </fields>
+                        </omise_offsite_internet_banking>
                     </fields>
                 </omise_payment>
             </groups>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -21,7 +21,7 @@
                             <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
                             <fields>
                                 <active translate="label">
-                                    <label>Module Enabled</label>
+                                    <label>Enabled</label>
                                     <frontend_type>select</frontend_type>
                                     <source_model>adminhtml/system_config_source_yesno</source_model>
                                     <sort_order>1</sort_order>
@@ -62,7 +62,7 @@
                             <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
                             <fields>
                                 <active translate="label">
-                                    <label>Module Enabled</label>
+                                    <label>Enabled</label>
                                     <frontend_type>select</frontend_type>
                                     <source_model>adminhtml/system_config_source_yesno</source_model>
                                     <sort_order>1</sort_order>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -13,10 +13,12 @@
                     <fields>
                         <omise_gateway type="group">
                             <label>Credit Card</label>
+                            <comment>Powerful payment features that allows you to easily and securely accept credit/debit card payments on your store.</comment>
                             <sort_order>680</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
+                            <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
                             <fields>
                                 <active translate="label">
                                     <label>Module Enabled</label>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -3,44 +3,54 @@
     <sections>
         <payment>
             <groups>
-                <omise_gateway translate="label" module="payment">
+                <omise_payment translate="label" module="payment">
                     <label>Omise Payment Gateway</label>
                     <sort_order>670</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>0</show_in_store>
+                    <frontend_class>complex</frontend_class>
                     <fields>
-                        <active translate="label">
-                            <label>Module Enabled</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>1</sort_order>
+                        <omise_gateway type="group">
+                            <label>Credit Card</label>
+                            <sort_order>670</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </active>
+                            <fields>
+                                <active translate="label">
+                                    <label>Module Enabled</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                                    <sort_order>1</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </active>
 
-                        <payment_action translate="label">
-                            <label>Payment Action</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>omise_gateway/config_var_paymentaction</source_model>
-                            <sort_order>2</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </payment_action>
+                                <payment_action translate="label">
+                                    <label>Payment Action</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>omise_gateway/config_var_paymentaction</source_model>
+                                    <sort_order>2</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </payment_action>
 
-                        <order_status translate="label">
-                            <label>New order status</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
-                            <sort_order>3</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </order_status>
+                                <order_status translate="label">
+                                    <label>New order status</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
+                                    <sort_order>3</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </order_status>
+                            </fields>
+                        </omise_gateway>
                     </fields>
-                </omise_gateway>
+                </omise_payment>
             </groups>
         </payment>
     </sections>


### PR DESCRIPTION
> This PR is a part of the Internet Banking feature implementation plan.
> For the detail, please check PR #48.

#### 1. Objective

To provide the Internet Banking payment option at the payment setting page.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2247

#### 2. Description of change

- Add the `Internet Banking` payment option to the setting page.

- Also, update the payment setting section by grouping the settings and separating the payment methods.
    Separate the setting between `Credit Card Payment` and `Internet Banking Payment`.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6.
- **PHP version**: 5.6.28.

**✏️ Details:**

- Go to setting page (`Magento Admin > System > Configuration > Sales > Payment Methods` ), you will see the payment setting's new design.
    ![screen shot 2560-02-02 at 5 23 59 am](https://cloud.githubusercontent.com/assets/2154669/22670443/c187dab0-ecfb-11e6-9761-25f3cf612964.png)

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- This PR just only provided the setting and redesign the module setting section, haven't complete the implementation part of the payment class yet (next PR).