### PR TITLE
Bump release to v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### [v1.10 _(March 9, 2017)_](https://github.com/omise/omise-magento/releases/tag/v1.10)
+
+#### ✨ Highlights
+
+- Add option to allows merchant config a card type support by themselves. (PR [#59](https://github.com/omise/omise-magento/pull/59))
+
+---
+
 ### [v1.8 _(March 6, 2017)_](https://github.com/omise/omise-magento/releases/tag/v1.8)
 
 #### ✨ Highlights

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Submit your requirement as an issue to [https://github.com/omise/omise-magento/i
 
 The steps below shows how to install the module manually.
 
-1. Download and extract the zip file from [Omise-Magento](https://github.com/omise/omise-magento/archive/v1.8.zip) to your `local machine` (or directly to your server).
+1. Download and extract the zip file from [Omise-Magento](https://github.com/omise/omise-magento/archive/v1.10.zip) to your `local machine` (or directly to your server).
     <p align="center"><a alt="omise-magento-install-manual-01" href='https://cloud.githubusercontent.com/assets/2154669/23201743/8ecb09da-f90d-11e6-836f-1fc935f6ea5e.png'><img title="omise-magento-install-manual-01" src='https://cloud.githubusercontent.com/assets/2154669/23201743/8ecb09da-f90d-11e6-836f-1fc935f6ea5e.png' /></a></p>
 2. locate to `/src` directory and copy **all files** into your **Magento Project**, at a root directory.
 3. Your installation is now completed. To check the installation result, open your **Magento admin page**.

--- a/src/app/code/community/Omise/Gateway/Model/Omise.php
+++ b/src/app/code/community/Omise/Gateway/Model/Omise.php
@@ -105,7 +105,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     public function defineUserAgent()
     {
         if (! defined('OMISE_USER_AGENT_SUFFIX')) {
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.8 Magento/' . Mage::getVersion());
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.10 Magento/' . Mage::getVersion());
         }
     }
 

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -14,7 +14,7 @@
     -->
     <modules>
         <Omise_Gateway>
-            <version>1.8.0.0</version>
+            <version>1.10.0</version>
         </Omise_Gateway>
     </modules>
 


### PR DESCRIPTION
Bump release to v1.10.

- Update README.md
-Update CHANGELOG.md
- Update version number from v1.8 to v1.10

> **TL;DR;**
> To make our plugin be able to install through the [Magento Connect Store](https://www.magentocommerce.com/magento-connect/omise-1.html) Im going to skip `v1.9` and tag with `v1.10` instead.
>
> ...
>
> Because **Magento extension management** can't do upgrade or downgrade an extension that a new version number is lower than the current one, which is, Omise-Magento's version was `v1.9.0.6` before we changed our versioning structure.
> So, if we go with `v1.9`. Merchant will not be able to upgrade our plugin through Magento extension management (Magento Connect).
> 
> At this page 👇 
> ![021](https://cloud.githubusercontent.com/assets/2154669/23717634/2e3a1b78-0467-11e7-8eb1-9dbd8ad65607.png)

