### PR TITLE
Validate an internet banking payment result and update order status.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -101,4 +101,20 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
 
         return $amount;
     }
+
+    /**
+     * @param  array $params
+     *
+     * @return string
+     */
+    public function getCallbackUri($params = array())
+    {
+        return Mage::getUrl(
+            'omise/callback_validateoffsiteinternetbanking',
+            array(
+                '_secure' => Mage::app()->getStore()->isCurrentlySecure(),
+                '_query'  => $params
+            )
+        );
+    }
 }

--- a/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
+++ b/src/app/code/community/Omise/Gateway/Model/OffsiteInternetBankingPayment.php
@@ -26,8 +26,9 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
      *
      * @var bool
      */
-    protected $_isGateway  = true;
-    protected $_canCapture = true;
+    protected $_isGateway        = true;
+    protected $_canCapture       = true;
+    protected $_canReviewPayment = true;
 
     /**
      * Capture payment method
@@ -55,6 +56,30 @@ class Omise_Gateway_Model_OffsiteInternetBankingPayment extends Omise_Gateway_Mo
 
         Mage::log('The transaction was created, processing internet banking payment by Omise payment gateway.');
         return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/community/Omise/Gateway/Model/PaymentMethod.php
+     */
+    public function acceptPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::acceptPayment($payment);
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/community/Omise/Gateway/Model/PaymentMethod.php
+     */
+    public function denyPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::denyPayment($payment);
+
+        return true;
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
@@ -13,7 +13,7 @@ class Omise_Gateway_Model_Strategies_OffsiteInternetBankingStrategy extends Omis
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
             'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
             'offsite'     => $info->getAdditionalInformation('offsite'),
-            'return_uri'  => 'https://www.omise.co'
+            'return_uri'  => $payment->getCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
         ));
     }
 

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateOffsiteInternetBankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateOffsiteInternetBankingController.php
@@ -3,6 +3,85 @@ class Omise_Gateway_Callback_ValidateOffsiteInternetBankingController extends Ma
 {
     public function indexAction()
     {
+        $omise = Mage::getModel('omise_gateway/omise');
+        $omise->initNecessaryConstant();
 
+        // Callback validation.
+        $order = $this->getOrder();
+
+        if (! $payment = $order->getPayment()) {
+            Mage::getSingleton('core/session')->addError(
+                $this->__('Internet banking validation was invalid, cannot retrieve your payment information. Please contact our support to confirm the payment.')
+            );
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        try {
+            $charge_id = $payment->getMethodInstance()->getInfoInstance()->getAdditionalInformation('omise_charge_id');
+            $charge    = OmiseCharge::retrieve($charge_id);
+
+            if (! $this->validate($charge)) {
+                return $this->considerFail(
+                    $order,
+                    $this->__('The payment was invalid, ' . $charge['failure_message'] . ' (' . $charge['failure_code'] . ').')
+                );
+            }
+
+            $payment->accept();
+            $order->save();
+            return $this->_redirect('checkout/onepage/success');
+        } catch (Exception $e) {
+            return $this->considerFail(
+                $order,
+                $this->__($e->getMessage())
+            );
+        }
+    }
+
+    /**
+     * @return \Mage_Sales_Model_Order
+     */
+    protected function getOrder()
+    {
+        $order_increment_id = $this->getRequest()->getParam('order_id');
+
+        if ($order_increment_id) {
+            return Mage::getModel('sales/order')->loadByIncrementId($order_increment_id);
+        }
+
+        return Mage::getModel('sales/order')->load(Mage::getSingleton('checkout/session')->getLastOrderId());
+    }
+
+    /**
+     * @param  \Mage_Sales_Model_Order $order
+     * @param  string                  $message
+     *
+     * @return self
+     */
+    protected function considerFail($order, $message)
+    {
+        $order->getPayment()
+            ->setPreparedMessage($message)
+            ->deny();
+        $order->save();
+
+        Mage::getSingleton('core/session')->addError($message);
+        return $this->_redirect('checkout/cart');
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     *
+     * @return bool
+     */
+    protected function validate($charge)
+    {
+        // check for auto capture.
+        if ($charge['status'] === 'successful' && $charge['authorized'] && $charge['captured']) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateOffsiteInternetBankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateOffsiteInternetBankingController.php
@@ -1,0 +1,8 @@
+<?php
+class Omise_Gateway_Callback_ValidateOffsiteInternetBankingController extends Mage_Core_Controller_Front_Action
+{
+    public function indexAction()
+    {
+
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -82,6 +82,18 @@
         </routers>
     </admin>
 
+    <frontend>
+        <routers>
+            <omise_gateway>
+                <use>standard</use>
+                <args>
+                    <module>Omise_Gateway</module>
+                    <frontName>omise</frontName>
+                </args>
+            </omise_gateway>
+        </routers>
+    </frontend>
+
     <!--
     /**
      * Payment Method configuration for front-end


### PR DESCRIPTION
> ⚠️ This PR required PR #56 to be merged first.

> This PR is a part of the 3-D Secure implementation plan.
> For the detail, please check PR #48.

#### 1. Objective

To update a payment detail at Magento side after Internet Banking payment process.
By validating the result, determine whether a payment success or not.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2419

#### 2. Description of change

- Provide new callback endpoint `/omise/callback_validateoffsiteinternetbankingcontroller`.

- Allow Omise plugin to perform `_canReviewPayment` action.

- At the Internet Banking callback (return_uri), validate an internet banking payment result (if success, update status to `processing`, if fail, update status to `canceled`).

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 1.9.3.1.
- **Omise plugin version**: Omise-Magento 1.9.0.6.
- **PHP version**: 5.6.28.

**✏️ Details:**

1. With Omise test account, at the authorize uri, let consider a charge to be failed.
    The result should be like these screenshots.

    Buyer will be redirected back to store with error message
    <img width="1552" alt="screen shot 2560-02-15 at 4 25 02 am" src="https://cloud.githubusercontent.com/assets/2154669/22953612/f68557dc-f337-11e6-93e3-309ae7cf039a.png">

    At the admin order detail page, a transaction history will show like below
    ![screen shot 2560-02-15 at 4 28 09 am](https://cloud.githubusercontent.com/assets/2154669/22953659/2c41c220-f338-11e6-94fe-a7f0268d82ae.png)

    At the Omise dashboard, charge detail will be like below
    ![screen shot 2560-02-15 at 4 28 56 am](https://cloud.githubusercontent.com/assets/2154669/22953662/2d3a77c6-f338-11e6-8c95-1560ebc1b901.png)

2. With Omise test account, at the authorize uri, let consider a charge to be successful.
    The result should be like these screenshots.

    At the admin order detail page, a transaction history will show like below
    ![screen shot 2560-02-15 at 4 28 32 am](https://cloud.githubusercontent.com/assets/2154669/22953663/2d3b3be8-f338-11e6-9af1-03e35254a592.png)

    At the Omise dashboard, charge detail will be like below
    ![screen shot 2560-02-15 at 4 28 40 am](https://cloud.githubusercontent.com/assets/2154669/22953661/2d31e674-f338-11e6-9860-0c5cdc4b74d3.png)



#### 4. Impact of the change

No.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

No.