### PR TITLE
Bump release to v1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+### [v1.11 _(April 3, 2017)_](https://github.com/omise/omise-magento/releases/tag/v1.11)
+
+#### 🚀 Enhancements
+
+- Upgrade Omise-PHP library to v2.7.1. (PR [#68](https://github.com/omise/omise-magento/pull/68))
+
+#### 👾 Bug Fixes
+
+- Rename files and classes to avoid case-sensitive issue from Magento. (PR [#67](https://github.com/omise/omise-magento/pull/67))
+
+---
+
 ### [v1.10 _(March 9, 2017)_](https://github.com/omise/omise-magento/releases/tag/v1.10)
 
 #### ✨ Highlights

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Submit your requirement as an issue to [https://github.com/omise/omise-magento/i
 
 The steps below shows how to install the module manually.
 
-1. Download and extract the zip file from [Omise-Magento](https://github.com/omise/omise-magento/archive/v1.10.zip) to your `local machine` (or directly to your server).
+1. Download and extract the zip file from [Omise-Magento](https://github.com/omise/omise-magento/archive/v1.11.zip) to your `local machine` (or directly to your server).
     <p align="center"><a alt="omise-magento-install-manual-01" href='https://cloud.githubusercontent.com/assets/2154669/23201743/8ecb09da-f90d-11e6-836f-1fc935f6ea5e.png'><img title="omise-magento-install-manual-01" src='https://cloud.githubusercontent.com/assets/2154669/23201743/8ecb09da-f90d-11e6-836f-1fc935f6ea5e.png' /></a></p>
 2. locate to `/src` directory and copy **all files** into your **Magento Project**, at a root directory.
 3. Your installation is now completed. To check the installation result, open your **Magento admin page**.

--- a/src/app/code/community/Omise/Gateway/Model/Omise.php
+++ b/src/app/code/community/Omise/Gateway/Model/Omise.php
@@ -105,7 +105,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     public function defineUserAgent()
     {
         if (! defined('OMISE_USER_AGENT_SUFFIX')) {
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.10 Magento/' . Mage::getVersion());
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.11 Magento/' . Mage::getVersion());
         }
     }
 

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -14,7 +14,7 @@
     -->
     <modules>
         <Omise_Gateway>
-            <version>1.10.0</version>
+            <version>1.11.0</version>
         </Omise_Gateway>
     </modules>
 


### PR DESCRIPTION
Bump release to v1.11.

- Update README.md
- Update CHANGELOG.md
- Update version number from v1.10 to v1.11

This release contains the following PRs.
- PR #67 : Rename files and classes to avoid case-sensitive issue from Magento
- PR #68 : Upgrade Omise-PHP library to v2.7.1.