### PR TITLE
Validate a 3-D Secure payment result and update order status.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
+++ b/src/app/code/community/Omise/Gateway/Model/PaymentMethod.php
@@ -32,9 +32,10 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
      *
      * @var bool
      */
-    protected $_isGateway     = true;
-    protected $_canAuthorize  = true;
-    protected $_canCapture    = true;
+    protected $_isGateway        = true;
+    protected $_canAuthorize     = true;
+    protected $_canCapture       = true;
+    protected $_canReviewPayment = true;
 
     /**
      * Authorize payment method
@@ -192,6 +193,38 @@ class Omise_Gateway_Model_PaymentMethod extends Omise_Gateway_Model_Payment
 
         Mage::log('The transaction was performed manual capture by Omise payment gateway and successful.');
         return $result;
+    }
+
+    /**
+     * Attempt to accept a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function acceptPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::acceptPayment($payment);
+
+        return true;
+    }
+
+    /**
+     * Attempt to deny a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function denyPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::denyPayment($payment);
+
+        return true;
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
         }
 
         if ($charge['object'] === 'charge'
-            && $charge['status'] === 'pending'
+            && $charge['status'] !== 'failed'
             && $charge['authorize_uri']) {
             return true;
         }

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
         }
 
         if ($charge['object'] === 'charge'
-            && $charge['status'] === 'pending'
+            && $charge['status'] !== 'failed'
             && $charge['authorize_uri']) {
             return true;
         }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -77,14 +77,6 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
      */
     protected function validate($charge)
     {
-        if (! $charge['authorized']) {
-            return false;
-        }
-        // Auto capture case.
-        if ($charge['capture'] && ! $charge['captured']) {
-            return false;
-        }
-
         // check for auto capture.
         if ($charge['capture'] && $charge['status'] === 'successful' && $charge['authorized'] && $charge['captured']) {
             return true;

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -3,7 +3,87 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
 {
     public function indexAction()
     {
+        $omise = Mage::getModel('omise_gateway/omise');
+        $omise->initNecessaryConstant();
+
         // Callback validation.
-        echo "validating!";
+        $order = $this->getOrder();
+
+        if (! $payment = $order->getPayment()) {
+            Mage::getSingleton('core/session')->addError(
+                $this->__('3-D Secure validation was invalid, cannot retrieve your payment information. Please contact our support to confirm the payment.')
+            );
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        try {
+            $charge_id = $payment->getMethodInstance()->getInfoInstance()->getAdditionalInformation('omise_charge_id');
+            $charge    = OmiseCharge::retrieve($charge_id);
+
+            if (! $this->validate($charge)) {
+                return $this->considerFail(
+                    $order,
+                    $this->__('The payment was invalid, ' . $charge['failure_message'] . ' (' . $charge['failure_code'] . ').')
+                );
+            }
+
+            $payment->accept();
+            $order->save();
+            return $this->_redirect('checkout/onepage/success');
+        } catch (Exception $e) {
+            return $this->considerFail(
+                $order,
+                $this->__($e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @return \Mage_Sales_Model_Order
+     */
+    protected function getOrder()
+    {
+        $order_increment_id = $this->getRequest()->getParam('order_id');
+
+        if ($order_increment_id) {
+            return Mage::getModel('sales/order')->loadByIncrementId($order_increment_id);
+        }
+
+        return Mage::getModel('sales/order')->load(Mage::getSingleton('checkout/session')->getLastOrderId());
+    }
+
+    protected function considerFail($order, $message)
+    {
+        $order->getPayment()
+            ->setPreparedMessage($message)
+            ->deny();
+        $order->save();
+
+        Mage::getSingleton('core/session')->addError($message);
+        return $this->_redirect('checkout/cart');
+    }
+
+    protected function validate($charge)
+    {
+        if (! $charge['authorized']) {
+            return false;
+        }
+        // Auto capture case.
+        if ($charge['capture'] && ! $charge['captured']) {
+            return false;
+        }
+
+        // check for auto capture.
+        if ($charge['capture'] && $charge['status'] === 'successful' && $charge['authorized'] && $charge['captured']) {
+            return true;
+        }
+
+        // Check for authorize only.
+        if (! $charge['capture'] && $charge['status'] === 'pending' && $charge['authorized']) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateThreeDSecureController.php
@@ -53,6 +53,12 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
         return Mage::getModel('sales/order')->load(Mage::getSingleton('checkout/session')->getLastOrderId());
     }
 
+    /**
+     * @param  \Mage_Sales_Model_Order $order
+     * @param  string                  $message
+     *
+     * @return self
+     */
     protected function considerFail($order, $message)
     {
         $order->getPayment()
@@ -64,6 +70,11 @@ class Omise_Gateway_Callback_ValidateThreeDSecureController extends Mage_Core_Co
         return $this->_redirect('checkout/cart');
     }
 
+    /**
+     * @param  \OmiseCharge $charge
+     *
+     * @return bool
+     */
     protected function validate($charge)
     {
         if (! $charge['authorized']) {


### PR DESCRIPTION
> ⚠️ This PR required PR #47 to be merged first.

> This PR is a part of the 3-D Secure implementation plan.
> For the detail, please check PR #41.

#### 1. Objective

To update a payment detail at Magento side after 3-D Secure payment process.
By validating the result, determine whether a payment success or not.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2376

#### 2. Description of change

- Allow Omise plugin to perform `_canReviewPayment` action.
- At the 3-D Secure callback (return_uri), validate a 3-D Secure payment result (if success, update status to `processing`, if fail, update status to `canceled`).

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1
- **Omise plugin version**: Omise-Magento 1.9.0.6
- **PHP version**: 5.6.28

**✏️ Details:**

> _note, with test account, buyer will be redirected to an `authorize_uri` and then, immediately be redirected back to a callback uri, the result will be considered as success unless you use a [failed card test](https://www.omise.co/api-testing#failed-charge)._

**With `enabled 3-D Secure Omise account` and `enabled 3-D Secure setting` in the payment setting page**

1. ✅ Test checkout with `payment action = authorize only`.
    Charge must be successful and order status will be set to `processing`.

    At admin, order detail page. You will see a transaction history there as below.
    ![screen shot 2560-02-14 at 11 19 51 pm](https://cloud.githubusercontent.com/assets/2154669/22941617/37b23cf6-f30c-11e6-97fa-40b343464f33.png)

2. ✅️ Test checkout with `payment action = authorize and capture`.
    Charge must be successful and order status will be set to `processing`.

    At admin, order detail page. You will see a transaction history there as below.
    ![screen shot 2560-02-14 at 11 12 05 pm](https://cloud.githubusercontent.com/assets/2154669/22941457/7d0d549e-f30b-11e6-83f6-d9cf1ba13eb6.png)

3. ✅ Test checkout with any of [fail card](https://www.omise.co/api-testing)
    Buyer see a failure message on a screen after redirect back from the authorize_uri (considered as charge failed). 
    <img width="1552" alt="screen shot 2560-02-14 at 12 24 38 pm" src="https://cloud.githubusercontent.com/assets/2154669/22921001/e493d5fa-f2bd-11e6-9bb3-fee22c8d127f.png">

    If check at the admin order list page, new order record will be appeared there with status `canceled`.
    ![screen shot 2560-02-14 at 12 25 34 pm](https://cloud.githubusercontent.com/assets/2154669/22921000/e48831aa-f2bd-11e6-8284-32aa516972e2.png)

    ![screen shot 2560-02-14 at 11 25 45 pm](https://cloud.githubusercontent.com/assets/2154669/22941859/28d782bc-f30d-11e6-8d8b-2a101d0d778b.png)

**With `enabled 3-D Secure Omise account` and `disabled 3-D Secure setting` in the payment setting page**

4. ✅ Test checkout with `payment action = authorize only`.

5. ✅ Test checkout with `payment action = authorize and capture`.
    Both will raise a `payment_reject` error as below.
    <img width="1552" alt="screen shot 2560-02-14 at 11 34 09 pm" src="https://cloud.githubusercontent.com/assets/2154669/22943512/d17a5222-f313-11e6-8c91-e44b5af7446c.png">

**With `disabled 3-D Secure Omise account` and `enabled 3-D Secure setting` in the payment setting page**

6. ✅ Test checkout with `payment action = authorize only`.

7. ✅ Test checkout with `payment action = authorize and capture`.
    Both cases will work as well.
    It functions as normal charge (check test 9th, 10th), but buyer will be redirect to an authorize_uri once and immediately redirect back to the callback uri (same behaviour as enabled 3-D Secure tests, but at the redirecting step, Omise will consider that a charge doesn't require to process with Omise 3-D Secure and then, Omise will redirect buyer back to `return_uri`).

    > _note, an order history will be shown as 3-D Secure feature process, see a screenshot below._
    ![screen shot 2560-02-15 at 12 38 41 am](https://cloud.githubusercontent.com/assets/2154669/22944654/63ecb494-f317-11e6-8798-b4f8f5f7af88.png)

8. ✅ While using `disabled 3-D Secure Omise account` and `enabled 3-D Secure setting`. Test checkout with any of [fail card](https://www.omise.co/api-testing).
    Failure message will be raised as normal charge without 3-D Secure behaviour.
    <img width="1150" alt="screen shot 2560-02-15 at 12 46 25 am" src="https://cloud.githubusercontent.com/assets/2154669/22944890/3c1265f8-f318-11e6-88fc-93dbec24b1c9.png">

**With `disabled 3-D Secure Omise account` and `disabled 3-D Secure setting` in the payment setting page**

9. ✅ Test checkout with `payment action = authorize only`.

10. ✅ Test checkout with `payment action = authorize and capture`.
    Both cases must function as well, since these 2 cases are not related with the 3-D Secure feature (just test to make sure that the 3-D Secure implementation will not make any effect to the current function).

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No