### PR TITLE
Refactor & correct the callback functions behavior

### DIFF
--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -163,6 +163,18 @@ class Internetbanking extends Action
      * @param \Magento\Sales\Model\Order       $order
      * @param \Magento\Framework\Phrase|string $message
      */
+    protected function invalid(Order $order, $message)
+    {
+        $order->addStatusHistoryComment($message);
+        $order->save();
+
+        $this->messageManager->addErrorMessage($message);
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order       $order
+     * @param \Magento\Framework\Phrase|string $message
+     */
     protected function cancel(Order $order, $message)
     {
         $this->invoice($order)->cancel()->save();
@@ -171,17 +183,5 @@ class Internetbanking extends Action
         $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
 
         $this->invalid($order, $message);
-    }
-
-    /**
-     * @param \Magento\Sales\Model\Order       $order
-     * @param \Magento\Framework\Phrase|string $message
-     */
-    protected function invalid(Order $order, $message)
-    {
-        $order->addStatusHistoryComment($message);
-        $order->save();
-
-        $this->messageManager->addErrorMessage($message);
     }
 }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -172,7 +172,9 @@ class Internetbanking extends Action
      */
     protected function cancel(Order $order, $message)
     {
-        $this->invoice($order)->cancel()->save();
+        $invoice = $this->invoice($order);
+        $invoice->cancel();
+        $order->addRelatedObject($invoice);
 
         $order->registerCancellation($message)->save();
         $this->messageManager->addErrorMessage($message);

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -118,7 +118,6 @@ class Internetbanking extends Action
             return $this->redirect(self::PATH_SUCCESS);
         } catch (Exception $e) {
             $this->cancel($order, $e->getMessage());
-            $this->session->restoreQuote();
 
             return $this->redirect(self::PATH_CART);
         }

--- a/Controller/Callback/Internetbanking.php
+++ b/Controller/Callback/Internetbanking.php
@@ -179,9 +179,7 @@ class Internetbanking extends Action
     {
         $this->invoice($order)->cancel()->save();
 
-        $order->setState(Order::STATE_CANCELED);
-        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CANCELED));
-
-        $this->invalid($order, $message);
+        $order->registerCancellation($message)->save();
+        $this->messageManager->addErrorMessage($message);
     }
 }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -182,7 +182,9 @@ class Threedsecure extends Action
     protected function cancel(Order $order, $message)
     {
         if ($order->hasInvoices()) {
-            $this->invoice($order)->cancel()->save();
+            $invoice = $this->invoice($order);
+            $invoice->cancel();
+            $order->addRelatedObject($invoice);
         }
 
         $order->registerCancellation($message)->save();

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -123,7 +123,6 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_SUCCESS);
         } catch (Exception $e) {
             $this->cancel($order, $e->getMessage());
-            $this->session->restoreQuote();
 
             return $this->redirect(self::PATH_CART);
         }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -152,7 +152,7 @@ class Threedsecure extends Action
     /**
      * @param  \OmiseCharge $charge
      *
-     * @return bool
+     * @return bool|Omise\Payment\Gateway\Validator\Message\Invalid
      */
     protected function validate($charge)
     {

--- a/Gateway/Validator/CommandResponseValidator.php
+++ b/Gateway/Validator/CommandResponseValidator.php
@@ -47,7 +47,7 @@ class CommandResponseValidator extends AbstractValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         return true;
     }

--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();

--- a/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
+++ b/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
@@ -12,7 +12,7 @@ class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
      *
      * @return mixed
      */
-    public function validateResponse($data)
+    protected function validateResponse($data)
     {
         if (! isset($data['object']) || $data['object'] !== 'charge') {
             return new OmiseObjectInvalid();


### PR DESCRIPTION
#### 1. Objective

To reduce some duplicated code and correct the callback behaviors on both Internet Banking & 3-D Secure.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. Reduce some duplicated conditional block in a charge validation of Internet Banking callback
    _Use `Validator\CaptureResultValidator` instead._

1. Correct the order cancellation behavior

1. Won't `restore a quote` even payment is failed.
    _An issue on Magento caused wrong amount of quantity in the product catalog. (if execute `registerCancellation` and `restoreQuote` together, an actual quantity amount on a product catalog will be doubled)._

1. Update Gateway\Validation's `validateResponse()` method visibility back to `protected`.

1. Correct DocBlock.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ Test checkout with some amount of product with internet banking payment, then, make a charge to be failed, and check the catalog, a product quantity should be released back with the same amount that user has ordered.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No