### PR TITLE
Refactor Gateway\Validation classes and update validation messages

### DIFF
--- a/Gateway/Validator/CommandResponseValidator.php
+++ b/Gateway/Validator/CommandResponseValidator.php
@@ -1,0 +1,54 @@
+<?php
+namespace Omise\Payment\Gateway\Validator;
+
+use Magento\Payment\Gateway\Validator\AbstractValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\ResponseInvalid;
+
+class CommandResponseValidator extends AbstractValidator
+{
+    /**
+     * Performs domain-related validation for business object
+     *
+     * @param  array $validationSubject
+     *
+     * @return ResultInterface
+     */
+    public function validate(array $validationSubject)
+    {
+        if (! isset($validationSubject['response']) || $validationSubject['response']['object'] !== 'omise') {
+            return $this->failed((new ResponseInvalid)->getMessage());
+        }
+
+        if ($validationSubject['response']['status'] === 'failed') {
+            return $this->failed((new Invalid($validationSubject['response']['message']))->getMessage());
+        }
+
+        $result = $this->validateResponse($validationSubject['response']['data']);
+        if ($result instanceof Invalid) {
+            return $this->failed($result->getMessage());
+        }
+
+        return $this->createResult(true, []);
+    }
+
+    /**
+     * @param  \Magento\Framework\Phrase|string $message
+     *
+     * @return \Magento\Payment\Gateway\Validator\ResultInterface
+     */
+    protected function failed($message)
+    {
+        return $this->createResult(false, [ $message ]);
+    }
+
+    /**
+     * @param  mixed $data
+     *
+     * @return mixed
+     */
+    protected function validateResponse($data)
+    {
+        return true;
+    }
+}

--- a/Gateway/Validator/Message/Invalid.php
+++ b/Gateway/Validator/Message/Invalid.php
@@ -22,6 +22,6 @@ class Invalid
 
     public function getMessage()
     {
-        return new Phase($this->message);
+        return new Phrase($this->message);
     }
 }

--- a/Gateway/Validator/Message/Invalid.php
+++ b/Gateway/Validator/Message/Invalid.php
@@ -1,0 +1,27 @@
+<?php
+namespace Omise\Payment\Gateway\Validator\Message;
+
+use Magento\Framework\Phrase;
+
+class Invalid
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        if (! $this->message) {
+            $this->message = $message;
+        }
+    }
+
+    public function getMessage()
+    {
+        return new Phase($this->message);
+    }
+}

--- a/Gateway/Validator/Message/OmiseObjectInvalid.php
+++ b/Gateway/Validator/Message/OmiseObjectInvalid.php
@@ -1,0 +1,12 @@
+<?php
+namespace Omise\Payment\Gateway\Validator\Message;
+
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+
+class OmiseObjectInvalid extends Invalid
+{
+    /**
+     * @var string
+     */
+    protected $message = 'Transaction has been declined. Please contact administrator';
+}

--- a/Gateway/Validator/Message/ResponseInvalid.php
+++ b/Gateway/Validator/Message/ResponseInvalid.php
@@ -1,0 +1,12 @@
+<?php
+namespace Omise\Payment\Gateway\Validator\Message;
+
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+
+class ResponseInvalid extends Invalid
+{
+    /**
+     * @var string
+     */
+    protected $message = 'Transaction has been declined, please contact our support if you have any questions';
+}

--- a/Gateway/Validator/Message/ResponseInvalid.php
+++ b/Gateway/Validator/Message/ResponseInvalid.php
@@ -8,5 +8,5 @@ class ResponseInvalid extends Invalid
     /**
      * @var string
      */
-    protected $message = 'Transaction has been declined, please contact our support if you have any questions';
+    protected $message = 'Couldn\'t retrieve charge transaction. Please contact administrator.';
 }

--- a/Gateway/Validator/Offsite/InternetbankingInitializeCommandResponseValidator.php
+++ b/Gateway/Validator/Offsite/InternetbankingInitializeCommandResponseValidator.php
@@ -1,62 +1,37 @@
 <?php
 namespace Omise\Payment\Gateway\Validator\Offsite;
 
-use Magento\Payment\Gateway\Validator\AbstractValidator;
+use Omise\Payment\Gateway\Validator\CommandResponseValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
 
-class InternetbankingInitializeCommandResponseValidator extends AbstractValidator
+class InternetbankingInitializeCommandResponseValidator extends CommandResponseValidator
 {
     /**
-     * @var string
-     */
-    protected $message;
-
-    /**
-     * Performs domain-related validation for business object
+     * @param  mixed
      *
-     * @param  array $validationSubject
-     *
-     * @return ResultInterface
+     * @return mixed
      */
-    public function validate(array $validationSubject)
+    protected function validateResponse($data)
     {
-        if (! isset($validationSubject['response']) || $validationSubject['response']['object'] !== 'omise') {
-            return $this->failed(__('Transaction has been declined, please contact our support if you have any questions'));
+        if (! isset($data['object']) || $data['object'] !== 'charge') {
+            return new OmiseObjectInvalid();
         }
 
-        if ($validationSubject['response']['status'] === 'failed') {
-            return $this->failed(__($validationSubject['response']['message']));
+        if ($data['status'] === 'failed') {
+            return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
         }
 
-        $charge = $validationSubject['response']['data'];
+        $captured = $data['captured'] ? $data['captured'] : $data['paid'];
 
-        if (! isset($charge['object']) || $charge['object'] !== 'charge') {
-            return $this->failed(__('Couldn\'t retrieve charge transaction, please contact our support if you have any questions.'));
-        }
-
-        if ($charge['status'] === 'failed') {
-            return $this->failed(__('Payment failed. ' . ucfirst($charge['failure_message']) . ', please contact our support if you have any questions.'));
-        }
-
-        $captured = $charge['captured'] ? $charge['captured'] : $charge['paid'];
-
-        if ($charge['status'] === 'pending'
-            && $charge['authorized'] == false
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == false
             && $captured == false
-            && $charge['authorize_uri']
+            && $data['authorize_uri']
         ) {
-            return $this->createResult(true, []);
+            return true;
         }
 
-        return $this->failed(__('Payment failed, invalid payment status, please contact our support if you have any questions'));
-    }
-
-    /**
-     * @param  \Magento\Framework\Phrase|string $message
-     *
-     * @return \Magento\Payment\Gateway\Validator\ResultInterface
-     */
-    protected function failed($message)
-    {
-        return $this->createResult(false, [ $message ]);
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
     }
 }

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -1,127 +1,33 @@
 <?php
 namespace Omise\Payment\Gateway\Validator;
 
-use Magento\Payment\Gateway\Command\CommandException;
-use Magento\Payment\Gateway\Validator\AbstractValidator;
+use Omise\Payment\Gateway\Validator\CommandResponseValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
 
-class OmiseAuthorizeCommandResponseValidator extends AbstractValidator
+class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
 {
     /**
-     * @var string
+     * @param  mixed
+     *
+     * @return mixed
      */
-    protected $message;
-
-    /**
-     * Performs domain-related validation for business object
-     *
-     * @param  array $validationSubject
-     *
-     * @throws \Magento\Payment\Gateway\Command\CommandException
-     *
-     * @return ResultInterface
-     */
-    public function validate(array $validationSubject)
+    protected function validateResponse($data)
     {
-        /**
-         * Note, normally we should return [$isValid = false, $errorMessages = ['msg_1', 'msg_2']]
-         * out to the GatewayCommand::execute() method.
-         * But since we couldn't overwrite the error message from CommandException.
-         * We have to throw the CommandException by ourself here.
-         *
-         * For the parameter of $validationSubject['response'],
-         * please see: Omise\Payment\Gateway\Http\Client\Payment.
-         */
-
-        if (! $this->isClientRequestedSuccess($validationSubject)) {
-            throw new CommandException(__($this->message));
+        if (! isset($data['object']) || $data['object'] !== 'charge') {
+            return new OmiseObjectInvalid();
         }
 
-        $omise_object = $validationSubject['response']['data'];
-
-        if (! $this->isReponseOmiseObject($omise_object)
-            || ! $this->validateAuthorizedCharge($omise_object)) {
-            throw new CommandException(__($this->message));
+        if ($data['status'] === 'failed') {
+            return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
         }
 
-        return $this->createResult(true, []);
-    }
-
-    /**
-     * @param  array $validationSubject
-     *
-     * @return boolean
-     */
-    protected function isValidResponse(array $validationSubject)
-    {
-        if (! isset($validationSubject['response']) || $validationSubject['response']['object'] !== "omise") {
-            $this->message = 'Transaction has been declined. Please contact administrator';
-            return false;
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == true
+        ) {
+            return true;
         }
 
-        return true;
-    }
-
-    /**
-     * @param  array $validationSubject
-     *
-     * @return boolean
-     */
-    protected function isClientRequestedSuccess(array $validationSubject)
-    {
-        if (! $this->isValidResponse($validationSubject)) {
-            return false;
-        }
-
-        $response = $validationSubject['response'];
-        if ($response['status'] === 'failed') {
-            $this->message = $response['message'];
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return boolean
-     */
-    protected function isReponseOmiseObject($omise)
-    {
-        if (! isset($omise['object']) || $omise['object'] !== 'charge') {
-            $this->message = "Couldn't retrieve charge transaction. Please contact administrator.";
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return boolean
-     */
-    protected function validateAuthorizedCharge($omise)
-    {
-        if (! $omise['authorized']) {
-            $this->message = $this->getOmiseFailureMessage($omise);
-            return false;
-        }
-
-        return true;   
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return string
-     */
-    protected function getOmiseFailureMessage($omise)
-    {
-        if (isset($omise['failure_message']) && $omise['failure_message'] !== "") {
-            return $omise['failure_message'];
-        }
-
-        return "We couldn't proceed charge well, some part of the process is failed. Please confirm your order with adminstrator.";
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
     }
 }

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -1,129 +1,36 @@
 <?php
 namespace Omise\Payment\Gateway\Validator;
 
-use Magento\Payment\Gateway\Command\CommandException;
-use Magento\Payment\Gateway\Validator\AbstractValidator;
+use Omise\Payment\Gateway\Validator\CommandResponseValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
 
-class OmiseCaptureCommandResponseValidator extends AbstractValidator
+class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
 {
     /**
-     * @var string
+     * @param  mixed
+     *
+     * @return mixed
      */
-    protected $message;
-
-    /**
-     * Performs domain-related validation for business object
-     *
-     * @param  array $validationSubject
-     *
-     * @throws \Magento\Payment\Gateway\Command\CommandException
-     *
-     * @return ResultInterface
-     */
-    public function validate(array $validationSubject)
+    protected function validateResponse($data)
     {
-        /**
-         * Note, normally we should return [$isValid = false, $errorMessages = ['msg_1', 'msg_2']]
-         * out to the GatewayCommand::execute() method.
-         * But since we couldn't overwrite the error message from CommandException.
-         * We have to throw the CommandException by ourself here.
-         *
-         * For the parameter of $validationSubject['response'],
-         * please see: Omise\Payment\Gateway\Http\Client\Payment.
-         */
-
-        if (! $this->isClientRequestedSuccess($validationSubject)) {
-            throw new CommandException(__($this->message));
+        if (! isset($data['object']) || $data['object'] !== 'charge') {
+            return new OmiseObjectInvalid();
         }
 
-        $omise_object = $validationSubject['response']['data'];
-
-        if (! $this->isReponseOmiseObject($omise_object)
-            || ! $this->validateAuthorizedAndCapturedCharge($omise_object)) {
-            throw new CommandException(__($this->message));
+        if ($data['status'] === 'failed') {
+            return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
         }
 
-        return $this->createResult(true, []);
-    }
+        $captured = $data['captured'] ? $data['captured'] : $data['paid'];
 
-    /**
-     * @param  array $validationSubject
-     *
-     * @return boolean
-     */
-    protected function isValidResponse(array $validationSubject)
-    {
-        if (! isset($validationSubject['response']) || $validationSubject['response']['object'] !== "omise") {
-            $this->message = 'Transaction has been declined. Please contact administrator';
-            return false;
+        if ($data['status'] === 'successful'
+            && $data['authorized'] == true
+            && $captured == true
+        ) {
+            return true;
         }
 
-        return true;
-    }
-
-    /**
-     * @param  array $validationSubject
-     *
-     * @return boolean
-     */
-    protected function isClientRequestedSuccess(array $validationSubject)
-    {
-        if (! $this->isValidResponse($validationSubject)) {
-            return false;
-        }
-
-        $response = $validationSubject['response'];
-        if ($response['status'] === 'failed') {
-            $this->message = $response['message'];
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return boolean
-     */
-    protected function isReponseOmiseObject($omise)
-    {
-        if (! isset($omise['object']) || $omise['object'] !== 'charge') {
-            $this->message = "Couldn't retrieve charge transaction. Please contact administrator.";
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return boolean
-     */
-    protected function validateAuthorizedAndCapturedCharge($omise)
-    {
-        // Support Omise API 2014-07-27
-        $paid = isset($omise['paid']) ? $omise['paid'] : $omise['captured'];
-        if (! $omise['authorized'] || ! $paid) {
-            $this->message = $this->getOmiseFailureMessage($omise);
-            return false;
-        }
-
-        return true;   
-    }
-
-    /**
-     * @param  \OmiseApiResource $omise
-     *
-     * @return string
-     */
-    protected function getOmiseFailureMessage($omise)
-    {
-        if (isset($omise['failure_message']) && $omise['failure_message'] !== "") {
-            return $omise['failure_message'];
-        }
-
-        return "We couldn't proceed charge well, some part of the process is failed. Please confirm your order with adminstrator.";
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
     }
 }


### PR DESCRIPTION
#### 1. Objective

To remove duplicated code and make validator classes more flexible & readable.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

- Refactor all Gateway\Validator classes.
- Move some duplicated code/ conditions to a `base validator` class.
- Update validation messages and implemented with `Phrase` class. (to be able to translate later on).

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

Test all related charge functions and make it fail.

**_Credit Card Payment Method_**
- Authorize Only
    - Use **[Failed Card Test](https://www.omise.co/api-testing#failed-charge)** 
    - Make a charge with Omise 3-D Secure enabled account (should be failed).

- Authorize and Capture
    - Use **[Failed Card Test](https://www.omise.co/api-testing#failed-charge)** 
    - Make a charge with Omise 3-D Secure enabled account (should be failed).

**_Internet Banking Payment Method_**
- Make a charge to be successful from the offsite page.
- Make a charge to be failed from the offsite page.

#### 4. Impact of the change

You must clear Magento caches to get this new payment method.

1. At Magento admin page, go to `SYSTEM > Cache Management`
2. Click `Flush Magento Cache`. (or you can choose to disable all caches while testing).
    ![screen shot 2560-03-22 at 5 32 08 pm](https://cloud.githubusercontent.com/assets/2154669/24193705/d5408768-0f25-11e7-9955-662ed63b6319.png)

And if you do manual (copy / paste) this PR, you must remove files in `app/code/Omise/Payment` first.
(do this step before clearing cache).
1. Just remove files, `cd app/code/Omise/Payment`, `rm -R *`.
2. Copy all files again, `cp -R omise-magento/* .`.

(this is for manual install).

#### 5. Priority of change

Normal

#### 6. Additional Notes

No.
