### PR TITLE
Be able to make a charge with Internet Banking payment method

### DIFF
--- a/Gateway/Http/Client/OffsiteInternetbanking.php
+++ b/Gateway/Http/Client/OffsiteInternetbanking.php
@@ -1,0 +1,27 @@
+<?php
+namespace Omise\Payment\Gateway\Http\Client;
+
+use Omise\Payment\Gateway\Request\PaymentDataBuilder;
+use Omise\Payment\Gateway\Request\PaymentOffsiteBuilder;
+
+class OffsiteInternetbanking extends AbstractOmiseClient
+{
+    /**
+     * @param  array $body
+     *
+     * @return array
+     */
+    public function request(Array $body)
+    {
+        return \OmiseCharge::create(
+            [
+                'amount'      => $body[PaymentDataBuilder::AMOUNT],
+                'currency'    => $body[PaymentDataBuilder::CURRENCY],
+                'description' => $body[PaymentDataBuilder::DESCRIPTION],
+                'offsite'     => $body[PaymentOffsiteBuilder::OFFSITE],
+            ],
+            $this->publicKey,
+            $this->secretKey
+        );
+    }
+}

--- a/Gateway/Http/Client/OffsiteInternetbanking.php
+++ b/Gateway/Http/Client/OffsiteInternetbanking.php
@@ -1,9 +1,6 @@
 <?php
 namespace Omise\Payment\Gateway\Http\Client;
 
-use Omise\Payment\Gateway\Request\PaymentDataBuilder;
-use Omise\Payment\Gateway\Request\PaymentOffsiteBuilder;
-
 class OffsiteInternetbanking extends AbstractOmiseClient
 {
     /**
@@ -13,15 +10,6 @@ class OffsiteInternetbanking extends AbstractOmiseClient
      */
     public function request(Array $body)
     {
-        return \OmiseCharge::create(
-            [
-                'amount'      => $body[PaymentDataBuilder::AMOUNT],
-                'currency'    => $body[PaymentDataBuilder::CURRENCY],
-                'description' => $body[PaymentDataBuilder::DESCRIPTION],
-                'offsite'     => $body[PaymentOffsiteBuilder::OFFSITE],
-            ],
-            $this->publicKey,
-            $this->secretKey
-        );
+        return \OmiseCharge::create($body, $this->publicKey, $this->secretKey);
     }
 }

--- a/Gateway/Request/PaymentOffsiteBuilder.php
+++ b/Gateway/Request/PaymentOffsiteBuilder.php
@@ -1,0 +1,29 @@
+<?php
+namespace Omise\Payment\Gateway\Request;
+
+use Magento\Payment\Gateway\Helper\SubjectReader;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver;
+
+class PaymentOffsiteBuilder implements BuilderInterface
+{
+    /**
+     * @var string
+     */
+    const OFFSITE = 'offsite';
+
+    /**
+     * @param  array $buildSubject
+     *
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        $payment = SubjectReader::readPayment($buildSubject);
+        $method  = $payment->getPayment();
+
+        return [
+            self::OFFSITE => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE)
+        ];
+    }
+}

--- a/Gateway/Request/PaymentOffsiteBuilder.php
+++ b/Gateway/Request/PaymentOffsiteBuilder.php
@@ -13,6 +13,11 @@ class PaymentOffsiteBuilder implements BuilderInterface
     const OFFSITE = 'offsite';
 
     /**
+     * @var string
+     */
+    const RETURN_URI = 'return_uri';
+
+    /**
      * @param  array $buildSubject
      *
      * @return array
@@ -23,7 +28,8 @@ class PaymentOffsiteBuilder implements BuilderInterface
         $method  = $payment->getPayment();
 
         return [
-            self::OFFSITE => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE)
+            self::OFFSITE    => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE),
+            self::RETURN_URI => 'http://127.0.0.1' // TODO: Remove this dump-data
         ];
     }
 }

--- a/Gateway/Validator/Offsite/InternetbankingChargeCommandResponseValidator.php
+++ b/Gateway/Validator/Offsite/InternetbankingChargeCommandResponseValidator.php
@@ -1,0 +1,25 @@
+<?php
+namespace Omise\Payment\Gateway\Validator\Offsite;
+
+use Magento\Payment\Gateway\Command\CommandException;
+use Magento\Payment\Gateway\Validator\AbstractValidator;
+
+class InternetbankingChargeCommandResponseValidator extends AbstractValidator
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * Performs domain-related validation for business object
+     *
+     * @param  array $validationSubject
+     *
+     * @return ResultInterface
+     */
+    public function validate(array $validationSubject)
+    {
+        return $this->createResult(true, []);
+    }
+}

--- a/Observer/OffsiteInternetbankingDataAssignObserver.php
+++ b/Observer/OffsiteInternetbankingDataAssignObserver.php
@@ -5,7 +5,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 
-class OmiseOffsiteInternetbankingDataAssignObserver extends AbstractDataAssignObserver
+class OffsiteInternetbankingDataAssignObserver extends AbstractDataAssignObserver
 {
     /**
      * @var string

--- a/Observer/OmiseOffsiteInternetbankingDataAssignObserver.php
+++ b/Observer/OmiseOffsiteInternetbankingDataAssignObserver.php
@@ -1,0 +1,48 @@
+<?php
+namespace Omise\Payment\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+
+class OmiseOffsiteInternetbankingDataAssignObserver extends AbstractDataAssignObserver
+{
+    /**
+     * @var string
+     */
+    const OFFSITE = 'offsite';
+
+    /**
+     * @var array
+     */
+    protected $additionalInformationList = [
+        self::OFFSITE
+    ];
+
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        $dataObject = $this->readDataArgument($observer);
+
+        $additionalData = $dataObject->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
+
+        if (! is_array($additionalData)) {
+            return;
+        }
+
+        $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        $paymentInfo->setOffsite($additionalData[self::OFFSITE]);
+
+        foreach ($this->additionalInformationList as $additionalInformationKey) {
+            if (isset($additionalData[$additionalInformationKey])) {
+                $paymentInfo->setAdditionalInformation(
+                    $additionalInformationKey,
+                    $additionalData[$additionalInformationKey]
+                );
+            }
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,7 +8,7 @@
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseOffsiteInternetbankingValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseOffsiteInternetbankingCommandPool</argument>
         </arguments>
     </virtualType>
 
@@ -29,6 +29,33 @@
     <virtualType name="OmiseOffsiteInternetbankingConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
             <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Offsite\Internetbanking::CODE</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseOffsiteInternetbankingCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="capture" xsi:type="string">OmiseOffsiteInternetbankingChargeCommand</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseOffsiteInternetbankingChargeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">OmiseOffsiteInternetbankingChargeRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Omise\Payment\Gateway\Http\Client\OffsiteInternetbanking</argument>
+            <argument name="handler" xsi:type="object">Magento\Payment\Gateway\Response\HandlerChain</argument>
+            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\Offsite\InternetbankingChargeCommandResponseValidator</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseOffsiteInternetbankingChargeRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
+                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentOffsiteBuilder</item>
+            </argument>
         </arguments>
     </virtualType>
 

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -2,4 +2,8 @@
     <event name="payment_method_assign_data_omise_cc">
         <observer name="omise_data_assign" instance="Omise\Payment\Observer\OmiseDataAssignObserver" />
     </event>
+
+    <event name="payment_method_assign_data_omise_offsite_internetbanking">
+        <observer name="omise_data_assign" instance="Omise\Payment\Observer\OmiseOffsiteInternetbankingDataAssignObserver" />
+    </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,6 +4,6 @@
     </event>
 
     <event name="payment_method_assign_data_omise_offsite_internetbanking">
-        <observer name="omise_data_assign" instance="Omise\Payment\Observer\OmiseOffsiteInternetbankingDataAssignObserver" />
+        <observer name="omise_data_assign" instance="Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver" />
     </event>
 </config>

--- a/view/frontend/web/css/offsite-internetbanking.css
+++ b/view/frontend/web/css/offsite-internetbanking.css
@@ -28,7 +28,7 @@
 #omise_offsite_internetbankingForm .omise-logo-wrapper img {
     width: 30px;
     height: 30px;
-    display: inline-block;
+    display: block;
 }
 
 #omise_offsite_internetbankingForm .omise-banking-text-wrapper {

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
@@ -1,7 +1,7 @@
 define(
     [
         'ko',
-        'Magento_Payment/js/view/payment/cc-form',
+        'Magento_Checkout/js/view/payment/default',
         'Magento_Checkout/js/action/redirect-on-success',
         'Magento_Checkout/js/model/quote'
     ],
@@ -30,13 +30,30 @@ define(
             },
 
             /**
+             * Initiate observable fields
+             *
+             * @return this
+             */
+            initObservable: function() {
+                this._super()
+                    .observe([
+                        'omiseOffsite'
+                    ]);
+
+                return this;
+            },
+
+            /**
              * Get a checkout form data
              *
              * @return {Object}
              */
             getData: function() {
                 return {
-                    'method': this.item.method
+                    'method': this.item.method,
+                    'additional_data': {
+                        'offsite': this.omiseOffsite()
+                    }
                 };
             },
 

--- a/view/frontend/web/template/payment/offsite-internetbanking-form.html
+++ b/view/frontend/web/template/payment/offsite-internetbanking-form.html
@@ -27,63 +27,102 @@
               data-bind="attr: {
               id: getCode() + 'Form',
               }">
-            <ul class="form-list">
-                <!-- SCB -->
-                <li class="items">
-                    <input id="internet_banking_scb" type="radio" name="payment[offsite]" value="internet_banking_scb" />
-                    <label for="internet_banking_scb">
-                        <div class="omise-logo-wrapper scb">
-                            <img class="scb" />
-                        </div>
-                        <div class="omise-banking-text-wrapper">
-                            <span class="title">Siam Commercial Bank</span><br/>
-                            <span class="rate secondary-text">Fee: 15 THB (same zone), 30 THB (out zone)</span>
-                        </div>
-                    </label>
-                </li>
 
-                <!-- KTB -->
-                <li class="items">
-                    <input id="internet_banking_ktb" type="radio" name="payment[offsite]" value="internet_banking_ktb" />
-                    <label for="internet_banking_ktb">
-                        <div class="omise-logo-wrapper ktb">
-                            <img class="ktb" />
-                        </div>
-                        <div class="omise-banking-text-wrapper">
-                            <span class="title">Krungthai Bank</span><br/>
-                            <span class="rate secondary-text">Fee: 15 THB (same zone), 15 THB (out zone)</span>
-                        </div>
-                    </label>
-                </li>
+            <fieldset data-bind="attr: {class: 'fieldset payment items ' + getCode(), id: 'payment_form_' + getCode()}">
+                <ul class="form-list">
+                    <!-- SCB -->
+                    <li class="items">
+                        <input
+                            type="radio"
+                            name="offsite"
+                            value="internet_banking_scb"
+                            data-bind="
+                            attr: {
+                                id: getCode() + '_scb'
+                            },
+                            checked: omiseOffsite"
+                        />
+                        <label for="omise_offsite_internetbanking_scb">
+                            <div class="omise-logo-wrapper scb">
+                                <img class="scb" />
+                            </div>
+                            <div class="omise-banking-text-wrapper">
+                                <span class="title">Siam Commercial Bank</span><br/>
+                                <span class="rate secondary-text">Fee: 15 THB (same zone), 30 THB (out zone)</span>
+                            </div>
+                        </label>
+                    </li>
 
-                <!-- BAY -->
-                <li class="items">
-                    <input id="internet_banking_bay" type="radio" name="payment[offsite]" value="internet_banking_bay" />
-                    <label for="internet_banking_bay">
-                        <div class="omise-logo-wrapper bay">
-                            <img class="bay" />
-                        </div>
-                        <div class="omise-banking-text-wrapper">
-                            <span class="title">Krungsri Bank</span><br/>
-                            <span class="rate secondary-text">Fee: 15 THB (same zone), 15 THB (out zone)</span>
-                        </div>
-                    </label>
-                </li>
+                    <!-- KTB -->
+                    <li class="items">
+                        <input
+                            type="radio"
+                            name="offsite"
+                            value="internet_banking_ktb"
+                            data-bind="
+                            attr: {
+                                id: getCode() + '_ktb'
+                            },
+                            checked: omiseOffsite"
+                        />
+                        <label for="omise_offsite_internetbanking_ktb">
+                            <div class="omise-logo-wrapper ktb">
+                                <img class="ktb" />
+                            </div>
+                            <div class="omise-banking-text-wrapper">
+                                <span class="title">Krungthai Bank</span><br/>
+                                <span class="rate secondary-text">Fee: 15 THB (same zone), 15 THB (out zone)</span>
+                            </div>
+                        </label>
+                    </li>
 
-                <!-- BBL -->
-                <li class="items">
-                    <input id="internet_banking_bbl" type="radio" name="payment[offsite]" value="internet_banking_bbl" />
-                    <label for="internet_banking_bbl">
-                        <div class="omise-logo-wrapper bbl">
-                            <img class="bbl" />
-                        </div>
-                        <div class="omise-banking-text-wrapper">
-                            <span class="title">Bangkok Bank</span><br/>
-                            <span class="rate secondary-text">Fee: 10 THB (same zone), 20 THB (out zone)</span>
-                        </div>
-                    </label>
-                </li>
-            </ul>
+                    <!-- BAY -->
+                    <li class="items">
+                        <input
+                            type="radio"
+                            name="offsite"
+                            value="internet_banking_bay"
+                            data-bind="
+                            attr: {
+                                id: getCode() + '_bay'
+                            },
+                            checked: omiseOffsite"
+                        />
+                        <label for="omise_offsite_internetbanking_bay">
+                            <div class="omise-logo-wrapper bay">
+                                <img class="bay" />
+                            </div>
+                            <div class="omise-banking-text-wrapper">
+                                <span class="title">Krungsri Bank</span><br/>
+                                <span class="rate secondary-text">Fee: 15 THB (same zone), 15 THB (out zone)</span>
+                            </div>
+                        </label>
+                    </li>
+
+                    <!-- BBL -->
+                    <li class="items">
+                        <input
+                            type="radio"
+                            name="offsite"
+                            value="internet_banking_bbl"
+                            data-bind="
+                            attr: {
+                                id: getCode() + '_bbl'
+                            },
+                            checked: omiseOffsite"
+                        />
+                        <label for="omise_offsite_internetbanking_bbl">
+                            <div class="omise-logo-wrapper bbl">
+                                <img class="bbl" />
+                            </div>
+                            <div class="omise-banking-text-wrapper">
+                                <span class="title">Bangkok Bank</span><br/>
+                                <span class="rate secondary-text">Fee: 10 THB (same zone), 20 THB (out zone)</span>
+                            </div>
+                        </label>
+                    </li>
+                </ul>
+            </fieldset>
         </form>
         <div class="checkout-agreements-block">
             <!-- ko foreach: $parent.getRegion('before-place-order') -->


### PR DESCRIPTION
> ⚠️ This PR is a sub PR of #62 

#### 1. Objective

Continue from PR #64.
To be able to make a charge with the Internet Banking payment solution.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

- Fix bank icon stylesheet.
    <img width="971" alt="029" src="https://cloud.githubusercontent.com/assets/2154669/24406760/273a0fb8-13f3-11e7-8b42-f132cfb9838e.png">

- Update the Internet Banking checkout form, to have real implementation with the real values.

- **Javascript**, update the Internet Banking payment object, by observing radio buttons at the Internet Banking checkout form.

- Add a new `payment_method_assign_data_omise_offsite_internetbanking` event and observer class to observe the parameter that frontend submit through the checkout form.

- **etc/DI.XML**, update real dependencies (classes that work with `OmiseOffsiteInternetbankingAdapter`), see `OmiseOffsiteInternetbankingCommandPool` (virtual object).

- Implement `Gateway\RequestBuilder`, `Gateway\Client`, `Gateway\Validator` classes that need to handle `build request object >> request to gateway service >> handle & validate the result` steps.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ _Test be able to checkout with the Internet Banking payment method._
    1. Enable the **Internet Banking payment solution** at the admin payment setting page.

    2. Do normal checkout process, and choose one of bank from the bank list.
    <img width="1263" alt="screen shot 2560-03-28 at 7 59 31 pm" src="https://cloud.githubusercontent.com/assets/2154669/24406192/d3d21b00-13f1-11e7-92db-9f1101d9c415.png">

    3. Then, charge will be completed and redirect buyer to the succesful page. (here, this PR will not validate the payment result).  

    4. Check at Omise dashboard, you will see the transaction that made by above step.
    ![screen shot 2560-03-28 at 8 01 00 pm](https://cloud.githubusercontent.com/assets/2154669/24406236/e9695e06-13f1-11e7-816d-15e235d2d66a.png)
    ![screen shot 2560-03-28 at 8 01 28 pm](https://cloud.githubusercontent.com/assets/2154669/24406235/e9445138-13f1-11e7-9123-494154394b3c.png)

    5. Back to Magento's admin order list page, you will see the last transaction was made with payment **Internet Banking** payment method.
    ![028](https://cloud.githubusercontent.com/assets/2154669/24406508/aa52bacc-13f2-11e7-816b-52adb0acd849.png)


#### 4. Impact of the change

You may need to clear cache if you can't see the result.
1. At Magento admin page, go to `SYSTEM > Cache Management`
2. Click `Flush Magento Cache`. (or you can choose to disable all caches while testing).
    ![screen shot 2560-03-22 at 5 32 08 pm](https://cloud.githubusercontent.com/assets/2154669/24193705/d5408768-0f25-11e7-9955-662ed63b6319.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

- This PR is a sub PR of #62. In order to see the full implementation, please check from that PR.
- This implementation is just focusing on checkout an order with Internet Banking feature, without concerning of a payment result. To prove that the plugin can request to Omise API with the proper parameters and Magento's order can show the name of the payment at an order detail page.
