### PR TITLE
Validate an internet banking payment result at the callback, update an order state along with the result

### DIFF
--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -134,6 +134,16 @@ class Internetbanking extends Action
     }
 
     /**
+     * @param  \Magento\Sales\Model\Order $order
+     *
+     * @return \Magento\Sales\Api\Data\InvoiceInterface
+     */
+    protected function invoice(Order $order)
+    {
+        return $order->getInvoiceCollection()->getLastItem();
+    }
+
+    /**
      * @param  string $path
      *
      * @return \Magento\Framework\App\ResponseInterface
@@ -168,10 +178,11 @@ class Internetbanking extends Action
      */
     protected function cancel(Order $order, $message)
     {
-        $this->invalid($order, $message);
+        $this->invoice($order)->cancel()->save();
 
         $order->setStatus(Order::STATE_CANCELED);
-        $order->save();
+
+        $this->invalid($order, $message);
     }
 
     /**
@@ -181,6 +192,7 @@ class Internetbanking extends Action
     protected function invalid(Order $order, $message)
     {
         $order->addStatusHistoryComment(__($message));
+        $order->save();
 
         $this->messageManager->addErrorMessage(__($message));
     }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -48,7 +48,7 @@ class Internetbanking extends Action
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {
-            $this->invalid($order, __('The order session no longer exists, please make an order again or contact our support if you have any questions.'));
+            $this->messageManager->addErrorMessage(__('The order session no longer exists, please make an order again or contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);
         }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -1,0 +1,22 @@
+<?php
+namespace Omise\Payment\Controller\Callback;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+
+class Internetbanking extends Action
+{
+    public function __construct(Context $context)
+    {
+        parent::__construct($context);
+    }
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        echo "here";
+        exit;
+    }
+}

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -48,32 +48,31 @@ class Internetbanking extends Action
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {
-            $this->invalid($order, 'The order session no longer exists, please make an order again or contact our support if you have any questions.');
+            $this->invalid($order, __('The order session no longer exists, please make an order again or contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);
         }
 
         if ($order->getState() !== Order::STATE_PENDING_PAYMENT) {
-            $this->invalid($order, 'Invalid order status, cannot validate the payment. Please contact our support if you have any questions.');
+            $this->invalid($order, __('Invalid order status, cannot validate the payment. Please contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);
         }
 
         if (! $payment = $order->getPayment()) {
-            $this->invalid($order, 'Cannot retrieve a payment detail from the request. Please contact our support if you have any questions.');
+            $this->invalid($order, __('Cannot retrieve a payment detail from the request. Please contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);
         }
 
         if ($payment->getMethod() !== 'omise_offsite_internetbanking') {
-            $this->cancel($order, 'Invalid payment method. Please contact our support if you have any questions.');
-            $this->session->restoreQuote();
+            $this->invalid($order, __('Invalid payment method. Please contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);
         }
 
         if (! $charge_id = $payment->getAdditionalInformation('charge_id')) {
-            $this->cancel($order, 'Cannot retrieve a charge reference id. Please contact our support if you have any questions.');
+            $this->cancel($order, __('Cannot retrieve a charge reference id. Please contact our support to confirm your payment.'));
             $this->session->restoreQuote();
 
             return $this->redirect(self::PATH_CART);

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -78,6 +78,13 @@ class Internetbanking extends Action
             return $this->redirect(self::PATH_CART);
         }
 
+        if (! $order->hasInvoices()) {
+            $this->cancel($order, __('Cannot create an invoice. Please contact our support to confirm your payment.'));
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+
         try {
             $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
 

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -180,7 +180,8 @@ class Internetbanking extends Action
     {
         $this->invoice($order)->cancel()->save();
 
-        $order->setStatus(Order::STATE_CANCELED);
+        $order->setState(Order::STATE_CANCELED);
+        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
 
         $this->invalid($order, $message);
     }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -1,14 +1,41 @@
 <?php
 namespace Omise\Payment\Controller\Callback;
 
+use Exception;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\SessionException;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
+use Magento\Sales\Model\Order;
+use Omise\Payment\Model\Config\Offsite\Internetbanking as Config;
 
 class Internetbanking extends Action
 {
-    public function __construct(Context $context)
-    {
+    /**
+     * @var string
+     */
+    const PATH_CART    = 'checkout/cart';
+    const PATH_SUCCESS = 'checkout/onepage/success';
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
+
+    /**
+     * @var \Omise\Payment\Model\Config\Offsite\Internetbanking
+     */
+    protected $config;
+
+    public function __construct(
+        Context $context,
+        Session $session,
+        Config  $config
+    ) {
         parent::__construct($context);
+
+        $this->session = $session;
+        $this->config  = $config;
     }
 
     /**
@@ -16,7 +43,108 @@ class Internetbanking extends Action
      */
     public function execute()
     {
-        echo "here";
-        exit;
+        $resultRedirect = $this->resultRedirectFactory->create();
+        $order          = $this->session->getLastRealOrder();
+
+        if (! $order->getId()) {
+            $this->invalid($order, 'The order session no longer exists, please make an order again or contact our support if you have any questions.');
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if (! $order->isPaymentReview()) {
+            $this->invalid($order, 'Invalid order status, cannot validate the payment. Please contact our support if you have any questions.');
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if (! $payment = $order->getPayment()) {
+            $this->invalid($order, 'Cannot retrieve a payment detail from the request. Please contact our support if you have any questions.');
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if ($payment->getMethod() !== 'omise_offsite_internetbanking') {
+            $this->cancel($order, 'Invalid payment method. Please contact our support if you have any questions.');
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if (! $charge_id = $payment->getAdditionalInformation('charge_id')) {
+            $this->cancel($order, 'Cannot retrieve a charge reference id. Please contact our support if you have any questions.');
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        try {
+            $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
+
+            if (! $this->validate($charge)) {
+                throw new Exception('Payment failed, ' . $charge['failure_message'] . ' ( ' . $charge['failure_code'] . ' ). Please contact our support if you have any questions.');
+            }
+
+            // TODO: Update order status to success payment.
+            $payment->accept();
+
+            return $this->redirect(self::PATH_SUCCESS);
+        } catch (Exception $e) {
+            $this->cancel($order, $e->getMessage());
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+    }
+
+    /**
+     * @param  string $path
+     *
+     * @return \Magento\Framework\App\ResponseInterface
+     */
+    protected function redirect($path)
+    {
+        return $this->_redirect($path, ['_secure' => true]);
+    }
+
+    /**
+     * @param  \OmiseCharge
+     *
+     * @return bool
+     */
+    protected function validate($charge)
+    {
+        $captured = $charge['captured'] ? $charge['captured'] : $charge['paid'];
+
+        if ($charge['status'] === 'successful'
+            && $charge['authorized'] == true
+            && $captured == true
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order
+     */
+    protected function cancel(Order $order, $message)
+    {
+        $this->invalid($order, $message);
+
+        $order->setStatus(Order::STATE_CANCELED);
+        $order->save();
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order
+     * @param string
+     */
+    protected function invalid(Order $order, $message)
+    {
+        $order->addStatusHistoryComment(__($message));
+
+        $this->messageManager->addErrorMessage(__($message));
     }
 }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -89,7 +89,7 @@ class Internetbanking extends Action
             $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
 
             if (! $this->validate($charge)) {
-                throw new Exception('Payment failed, ' . $charge['failure_message'] . ' ( ' . $charge['failure_code'] . ' ). Please contact our support if you have any questions.');
+                throw new Exception('Payment failed. ' . ucfirst($charge['failure_message']) . ', please contact our support if you have any questions.');
             }
 
             $payment->setTransactionId($charge['transaction']);

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -144,7 +144,7 @@ class Internetbanking extends Action
     }
 
     /**
-     * @param  \OmiseCharge
+     * @param  \OmiseCharge $charge
      *
      * @return bool
      */
@@ -163,7 +163,8 @@ class Internetbanking extends Action
     }
 
     /**
-     * @param \Magento\Sales\Model\Order
+     * @param \Magento\Sales\Model\Order $order
+     * @param string                     $message
      */
     protected function cancel(Order $order, $message)
     {
@@ -174,8 +175,8 @@ class Internetbanking extends Action
     }
 
     /**
-     * @param \Magento\Sales\Model\Order
-     * @param string
+     * @param \Magento\Sales\Model\Order $order
+     * @param string                     $message
      */
     protected function invalid(Order $order, $message)
     {

--- a/Gateway/Request/PaymentOffsiteBuilder.php
+++ b/Gateway/Request/PaymentOffsiteBuilder.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omise\Payment\Gateway\Request;
 
+use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver;
@@ -18,6 +19,16 @@ class PaymentOffsiteBuilder implements BuilderInterface
     const RETURN_URI = 'return_uri';
 
     /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    protected $url;
+
+    public function __construct(UrlInterface $url)
+    {
+        $this->url = $url;
+    }
+
+    /**
      * @param  array $buildSubject
      *
      * @return array
@@ -29,7 +40,7 @@ class PaymentOffsiteBuilder implements BuilderInterface
 
         return [
             self::OFFSITE    => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE),
-            self::RETURN_URI => 'http://127.0.0.1' // TODO: Remove this dump-data
+            self::RETURN_URI => $this->url->getUrl('omise/callback/internetbanking', ['_secure' => true])
         ];
     }
 }

--- a/Gateway/Response/PendingPaymentHandler.php
+++ b/Gateway/Response/PendingPaymentHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omise\Payment\Gateway\Response;
 
+use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Sales\Model\Order;
 
@@ -19,6 +20,14 @@ class PendingPaymentHandler implements HandlerInterface
             && $captured == false
             && $response['data']['authorize_uri']
         ) {
+            /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
+            $payment = SubjectReader::readPayment($handlingSubject);
+
+            $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
+            $invoice->register();
+
+            $payment->getPayment()->getOrder()->addRelatedObject($invoice);
+
             $stateObject = $handlingSubject['stateObject'];
             $stateObject->setState(Order::STATE_PENDING_PAYMENT);
             $stateObject->setStatus(Order::STATE_PENDING_PAYMENT);

--- a/etc/frontend/routes.xml
+++ b/etc/frontend/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="standard">
+        <route id="omise" frontName="omise">
+            <module name="Omise_Payment" />
+        </route>
+    </router>
+</config>


### PR DESCRIPTION
#### 1. Objective

To validate an internet baking payment result at the callback uri and update an order state along with the payment result.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. Register new route `omise/callback/internetbanking` with a callback controller to validate a payment result.

2. Validate a payment result.

3. Update an order's state/ status and an invoice's state along with the validation result.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16

**✏️ Details:**

1. ✅ Once offsite page redirects user back to the callback url, an order state/status will be updated according to the validation result.

2. ✅ If `charge.status = successful`, `charge.authorized = true`, and `charge.paid = true`. An order state will be set to `processing` and an order's invoice status should be set to `paid`.

3. ✅ In case of payment failed, user will be redirect to `/checkout/cart` page with an error, `charge.failure_message`.
    <img width="1231" alt="screen shot 2560-04-07 at 12 39 58 am" src="https://cloud.githubusercontent.com/assets/2154669/24767861/c6bbd402-1b2a-11e7-9971-03f5ec2663ed.png">

4. ✅ Test access to the callback url directly (without a cart or checkout session) should force redirect user back to `/checkout/cart` page and raise an error like below on a screen.
    ```
    The order session no longer exists, please make an order again or contact our support
    if you have any questions.
    ```
    ![screen shot 2560-04-06 at 8 21 17 pm](https://cloud.githubusercontent.com/assets/2154669/24756055/a1d7561c-1b06-11e7-8458-b6135c5031cc.png)

5. ✅ If an order status in the session != `pending`, you will be redirected back to `/checkout/cart` page with an error below
    ```
    Invalid order status, cannot validate the payment.
    Please contact our support if you have any questions.
    ```
    <img width="1231" alt="screen shot 2560-04-06 at 10 26 46 pm" src="https://cloud.githubusercontent.com/assets/2154669/24762498/c585e3e6-1b18-11e7-9fb7-3054719d6f44.png">

6. ✅ If payment method != `omise_offsite_internetbanking`, you will be redirected back to `/checkout/cart` page with an error below
    ```
    Invalid payment method. Please contact our support if you have any questions.
    ```
    <img width="1231" alt="screen shot 2560-04-06 at 10 38 29 pm" src="https://cloud.githubusercontent.com/assets/2154669/24762886/eb2b3474-1b19-11e7-9e33-3c7504139334.png">

7. ✅ If cannot retrieve a `charge.id` from the Magento payment object at the callback validation, user will be redirected back to `/checkout/cart` page with an error.
    ```
    Cannot retrieve a charge reference id. Please contact our support to confirm your payment.
    ```
    And, an order and invoice statuses will be set to `canceled`, then, restore user's cart back to the session.
    ![031](https://cloud.githubusercontent.com/assets/2154669/24766784/d52c7ce8-1b26-11e7-89bd-ac5bd082fe12.png)
    ![032](https://cloud.githubusercontent.com/assets/2154669/24766786/d5a23bb8-1b26-11e7-8edc-1e55775485fe.png)

#### 4. Impact of the change

If you cannot access to the callback url (`/omise/callback/internetbanking`), then you might need to clear a Magento cache once.
1. At Magento admin page, go to `SYSTEM > Cache Management`
2. Click `Flush Magento Cache`. (or you can choose to disable all caches while testing).
    ![screen shot 2560-03-22 at 5 32 08 pm](https://cloud.githubusercontent.com/assets/2154669/24193705/d5408768-0f25-11e7-9955-662ed63b6319.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

No