### PR TITLE
Support IDR and SGD currencies

### DIFF
--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -28,14 +28,10 @@ class OmiseHelper extends AbstractHelper
     {
         switch (strtoupper($currency)) {
             case 'THB':
-                // Convert to satang unit
+            case 'IDR':
+            case 'SGD':
+                // Convert to a small unit
                 $amount = $amount * 100;
-                break;
-
-            case 'JPY':
-                break;
-
-            default:
                 break;
         }
 


### PR DESCRIPTION
#### 1. Objective

Correct an amount when make a charge with `IDR` (Indonesian Rupiah) and `SGD` (Singapore Dollar).

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

Convert an amount to a small unit if create charge with IDR or SGD currency.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ Make a charge with `IDR` currency, an amount of an order will be multiplied by 100 to convert it to a smallest unit.

2. ✅ Make a charge with `IDR` currency, but set an order amount lower than the minimum amount that can pay with Omise payment. An error will be raised.

3. ✅ Make a charge with `USD`, an error `An error occurred on the server. Please try to place the order again.` should be raised on a checkout screen.


#### 4. Impact of the change

Nothing.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- From the test case number 3.
    Currently, Magento cannot show a proper error that the payment gateway throw out. 
    According to the ticket https://github.com/magento/magento2/issues/6246 An error message will be the same as below in every cases.
    ```
    An error occurred on the server. Please try to place the order again.
    ```
  
    _Note, currently this issue has been solved, but still in the `develop` branch, they (Magento) haven't released this fixes yet (latest released version was v2.1.5)._

- SGD currency is currently not supported from Omise API. This pull request just for prepare the plugin to be ready for coming feature.

- This is not a multi-currency feature. In order to make a charge with THB, JPY or IDR. Your Omise account must be registered under the country that the currency belongs to.
    ![screen shot 2560-04-07 at 7 24 15 pm](https://cloud.githubusercontent.com/assets/2154669/24799882/d78c22a8-1bc7-11e7-9d36-bd83a5566405.png)