### PR TITLE
Prepare the code structure for 3-D Secure payment.

### DIFF
--- a/Gateway/Command/CreditCardStrategyCommand.php
+++ b/Gateway/Command/CreditCardStrategyCommand.php
@@ -1,0 +1,110 @@
+<?php
+namespace Omise\Payment\Gateway\Command;
+
+use Magento\Payment\Gateway\Command\CommandException;
+use Magento\Payment\Gateway\Command\CommandPoolInterface;
+use Magento\Payment\Gateway\CommandInterface;
+use Magento\Payment\Gateway\Helper\ContextHelper;
+use Magento\Payment\Gateway\Helper\SubjectReader;
+use Magento\Sales\Model\Order;
+use Omise\Payment\Model\Config\Cc as Config;
+
+class CreditCardStrategyCommand implements CommandInterface
+{
+    /**
+     * @var string
+     */
+    const ACTION_AUTHORIZE                     = \Magento\Payment\Model\Method\AbstractMethod::ACTION_AUTHORIZE;
+    const ACTION_AUTHORIZE_THREEDSECURE        = self::ACTION_AUTHORIZE . '_3ds';
+    const ACTION_AUTHORIZE_CAPTURE             = \Magento\Payment\Model\Method\AbstractMethod::ACTION_AUTHORIZE_CAPTURE;
+    const ACTION_AUTHORIZE_CAPTURETHREEDSECURE = self::ACTION_AUTHORIZE_CAPTURE . '_3ds';
+
+    /**
+     * @var \Magento\Payment\Gateway\Command\CommandPoolInterface
+     */
+    private $commandPool;
+
+    /**
+     * @var \Omise\Payment\Model\Config\Cc
+     */
+    private $config;
+
+    public function __construct(
+        CommandPoolInterface $commandPool,
+        Config               $config
+    ) {
+        $this->commandPool = $commandPool;
+        $this->config      = $config;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(array $commandSubject)
+    {
+        /** @var \Magento\Payment\Model\InfoInterface **/
+        $payment = SubjectReader::readPayment($commandSubject)->getPayment();
+        ContextHelper::assertOrderPayment($payment);
+
+        $order        = $payment->getOrder();
+        $totalDue     = $order->getTotalDue();
+        $baseTotalDue = $order->getBaseTotalDue();
+
+        switch ($this->getPaymentAction($commandSubject)) {
+            case self::ACTION_AUTHORIZE:
+                $payment->authorize(true, $baseTotalDue);
+                $payment->setAmountAuthorized($totalDue);
+                break;
+
+            case self::ACTION_AUTHORIZE_CAPTURE:
+                $payment->setAmountAuthorized($totalDue);
+                $payment->setBaseAmountAuthorized($baseTotalDue);
+                $payment->capture(null);
+                break;
+
+            case self::ACTION_AUTHORIZE_THREEDSECURE:
+                throw new CommandException(__('TODO : Rewrite error message'));
+                break;
+
+            case self::ACTION_AUTHORIZE_CAPTURETHREEDSECURE:
+                throw new CommandException(__('TODO : Rewrite error message'));
+                break;
+
+            default:
+                throw new CommandException(__('TODO : Rewrite error message'));
+                break;
+        }
+
+        $this->updateOrderState(
+            $commandSubject,
+            ($order->getState() ? $order->getState() : Order::STATE_PROCESSING),
+            ($order->getStatus() ? $order->getStatus() : $order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING))            
+        );
+    }
+
+    /**
+     * @param  array  $commandSubject
+     *
+     * @return string
+     */
+    protected function getPaymentAction(array $commandSubject)
+    {
+        if ($this->config->is3DSecureEnabled()) {
+            return $commandSubject['paymentAction'] . '_3ds'; 
+        }
+
+        return $commandSubject['paymentAction'];
+    }
+
+    /**
+     * @param array  $commandSubject
+     * @param string $state
+     * @param string $status
+     */
+    protected function updateOrderState(array $commandSubject, $state, $status)
+    {
+        $stateObject = SubjectReader::readStateObject($commandSubject);
+        $stateObject->setState($state);
+        $stateObject->setStatus($status);
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@
                 <title>Credit / Debit Card</title>
                 <model>OmiseCcAdapter</model>
                 <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
                 <can_use_checkout>1</can_use_checkout>
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -87,14 +87,23 @@
         </arguments>
     </virtualType>
 
+    <!-- Credit Card :: Command Pool -->
     <virtualType name="OmiseCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
         <arguments>
             <argument name="commands" xsi:type="array">
+                <item name="initialize" xsi:type="string">OmiseCreditCardInitializeCommand</item>
                 <item name="authorize" xsi:type="string">OmiseAuthorizeCommand</item>
                 <item name="capture" xsi:type="string">OmiseCaptureCommand</item>
             </argument>
         </arguments>
     </virtualType>
+
+    <virtualType name="OmiseCreditCardInitializeCommand" type="Omise\Payment\Gateway\Command\CreditCardStrategyCommand">
+        <arguments>
+            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Command Pool -->
 
     <virtualType name="OmiseValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>


### PR DESCRIPTION
#### 1. Objective

To prepare core code structure to support an implementation of the 3-D Secure payment.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

**_• Integrate payment with an `initialize` gateway command, to use it as a middle layer to determine which final command that it will proceed with._**
The reason why we need this, is because in Magento system, they've only provided 2 commands as a basic/ general credit card payment method use case.

For example, for the `Authorize and Capture` command. The general Magento flow will be 
```
1. Place Order
    > 2. Try submit payment
        > 3. if payment success (captured), create an invoice
            > 4. update status to "processing"
```

But as for 3-D Secure payment behavior, we need to hold the result at the step 3.
So, the flow is gonna be something like below.
```
1. Place Order
    > 2. Try submit payment
        > 3. if payment success (just successs on create a transaction), update status to "pending payment"

4. Trigger callback
    > 5. Validate the charge result
        > 6. If success, create an invoice
            > 7. Update order status to `processing`
```
👆 To go with this flow, we need to reimplement the payment flow by ourself by using `initialize` gateway command.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16

**✏️ Details:**

_The main purpose of these tests is to make sure that this change will not effect to the current charge functions_
 
1. ✅ Test create charge with `authorize only` payment action.

2. ✅ Test create charge with `authorize and capture` payment action.

3. ✅ Test create charge with any payment action, and make it fail by using **[Failed Card Test](https://www.omise.co/api-testing#failed-charge)**

#### 4. Impact of the change

You must clear Magento caches to get this new payment method.

1. At Magento admin page, go to `SYSTEM > Cache Management`
2. Click `Flush Magento Cache`. (or you can choose to disable all caches while testing).
    ![screen shot 2560-03-22 at 5 32 08 pm](https://cloud.githubusercontent.com/assets/2154669/24193705/d5408768-0f25-11e7-9955-662ed63b6319.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

1. The implementation of 3-D Secure payment haven't been implemented yet. This PR just prepare the core structure to support the coming PRs.