### PR TITLE
Refactor & correct the internet banking callback, order cancellation behavior

### DIFF
--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -163,6 +163,18 @@ class Internetbanking extends Action
      * @param \Magento\Sales\Model\Order       $order
      * @param \Magento\Framework\Phrase|string $message
      */
+    protected function invalid(Order $order, $message)
+    {
+        $order->addStatusHistoryComment($message);
+        $order->save();
+
+        $this->messageManager->addErrorMessage($message);
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order       $order
+     * @param \Magento\Framework\Phrase|string $message
+     */
     protected function cancel(Order $order, $message)
     {
         $this->invoice($order)->cancel()->save();
@@ -171,17 +183,5 @@ class Internetbanking extends Action
         $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
 
         $this->invalid($order, $message);
-    }
-
-    /**
-     * @param \Magento\Sales\Model\Order       $order
-     * @param \Magento\Framework\Phrase|string $message
-     */
-    protected function invalid(Order $order, $message)
-    {
-        $order->addStatusHistoryComment($message);
-        $order->save();
-
-        $this->messageManager->addErrorMessage($message);
     }
 }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -179,9 +179,7 @@ class Internetbanking extends Action
     {
         $this->invoice($order)->cancel()->save();
 
-        $order->setState(Order::STATE_CANCELED);
-        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
-
-        $this->invalid($order, $message);
+        $order->registerCancellation($message)->save();
+        $this->messageManager->addErrorMessage($message);
     }
 }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -152,7 +152,7 @@ class Threedsecure extends Action
     /**
      * @param  \OmiseCharge $charge
      *
-     * @return bool
+     * @return bool|Omise\Payment\Gateway\Validator\Message\Invalid
      */
     protected function validate($charge)
     {

--- a/Gateway/Validator/CommandResponseValidator.php
+++ b/Gateway/Validator/CommandResponseValidator.php
@@ -47,7 +47,7 @@ class CommandResponseValidator extends AbstractValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         return true;
     }

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
+++ b/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();


### PR DESCRIPTION
#### 1. Objective

To reduce some duplicated conditional block code in the internet banking callback controller class.
And, release an locked item quantity in an order back to the product catalog.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. _Reduce some duplicated conditional block_

2. _Correct the order cancellation behavior_

3. _Update Gateway\Validation's `validateResponse()` method visibility back to `protected`_

4. _Correct DocBlock_

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ Test checkout with some amount of product with internet banking payment, then, make a charge to be failed, and check the catalog, a product quantity should be released back.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No