### PR TITLE
Be able to make a charge through Internet Banking payment method.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -62,4 +62,27 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
         Mage::log('The transaction was created, processing internet banking payment by Omise payment gateway.');
         return $this;
     }
+
+    /**
+     * Format a Magento's amount to be a small-unit that Omise's API requires.
+     * Note, no specific format for JPY currency.
+     *
+     * @param  string          $currency
+     * @param  integer | float $amount
+     *
+     * @return integer
+     */
+    public function formatAmount($currency, $amount)
+    {
+        switch (strtoupper($currency)) {
+            case 'THB':
+            case 'IDR':
+            case 'SGD':
+                // Convert to a small unit
+                $amount = $amount * 100;
+                break;
+        }
+
+        return $amount;
+    }
 }

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -59,6 +59,12 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
             $amount
         );
 
+        $payment->setIsTransactionPending(true);
+
+        $this->getInfoInstance()->setAdditionalInformation('omise_charge_id', $result['id']);
+
+        Mage::getSingleton('checkout/session')->setOmiseAuthorizeUri($result['authorize_uri']);
+
         Mage::log('The transaction was created, processing internet banking payment by Omise payment gateway.');
         return $this;
     }
@@ -73,6 +79,16 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
         parent::assignData($data);
 
         $this->getInfoInstance()->setAdditionalInformation('offsite', $data->getData('offsite'));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Sales/Model/Quote/Payment.php
+     */
+    public function getOrderPlaceRedirectUrl()
+    {
+        return Mage::getSingleton('checkout/session')->getOmiseAuthorizeUri();
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -22,4 +22,16 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
      * @var bool
      */
     protected $_isGateway = true;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Payment/Model/Method/Abstract.php
+     */
+    public function assignData($data)
+    {
+        parent::assignData($data);
+
+        $this->getInfoInstance()->setAdditionalInformation('offsite', $data->getData('offsite'));
+    }
 }

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -64,6 +64,18 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Payment/Model/Method/Abstract.php
+     */
+    public function assignData($data)
+    {
+        parent::assignData($data);
+
+        $this->getInfoInstance()->setAdditionalInformation('offsite', $data->getData('offsite'));
+    }
+
+    /**
      * Format a Magento's amount to be a small-unit that Omise's API requires.
      * Note, no specific format for JPY currency.
      *

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -21,7 +21,8 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
      *
      * @var bool
      */
-    protected $_isGateway = true;
+    protected $_isGateway  = true;
+    protected $_canCapture = true;
 
     /**
      * {@inheritDoc}
@@ -33,5 +34,21 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
         parent::assignData($data);
 
         $this->getInfoInstance()->setAdditionalInformation('offsite', $data->getData('offsite'));
+    }
+
+    /**
+     * Capture payment method
+     *
+     * @param  Varien_Object $payment
+     * @param  float         $amount
+     *
+     * @return Mage_Payment_Model_Abstract
+     */
+    public function capture(Varien_Object $payment, $amount)
+    {
+        Mage::log('Start processing internet banking payment method with Omise payment gateway.');
+
+        Mage::log('The transaction was created, processing internet banking payment by Omise payment gateway.');
+        return $this;
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -4,6 +4,11 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
     /**
      * @var string
      */
+    const STRATEGY_OFFSITE_INTERNET_BANKING = 'OffsiteInternetBankingStrategy';
+
+    /**
+     * @var string
+     */
     protected $_code = 'omise_offsite_internet_banking';
 
     /**
@@ -47,6 +52,12 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
     public function capture(Varien_Object $payment, $amount)
     {
         Mage::log('Start processing internet banking payment method with Omise payment gateway.');
+
+        $result = $this->perform(
+            Mage::getModel('omise_gateway/Strategies_' . self::STRATEGY_OFFSITE_INTERNET_BANKING),
+            $payment,
+            $amount
+        );
 
         Mage::log('The transaction was created, processing internet banking payment by Omise payment gateway.');
         return $this;

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
@@ -6,7 +6,15 @@ class Omise_Gateway_Model_Strategies_OffsiteInternetBankingStrategy extends Omis
      */
     public function perform($payment, $amount)
     {
-        // ...
+        $info = $payment->getPaymentInformation();
+
+        return OmiseCharge::create(array(
+            'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
+            'currency'    => $info->getOrder()->getOrderCurrencyCode(),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'offsite'     => $info->getAdditionalInformation('offsite'),
+            'return_uri'  => 'https://www.omise.co'
+        ));
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
@@ -1,0 +1,25 @@
+<?php
+class Omise_Gateway_Model_Strategies_OffsiteInternetBankingStrategy extends Omise_Gateway_Model_Strategies_StrategyAbstract
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function perform($payment, $amount)
+    {
+        // ...
+    }
+
+    /**
+     * Validate a payment process result.
+     *
+     * @param  \OmiseCharge $charge
+     *
+     * @return boolean
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCharge.php
+     */
+    public function validate($charge)
+    {
+        // ...
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -100,6 +100,7 @@
 
             <omise_offsite_internet_banking>
                 <active>0</active>
+                <payment_action>authorize_capture</payment_action>
                 <model>omise_gateway/OffsiteInternetBankingPayment</model>
                 <title>Internet Banking</title>
             </omise_offsite_internet_banking>

--- a/src/app/design/frontend/base/default/template/payment/form/omiseoffsiteinternetbankingpayment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omiseoffsiteinternetbankingpayment.phtml
@@ -7,7 +7,7 @@ $code = $this->getMethodCode();
 <ul id="payment_form_<?php echo $code; ?>" class="form-list" style="display:none;">
     <!-- SCB -->
     <li class="item">
-        <input id="internet_banking_scb" type="radio" name="offsite" value="internet_banking_scb" />
+        <input id="internet_banking_scb" type="radio" name="payment[offsite]" value="internet_banking_scb" />
         <label for="internet_banking_scb">
             <div class="omise-logo-wrapper scb">
                 <img class="scb" />
@@ -18,7 +18,7 @@ $code = $this->getMethodCode();
 
     <!-- KTB -->
     <li class="item">
-        <input id="internet_banking_ktb" type="radio" name="offsite" value="internet_banking_ktb" />
+        <input id="internet_banking_ktb" type="radio" name="payment[offsite]" value="internet_banking_ktb" />
         <label for="internet_banking_ktb">
             <div class="omise-logo-wrapper ktb">
                 <img class="ktb" />
@@ -29,7 +29,7 @@ $code = $this->getMethodCode();
 
     <!-- BAY -->
     <li class="item">
-        <input id="internet_banking_bay" type="radio" name="offsite" value="internet_banking_bay" />
+        <input id="internet_banking_bay" type="radio" name="payment[offsite]" value="internet_banking_bay" />
         <label for="internet_banking_bay">
             <div class="omise-logo-wrapper bay">
                 <img class="bay" />
@@ -40,7 +40,7 @@ $code = $this->getMethodCode();
 
     <!-- BBL -->
     <li class="item">
-        <input id="internet_banking_bbl" type="radio" name="offsite" value="internet_banking_bbl" />
+        <input id="internet_banking_bbl" type="radio" name="payment[offsite]" value="internet_banking_bbl" />
         <label for="internet_banking_bbl">
             <div class="omise-logo-wrapper bbl">
                 <img class="bbl" />


### PR DESCRIPTION
> ⚠️ This PR required PR #51 to be merged first.

> This PR is a part of the Internet Banking feature implementation plan.
> For the detail, please check PR #48.

#### 1. Objective

To allow buyer to checkout with Omise Internet Banking payment method.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2249

#### 2. Description of change

- Correct the checkout form that backend could retrieve a POST request information.

- Implement new strategy class, `OffsiteInternetBankingStrategy`, to handle create charge with internet banking payment method.

- Implement `Model/OffsiteInternetBankingPayment` to process payment with `internet banking` feature.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6.
- **PHP version**: 5.6.28.

**✏️ Details:**

1. Test checkout with `Internet Banking` payment method.
    1.1. Select a bank that you want to process with.
    1.2. Then do submit (place order) as normal.
    1.3. Buyer will be redirected to an `authorize_uri` page.
    _note, if you process charge with test account, at the `authorize_uri` page, you will see._
    <img width="1040" alt="screen shot 2560-02-15 at 2 59 50 am" src="https://cloud.githubusercontent.com/assets/2154669/22950204/d83f5910-f32a-11e6-9b86-5ec7c8bc802a.png">

    Check at the request parameters
    <img width="1153" alt="screen shot 2560-02-15 at 2 58 33 am" src="https://cloud.githubusercontent.com/assets/2154669/22950175/bd133eea-f32a-11e6-9663-01f86c4e8ea7.png">

    Check at the admin order detail page.
    ![screen shot 2560-02-15 at 3 03 32 am](https://cloud.githubusercontent.com/assets/2154669/22950390/71e0cd06-f32b-11e6-952b-f60039997bef.png)

    Omise dashboard, charge detail page.
    ![screen shot 2560-02-15 at 3 05 17 am](https://cloud.githubusercontent.com/assets/2154669/22950449/a5df9c4a-f32b-11e6-8219-ecd4ddda0de0.png)

    Consider at the request parameters.
    ![screen shot 2560-02-15 at 3 05 28 am](https://cloud.githubusercontent.com/assets/2154669/22950447/a5b86832-f32b-11e6-8880-2a1cc14a4888.png)

    1.4. Whether you click `success` or `fail` button, Omise will redirect buyer back to a callback uri that we provided (for temporary, it's https://github.com/omise/omise-magento/pull/55/files#diff-8a0ffcdae3371e0515e97cc50d549966R16)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

- This PR haven't implement a callback/ callback validation part yet. (It would be implemented in the next PR.)

- From above, it means I can't provide a callback uri at the `OffsiteInternetBankingStrategy` class.
    So, right now I just did hard-code to other url as a temporary.