### PR TITLE
Redirect user to a 3-D Secure auth page if the 3-D Secure option is enabled

### DIFF
--- a/Gateway/Command/CreditCardStrategyCommand.php
+++ b/Gateway/Command/CreditCardStrategyCommand.php
@@ -20,6 +20,12 @@ class CreditCardStrategyCommand implements CommandInterface
     const ACTION_AUTHORIZE_CAPTURETHREEDSECURE = self::ACTION_AUTHORIZE_CAPTURE . '_3ds';
 
     /**
+     * @var string
+     */
+    const COMMAND_AUTHORIZE_THREEDSECURE        = 'authorize_3ds';
+    const COMMAND_AUTHORIZE_CAPTURETHREEDSECURE = 'capture_3ds';
+
+    /**
      * @var \Magento\Payment\Gateway\Command\CommandPoolInterface
      */
     private $commandPool;
@@ -63,11 +69,11 @@ class CreditCardStrategyCommand implements CommandInterface
                 break;
 
             case self::ACTION_AUTHORIZE_THREEDSECURE:
-                throw new CommandException(__('TODO : Rewrite error message'));
+                $this->commandPool->get(self::COMMAND_AUTHORIZE_THREEDSECURE)->execute($commandSubject);
                 break;
 
             case self::ACTION_AUTHORIZE_CAPTURETHREEDSECURE:
-                throw new CommandException(__('TODO : Rewrite error message'));
+                $this->commandPool->get(self::COMMAND_AUTHORIZE_CAPTURETHREEDSECURE)->execute($commandSubject);
                 break;
 
             default:

--- a/Gateway/Command/CreditCardStrategyCommand.php
+++ b/Gateway/Command/CreditCardStrategyCommand.php
@@ -81,11 +81,13 @@ class CreditCardStrategyCommand implements CommandInterface
                 break;
         }
 
-        $this->updateOrderState(
-            $commandSubject,
-            ($order->getState() ? $order->getState() : Order::STATE_PROCESSING),
-            ($order->getStatus() ? $order->getStatus() : $order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING))            
-        );
+        if (! $this->config->is3DSecureEnabled()) {
+            $this->updateOrderState(
+                $commandSubject,
+                ($order->getState() ? $order->getState() : Order::STATE_PROCESSING),
+                ($order->getStatus() ? $order->getStatus() : $order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING))
+            );
+        }
     }
 
     /**

--- a/Gateway/Request/PaymentThreeDSecureBuilder.php
+++ b/Gateway/Request/PaymentThreeDSecureBuilder.php
@@ -3,7 +3,6 @@ namespace Omise\Payment\Gateway\Request;
 
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Omise\Payment\Model\Config\Cc as Config;
 
 class PaymentThreeDSecureBuilder implements BuilderInterface
 {
@@ -17,15 +16,9 @@ class PaymentThreeDSecureBuilder implements BuilderInterface
      */
     protected $url;
 
-    /**
-     * @var \Omise\Payment\Model\Config\Cc
-     */
-    protected $config;
-
-    public function __construct(UrlInterface $url, Config $config)
+    public function __construct(UrlInterface $url)
     {
-        $this->url    = $url;
-        $this->config = $config;
+        $this->url = $url;
     }
 
     /**
@@ -35,12 +28,8 @@ class PaymentThreeDSecureBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
-        if ($this->config->is3DSecureEnabled()) {
-            return [
-                self::RETURN_URI => $this->url->getUrl('omise/callback/threedsecure', ['_secure' => true])
-            ];
-        }
-
-        return [];
+        return [
+            self::RETURN_URI => $this->url->getUrl('omise/callback/threedsecure', ['_secure' => true])
+        ];
     }
 }

--- a/Gateway/Request/PaymentThreeDSecureBuilder.php
+++ b/Gateway/Request/PaymentThreeDSecureBuilder.php
@@ -1,0 +1,46 @@
+<?php
+namespace Omise\Payment\Gateway\Request;
+
+use Magento\Framework\UrlInterface;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Omise\Payment\Model\Config\Cc as Config;
+
+class PaymentThreeDSecureBuilder implements BuilderInterface
+{
+    /**
+     * @var string
+     */
+    const RETURN_URI = 'return_uri';
+
+    /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    protected $url;
+
+    /**
+     * @var \Omise\Payment\Model\Config\Cc
+     */
+    protected $config;
+
+    public function __construct(UrlInterface $url, Config $config)
+    {
+        $this->url    = $url;
+        $this->config = $config;
+    }
+
+    /**
+     * @param  array $buildSubject
+     *
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        if ($this->config->is3DSecureEnabled()) {
+            return [
+                self::RETURN_URI => $this->url->getUrl('omise/callback/threedsecure', ['_secure' => true])
+            ];
+        }
+
+        return [];
+    }
+}

--- a/Gateway/Response/PendingInvoiceHandler.php
+++ b/Gateway/Response/PendingInvoiceHandler.php
@@ -1,10 +1,10 @@
 <?php
 namespace Omise\Payment\Gateway\Response;
 
+use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Response\HandlerInterface;
-use Magento\Sales\Model\Order;
 
-class PendingPaymentHandler implements HandlerInterface
+class PendingInvoiceHandler implements HandlerInterface
 {
     /**
      * @inheritdoc
@@ -19,10 +19,13 @@ class PendingPaymentHandler implements HandlerInterface
             && $captured == false
             && $response['data']['authorize_uri']
         ) {
-            $stateObject = $handlingSubject['stateObject'];
-            $stateObject->setState(Order::STATE_PENDING_PAYMENT);
-            $stateObject->setStatus(Order::STATE_PENDING_PAYMENT);
-            $stateObject->setIsNotified(false);
+            /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
+            $payment = SubjectReader::readPayment($handlingSubject);
+
+            $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
+            $invoice->register();
+
+            $payment->getPayment()->getOrder()->addRelatedObject($invoice);
         }
     }
 }

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -22,15 +22,6 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
             return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
         }
 
-        // For 3-D Secure payment.
-        if ($data['status'] === 'pending'
-            && $data['authorized'] == false
-            && $captured == false
-            && $data['authorize_uri']
-        ) {
-            return true;
-        }
-
         if ($data['status'] === 'pending'
             && $data['authorized'] == true
         ) {

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -22,6 +22,15 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
             return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
         }
 
+        // For 3-D Secure payment.
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == false
+            && $captured == false
+            && $data['authorize_uri']
+        ) {
+            return true;
+        }
+
         if ($data['status'] === 'pending'
             && $data['authorized'] == true
         ) {

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -7,7 +7,6 @@ use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
 
 class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
 {
-
     /**
      * @param  mixed
      *
@@ -25,16 +24,6 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
 
         $captured = $data['captured'] ? $data['captured'] : $data['paid'];
 
-        // For 3-D Secure payment.
-        if ($data['status'] === 'pending'
-            && $data['authorized'] == false
-            && $captured == false
-            && $data['authorize_uri']
-        ) {
-            return true;
-        }
-
-        // For normal charge.
         if ($data['status'] === 'successful'
             && $data['authorized'] == true
             && $captured == true

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -7,6 +7,7 @@ use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
 
 class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
 {
+
     /**
      * @param  mixed
      *
@@ -24,6 +25,16 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
 
         $captured = $data['captured'] ? $data['captured'] : $data['paid'];
 
+        // For 3-D Secure payment.
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == false
+            && $captured == false
+            && $data['authorize_uri']
+        ) {
+            return true;
+        }
+
+        // For normal charge.
         if ($data['status'] === 'successful'
             && $data['authorized'] == true
             && $captured == true

--- a/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
+++ b/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
@@ -1,0 +1,38 @@
+<?php
+namespace Omise\Payment\Gateway\Validator;
+
+use Omise\Payment\Gateway\Validator\CommandResponseValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
+
+class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
+{
+    /**
+     * @param  mixed
+     *
+     * @return mixed
+     */
+    protected function validateResponse($data)
+    {
+        if (! isset($data['object']) || $data['object'] !== 'charge') {
+            return new OmiseObjectInvalid();
+        }
+
+        if ($data['status'] === 'failed') {
+            return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
+        }
+
+        $captured = $data['captured'] ? $data['captured'] : $data['paid'];
+
+        // For 3-D Secure payment.
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == false
+            && $captured == false
+            && $data['authorize_uri']
+        ) {
+            return true;
+        }
+
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
+    }
+}

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -35,7 +35,7 @@ class Config
     public function getValue($field, $code = self::CODE)
     {
         return $this->scopeConfig->getValue(
-            'payment/' . self::CODE . '/' . $field,
+            'payment/' . $code . '/' . $field,
             MagentoScopeInterface::SCOPE_STORE
         );
     }

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -37,7 +37,8 @@ class CcConfigProvider implements ConfigProviderInterface
                     'years'  => [OmiseCcConfig::CODE => $this->magentoCcConfig->getCcYears()],
                 ],
                 OmiseCcConfig::CODE => [
-                    'publicKey' => $this->omiseCcConfig->getPublicKey(),
+                    'publicKey'      => $this->omiseCcConfig->getPublicKey(),
+                    'offsitePayment' => $this->omiseCcConfig->is3DSecureEnabled()
                 ],
             ]
         ];

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -93,7 +93,9 @@
             <argument name="commands" xsi:type="array">
                 <item name="initialize" xsi:type="string">OmiseCreditCardInitializeCommand</item>
                 <item name="authorize" xsi:type="string">OmiseAuthorizeCommand</item>
+                <item name="authorize_3ds" xsi:type="string">OmiseAuthorizeThreeDSecureCommand</item>
                 <item name="capture" xsi:type="string">OmiseCaptureCommand</item>
+                <item name="capture_3ds" xsi:type="string">OmiseCaptureThreeDSecureCommand</item>
             </argument>
         </arguments>
     </virtualType>
@@ -101,6 +103,50 @@
     <virtualType name="OmiseCreditCardInitializeCommand" type="Omise\Payment\Gateway\Command\CreditCardStrategyCommand">
         <arguments>
             <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- Credit Card :: Authorize with 3-D Secure payment -->
+    <virtualType name="OmiseAuthorizeThreeDSecureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeThreeDSecureRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAuthorizeThreeDSecureRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
+                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <!-- Credit Card :: Authorize and Capture with 3-D Secure payment -->
+    <virtualType name="OmiseCaptureThreeDSecureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">OmiseCaptureThreeDSecureRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseCaptureThreeDSecureRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
+                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
+            </argument>
         </arguments>
     </virtualType>
     <!-- /Command Pool -->
@@ -150,7 +196,6 @@
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
-                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -173,7 +218,6 @@
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
-                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -138,7 +138,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">Magento\Payment\Gateway\Response\HandlerChain</argument>
+            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator</argument>
         </arguments>
     </virtualType>
@@ -161,7 +161,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">Magento\Payment\Gateway\Response\HandlerChain</argument>
+            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator</argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -150,6 +150,7 @@
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -172,6 +173,7 @@
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -51,7 +51,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseOffsiteInternetbankingRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseOffsiteResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\Offsite\InternetbankingInitializeCommandResponseValidator</argument>
         </arguments>
     </virtualType>
@@ -66,6 +66,24 @@
     </virtualType>
 
     <virtualType name="OmiseResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseOffsiteResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
+                <item name="pendingPayment" xsi:type="string">Omise\Payment\Gateway\Response\PendingPaymentHandler</item>
+                <item name="pendingInvoice" xsi:type="string">Omise\Payment\Gateway\Response\PendingInvoiceHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseOffsiteAuthorizeResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
@@ -112,7 +130,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseOffsiteAuthorizeResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
     </virtualType>
@@ -134,7 +152,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseOffsiteResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
> ⚠️ This PR is a part of 3-D Secure implementation, PR #76 

#### 1. Objective

To assign a callback uri when create a charge, and redirect user to a 3-D Secure auth page if the 3-D Secure option in the Magento payment setting page is enabled.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

• Assign a callback uri parameter when creating charge with 3-D Secure payment

• Update javascript to be able to redirect user if proceed a charge with 3-D Secure payment.

• Update validator conditionals to allows `pending` charge (_charge.status = pending_) to be passed and valid. 

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

**_Tested by using an Omise 3-D Secure enabled account._**

1. ✅ Make charge with `authorize only` payment action.

2. ✅ Make charge with `authorize and capture` payment action.


#### 4. Impact of the change

You might clear Magento store caches if you can't see the result.

1. At Magento admin page, go to `SYSTEM > Cache Management`
2. Click `Flush Magento Cache`. (or you can choose to disable all caches while testing).
    ![screen shot 2560-03-22 at 5 32 08 pm](https://cloud.githubusercontent.com/assets/2154669/24193705/d5408768-0f25-11e7-9955-662ed63b6319.png)

#### 5. Priority of change

Normal

#### 6. Additional Notes

No
