### PR TITLE
[WIP] Validate a 3-D Secure payment result at the callback uri

### DIFF
--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -185,9 +185,7 @@ class Threedsecure extends Action
             $this->invoice($order)->cancel()->save();
         }
 
-        $order->setState(Order::STATE_CANCELED);
-        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
-
-        $this->invalid($order, $message);
+        $order->registerCancellation($message)->save();
+        $this->messageManager->addErrorMessage($message);
     }
 }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -103,7 +103,7 @@ class Threedsecure extends Action
                 $payment->addTransactionCommentsToOrder(
                     $payment->addTransaction(Transaction::TYPE_CAPTURE, $invoice),
                     __(
-                        'Amount of %1 has been paid via Omise Internet Banking payment',
+                        'Captured amount of %1 online via Omise Payment Gateway (3-D Secure payment).',
                         $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal())
                     )
                 );
@@ -112,7 +112,7 @@ class Threedsecure extends Action
                     $payment->addTransaction(Transaction::TYPE_AUTH),
                     $payment->prependMessage(
                         __(
-                            'Authorized amount of %1.',
+                            'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
                             $order->getBaseCurrency()->formatTxt($order->getTotalDue())
                         )
                     )

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -1,0 +1,21 @@
+<?php
+namespace Omise\Payment\Controller\Callback;
+
+use Magento\Framework\App\Action\Action;
+
+class Threedsecure extends Action
+{
+    /**
+     * @var string
+     */
+    const PATH_CART    = 'checkout/cart';
+    const PATH_SUCCESS = 'checkout/onepage/success';
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        echo "3-D Secure callback validation";
+    }
+}

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -1,11 +1,13 @@
 <?php
 namespace Omise\Payment\Controller\Callback;
 
+use Exception;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
 use Omise\Payment\Model\Config\Cc as Config;
 use Omise\Payment\Model\Validator\Payment\AuthorizeResultValidator;
 use Omise\Payment\Model\Validator\Payment\CaptureResultValidator;

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -1,7 +1,14 @@
 <?php
 namespace Omise\Payment\Controller\Callback;
 
+use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment\Transaction;
+use Omise\Payment\Model\Config\Cc as Config;
+use Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator;
+use Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator;
 
 class Threedsecure extends Action
 {
@@ -12,10 +19,168 @@ class Threedsecure extends Action
     const PATH_SUCCESS = 'checkout/onepage/success';
 
     /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
+
+    /**
+     * @var \Omise\Payment\Model\Config\Cc
+     */
+    protected $config;
+
+    public function __construct(
+        Context $context,
+        Session $session,
+        Config  $config
+    ) {
+        parent::__construct($context);
+
+        $this->session = $session;
+        $this->config  = $config;
+    }
+
+    /**
      * @return void
      */
     public function execute()
     {
-        echo "3-D Secure callback validation";
+        $order = $this->session->getLastRealOrder();
+
+        if (! $order->getId()) {
+            $this->messageManager->addErrorMessage(__('The order session no longer exists, please make an order again or contact our support if you have any questions.'));
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if ($order->getState() !== Order::STATE_PENDING_PAYMENT) {
+            $this->invalid($order, __('Invalid order status, cannot validate the payment. Please contact our support if you have any questions.'));
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if (! $payment = $order->getPayment()) {
+            $this->invalid($order, __('Cannot retrieve a payment detail from the request. Please contact our support if you have any questions.'));
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if ($payment->getMethod() !== 'omise' && $payment->getMethod() !== 'omise_cc') {
+            $this->invalid($order, __('Invalid payment method. Please contact our support if you have any questions.'));
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        if (! $charge_id = $payment->getAdditionalInformation('charge_id')) {
+            $this->cancel($order, __('Cannot retrieve a charge reference id. Please contact our support to confirm your payment.'));
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+
+        try {
+            $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
+
+            $result = $this->validate($charge);
+
+            if ($result instanceof Invalid) {
+                throw new Exception($result->getMessage());
+            }
+
+            $order->setState(Order::STATE_PROCESSING);
+            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
+
+            // Update order state and status.
+            if ($order->hasInvoices()) {
+                $payment->setTransactionId($charge['transaction']);
+                $payment->setLastTransId($charge['transaction']);
+
+                $invoice = $this->invoice($order);
+                $invoice->setTransactionId($charge['transaction'])->pay()->save();
+
+                // Add transaction.
+                $payment->addTransactionCommentsToOrder(
+                    $payment->addTransaction(Transaction::TYPE_CAPTURE, $invoice),
+                    __(
+                        'Amount of %1 has been paid via Omise Internet Banking payment',
+                        $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal())
+                    )
+                );
+            } else {
+                $payment->addTransactionCommentsToOrder(
+                    $payment->addTransaction(Transaction::TYPE_AUTH),
+                    $payment->prependMessage(__('Authorized amount of %1.', $order->getTotalDue()))
+                );
+            }
+
+            $order->save();
+            return $this->redirect(self::PATH_SUCCESS);
+        } catch (Exception $e) {
+            $this->cancel($order, $e->getMessage());
+            $this->session->restoreQuote();
+
+            return $this->redirect(self::PATH_CART);
+        }
+    }
+
+    /**
+     * @param  \Magento\Sales\Model\Order $order
+     *
+     * @return \Magento\Sales\Api\Data\InvoiceInterface
+     */
+    protected function invoice(Order $order)
+    {
+        return $order->getInvoiceCollection()->getLastItem();
+    }
+
+    /**
+     * @param  string $path
+     *
+     * @return \Magento\Framework\App\ResponseInterface
+     */
+    protected function redirect($path)
+    {
+        return $this->_redirect($path, ['_secure' => true]);
+    }
+
+    /**
+     * @param  \OmiseCharge $charge
+     *
+     * @return bool
+     */
+    protected function validate($charge)
+    {
+        if ($charge['capture']) {
+            return (new OmiseCaptureCommandResponseValidator)->validateResponse($charge);
+        }
+
+        return (new OmiseAuthorizeCommandResponseValidator)->validateResponse($charge);
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order       $order
+     * @param \Magento\Framework\Phrase|string $message
+     */
+    protected function invalid(Order $order, $message)
+    {
+        $order->addStatusHistoryComment($message);
+        $order->save();
+
+        $this->messageManager->addErrorMessage($message);
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order       $order
+     * @param \Magento\Framework\Phrase|string $message
+     */
+    protected function cancel(Order $order, $message)
+    {
+        if ($order->hasInvoices()) {
+            $this->invoice($order)->cancel()->save();
+        }
+
+        $order->setState(Order::STATE_CANCELED);
+        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
+
+        $this->invalid($order, $message);
     }
 }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -7,8 +7,8 @@ use Magento\Framework\App\Action\Context;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Omise\Payment\Model\Config\Cc as Config;
-use Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator;
-use Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator;
+use Omise\Payment\Model\Validator\Payment\AuthorizeResultValidator;
+use Omise\Payment\Model\Validator\Payment\CaptureResultValidator;
 
 class Threedsecure extends Action
 {
@@ -150,10 +150,10 @@ class Threedsecure extends Action
     protected function validate($charge)
     {
         if ($charge['capture']) {
-            return (new OmiseCaptureCommandResponseValidator)->validateResponse($charge);
+            return (new CaptureResultValidator)->validate($charge);
         }
 
-        return (new OmiseAuthorizeCommandResponseValidator)->validateResponse($charge);
+        return (new AuthorizeResultValidator)->validate($charge);
     }
 
     /**

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -110,7 +110,12 @@ class Threedsecure extends Action
             } else {
                 $payment->addTransactionCommentsToOrder(
                     $payment->addTransaction(Transaction::TYPE_AUTH),
-                    $payment->prependMessage(__('Authorized amount of %1.', $order->getTotalDue()))
+                    $payment->prependMessage(
+                        __(
+                            'Authorized amount of %1.',
+                            $order->getBaseCurrency()->formatTxt($order->getTotalDue())
+                        )
+                    )
                 );
             }
 

--- a/Gateway/Validator/CommandResponseValidator.php
+++ b/Gateway/Validator/CommandResponseValidator.php
@@ -47,7 +47,7 @@ class CommandResponseValidator extends AbstractValidator
      *
      * @return mixed
      */
-    protected function validateResponse($data)
+    public function validateResponse($data)
     {
         return true;
     }

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    protected function validateResponse($data)
+    public function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    protected function validateResponse($data)
+    public function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
+++ b/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    protected function validateResponse($data)
+    public function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Model/Validator/Payment/AuthorizeResultValidator.php
+++ b/Model/Validator/Payment/AuthorizeResultValidator.php
@@ -1,0 +1,27 @@
+<?php
+namespace Omise\Payment\Model\Validator\Payment;
+
+use Omise\Payment\Model\Validator\Payment\ResultValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+
+class AuthorizeResultValidator extends ResultValidator
+{
+    /**
+     * @param  mixed
+     *
+     * @return mixed
+     */
+    public function validate($data)
+    {
+        $validate = parent::validate($data);
+        if ($validate instanceof Invalid) {
+            return $validate;
+        }
+
+        if ($data['status'] === 'pending' && $data['authorized'] == true) {
+            return true;
+        }
+
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
+    }
+}

--- a/Model/Validator/Payment/CaptureResultValidator.php
+++ b/Model/Validator/Payment/CaptureResultValidator.php
@@ -1,0 +1,32 @@
+<?php
+namespace Omise\Payment\Model\Validator\Payment;
+
+use Omise\Payment\Model\Validator\Payment\ResultValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+
+class CaptureResultValidator extends ResultValidator
+{
+    /**
+     * @param  mixed
+     *
+     * @return mixed
+     */
+    public function validate($data)
+    {
+        $validate = parent::validate($data);
+        if ($validate instanceof Invalid) {
+            return $validate;
+        }
+
+        $captured = $data['captured'] ? $data['captured'] : $data['paid'];
+
+        if ($data['status'] === 'successful'
+            && $data['authorized'] == true
+            && $captured == true
+        ) {
+            return true;
+        }
+
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
+    }
+}

--- a/Model/Validator/Payment/OffsiteResultValidator.php
+++ b/Model/Validator/Payment/OffsiteResultValidator.php
@@ -1,0 +1,33 @@
+<?php
+namespace Omise\Payment\Model\Validator\Payment;
+
+use Omise\Payment\Model\Validator\Payment\ResultValidator;
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+
+class OffsiteResultValidator extends ResultValidator
+{
+    /**
+     * @param  mixed
+     *
+     * @return mixed
+     */
+    public function validate($data)
+    {
+        $validate = parent::validate($data);
+        if ($validate instanceof Invalid) {
+            return $validate;
+        }
+
+        $captured = $data['captured'] ? $data['captured'] : $data['paid'];
+
+        if ($data['status'] === 'pending'
+            && $data['authorized'] == false
+            && $captured == false
+            && $data['authorize_uri']
+        ) {
+            return true;
+        }
+
+        return new Invalid('Payment failed, invalid payment status, please contact our support if you have any questions');
+    }
+}

--- a/Model/Validator/Payment/ResultValidator.php
+++ b/Model/Validator/Payment/ResultValidator.php
@@ -1,0 +1,26 @@
+<?php
+namespace Omise\Payment\Model\Validator\Payment;
+
+use Omise\Payment\Gateway\Validator\Message\Invalid;
+use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
+
+class ResultValidator
+{
+    /**
+     * @param  mixed
+     *
+     * @return mixed
+     */
+    public function validate($data)
+    {
+        if (! isset($data['object']) || $data['object'] !== 'charge') {
+            return new OmiseObjectInvalid();
+        }
+
+        if ($data['status'] === 'failed') {
+            return new Invalid('Payment failed. ' . ucfirst($data['failure_message']) . ', please contact our support if you have any questions.');
+        }
+
+        return true;
+    }
+}

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -151,8 +151,10 @@ define(
                         self.omiseCardToken(response.id);
                         self.getPlaceOrderDeferredObject()
                             .fail(
-                                function() {
-                                    self.stopPerformingPlaceOrderAction();
+                                function(response) {
+                                    errorProcessor.process(response, self.messageContainer);
+                                    fullScreenLoader.stopLoader();
+                                    self.isPlaceOrderActionAllowed(true);
                                 }
                             ).done(
                                 function(response) {


### PR DESCRIPTION
#### 1. Objective

To validate a 3-D Secure payment result and update an order status, invoice and transaction.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

**_• New callback uri, `omise/callback/threedsecure`_**

**_• Add new controller to handle the validation process on the callback uri._**

**_• Introduce new validation structure and enhance the process between validate & raise an error_**

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ Test access to the callback uri directly, user will be redirected to the `checkout/cart` page and an error will be raised.
    <img width="1075" alt="screen shot 2560-04-11 at 2 41 16 pm" src="https://cloud.githubusercontent.com/assets/2154669/24897915/f69101d2-1ec4-11e7-87ed-978ddb5dd61f.png">

2. ✅ Test validate a charge result with `Order.status != pending payment`, user will be redirected to the `checkout/cart` page and an error will be raised.
    - An error message will be saved into an order history comment section.

3. ✅ If payment method != `omise` or `omise_cc`, user will be redirected to the `checkout/cart` page and an error will be raised.
    - An error message will be saved into an order history comment section.

4. ✅ If cannot retrieve a charge id from a target order, user will be redirected to the `checkout/cart` page and an error will be raised.
    - An error message will be saved into an order history comment section.
    - If it has, invoice will be set to `canceled`.
    - Perform `cancel order`. 

5. ✅ Test validate a charge response with `payment action = authorize`. It should works properly.
    - An order status will be set to `processing`

6. ✅ Test validate a charge response with `payment action = authorize_capture`. It should works properly.
    - An order status will be set to `processing`
    - An invoice will be created with the status `paid`
    - A transaction will be created and `omise.transaction.id` will be attached to the transaction record.
    - A transaction status will be set to `closed`

7. ✅ Test charge with a failed card test, both `authorize` and `authorize_capture` will redirect user to the `checkout/cart` page and raise an error on a screen.
    - An error message will be saved into an order history comment section.
    - If it has, invoice will be set to `canceled`.
    - Perform `cancel order`. 

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No