### PR TITLE
Add payment option to allows buyer to create charge with JCB and AMEX card types

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Config/Var/Cctype.php
+++ b/src/app/code/community/Omise/Gateway/Model/Config/Var/Cctype.php
@@ -1,0 +1,13 @@
+<?php
+class Omise_Gateway_Model_Config_Var_Cctype extends Mage_Payment_Model_Source_Cctype
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Payment/Model/Source/Cctype.php
+     */
+    public function getAllowedTypes()
+    {
+        return array('VI', 'MC', 'AE', 'JCB');
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -68,6 +68,17 @@
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
                                 </order_status>
+
+                                <cctypes translate="label">
+                                    <label>Card type support</label>
+                                    <comment><![CDATA[This only controls the credit card type option on the checkout page. It is not related to card processing on Omise payment gateway.<br/><br/>Feel free to contact us at support@omise.co if you cannot process a payment with those card types.]]></comment>
+                                    <frontend_type>multiselect</frontend_type>
+                                    <source_model>omise_gateway/config_var_cctype</source_model>
+                                    <sort_order>6</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </cctypes>
                             </fields>
                         </omise_gateway>
 


### PR DESCRIPTION
#### 1. Objective

At the Magento admin's payment setting page, add an option to config a card type to give a fully control to merchants that they can config the option by themselves.

So, if you go through the checkout step, at the step 5th **Payment Information**. You will see only **card types** that were allowed by the configuration at the payment setting page.

**Related information**:
Related issue(s): 🙅
Related ticket(s): T2537

#### 2. Description of change

- Add new **Card type support** option at the Magento admin's payment setting page.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE v1.9.3.2.
- **Omise plugin version**: Omise-Magento v1.8.
- **PHP version**: 5.6.30.

**✏️ Details:**

1. ✅ Test config card type at the admin, payment setting page.
    ![019](https://cloud.githubusercontent.com/assets/2154669/23683643/bea2967c-03cc-11e7-8148-3fe5afbae69b.png)

2. ✅ Test if checkout form shows `JCB` and `American Express` options correctly.
    <img width="1149" alt="017" src="https://cloud.githubusercontent.com/assets/2154669/23683768/5dbb7788-03cd-11e7-8c46-e5e9616ec88c.png">

    _note, this test, I set `card type support` to allows `Visa, MasterCard, JCB, American Express`._

3. ✅ Test Magento's validation by choosing `JCB` card type, then use a **wrong** card number.
    <img width="1149" alt="screen shot 2560-03-08 at 4 52 46 am" src="https://cloud.githubusercontent.com/assets/2154669/23680432/cd03759c-03bd-11e7-8a29-7c1e3c177680.png">

4. ✅ Test Magento's validation by choosing `JCB` card type, then use a **correct** card number.
    <img width="1149" alt="screen shot 2560-03-08 at 4 52 27 am" src="https://cloud.githubusercontent.com/assets/2154669/23680450/da644eaa-03bd-11e7-91bc-05909b8d8e37.png">

5. ✅ Test Magento's validation by choosing `American Express` card type, then use a **wrong** card number.
    <img width="1149" alt="screen shot 2560-03-08 at 5 16 40 am" src="https://cloud.githubusercontent.com/assets/2154669/23680646/92c40bde-03be-11e7-8f85-075524a5c4ef.png">

6. ✅ Test Magento's validation by choosing `American Express` card type, then use a **correct** card number.
    <img width="1149" alt="screen shot 2560-03-08 at 4 58 32 am" src="https://cloud.githubusercontent.com/assets/2154669/23680526/23262014-03be-11e7-9f26-b9f23025e4d0.png">
    _note, error here, because my Omise account doesn't support an American Express card._
    _But it's not a point of test, the point is to check if Magento system could validate an American Express card correctly._

#### 4. Impact of the change

- Please clear Magento's cache if you cannot see the changes. By going to `Admin / System / Cache Management` then, click `Flush Magento Cache` button.

- After update the plugin to this version, please make sure that the configuration is set properly.
    By going to the payment setting page. (at the top bar menu, click `Omise > Module Setting` menu.
    Then, check the `Card type support` option. At least `Visa` and `MasterCard` should be checked.)
        ![019](https://cloud.githubusercontent.com/assets/2154669/23683643/bea2967c-03cc-11e7-8148-3fe5afbae69b.png)


#### 5. Priority of change

Normal.

#### 6. Additional Notes

- This changed is just only allows Magento system to show a credit card type option at the checkout page, it's not related with Omise account configuration (means, even you set to allow `JCB` card type but if your Omise account doesn't support to process a payment with JCB card, a charge will be failed). 

  _(if you cannot make charge with those card types, please contact support@omise.co to confirm if your account is supported for JCB or/and AMEX card)_