### PR TITLE
Allow Omise none 3-D Secure account to process with the same behavior as 3-D Secure payment

### DIFF
--- a/Gateway/Response/PendingInvoiceHandler.php
+++ b/Gateway/Response/PendingInvoiceHandler.php
@@ -11,21 +11,12 @@ class PendingInvoiceHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        /** @var bool **/
-        $captured = $response['data']['captured'] ? $response['data']['captured'] : $response['data']['paid'];
+        /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
+        $payment = SubjectReader::readPayment($handlingSubject);
 
-        if ($response['data']['status'] === 'pending'
-            && $response['data']['authorized'] == false
-            && $captured == false
-            && $response['data']['authorize_uri']
-        ) {
-            /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
-            $payment = SubjectReader::readPayment($handlingSubject);
+        $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
+        $invoice->register();
 
-            $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
-            $invoice->register();
-
-            $payment->getPayment()->getOrder()->addRelatedObject($invoice);
-        }
+        $payment->getPayment()->getOrder()->addRelatedObject($invoice);
     }
 }

--- a/Gateway/Response/PendingPaymentHandler.php
+++ b/Gateway/Response/PendingPaymentHandler.php
@@ -11,18 +11,9 @@ class PendingPaymentHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        /** @var bool **/
-        $captured = $response['data']['captured'] ? $response['data']['captured'] : $response['data']['paid'];
-
-        if ($response['data']['status'] === 'pending'
-            && $response['data']['authorized'] == false
-            && $captured == false
-            && $response['data']['authorize_uri']
-        ) {
-            $stateObject = $handlingSubject['stateObject'];
-            $stateObject->setState(Order::STATE_PENDING_PAYMENT);
-            $stateObject->setStatus(Order::STATE_PENDING_PAYMENT);
-            $stateObject->setIsNotified(false);
-        }
+        $stateObject = $handlingSubject['stateObject'];
+        $stateObject->setState(Order::STATE_PENDING_PAYMENT);
+        $stateObject->setStatus(Order::STATE_PENDING_PAYMENT);
+        $stateObject->setIsNotified(false);
     }
 }

--- a/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
+++ b/Gateway/Validator/ThreeDSecureCommandResponseValidator.php
@@ -4,6 +4,8 @@ namespace Omise\Payment\Gateway\Validator;
 use Omise\Payment\Gateway\Validator\CommandResponseValidator;
 use Omise\Payment\Gateway\Validator\Message\Invalid;
 use Omise\Payment\Gateway\Validator\Message\OmiseObjectInvalid;
+use Omise\Payment\Model\Validator\Payment\AuthorizeResultValidator;
+use Omise\Payment\Model\Validator\Payment\CaptureResultValidator;
 
 class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
 {
@@ -24,12 +26,22 @@ class ThreeDSecureCommandResponseValidator extends CommandResponseValidator
 
         $captured = $data['captured'] ? $data['captured'] : $data['paid'];
 
-        // For 3-D Secure payment.
         if ($data['status'] === 'pending'
             && $data['authorized'] == false
             && $captured == false
             && $data['authorize_uri']
         ) {
+            return true;
+        }
+
+        // Try validate for none 3-D Secure account case before mark as invalid
+        if ($data['capture']) {
+            $result = (new CaptureResultValidator)->validate($data);
+        } else {
+            $result = (new AuthorizeResultValidator)->validate($data);
+        }
+
+        if ($result === true) {
             return true;
         }
 


### PR DESCRIPTION
#### 1. Objective

To prevent 1 use case that, if Omise enables 3-D Secure payment to a merchant account but merchant doesn't set `3-D Secure option` to `Yes` at the plugin side, it will breaks all of charge transactions.

This changes allow none 3-D Secure account to be able to process with the same behavior as 3-D Secure account. (plugin behavior).

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. Remove conditional block that check if charge.status is `pending` out from the validation

2. At the `ThreeDSecureCommandResponseValidator` class, recheck at the last step to make sure if that charge transaction is really failed or it's just normal charge from none 3-D Secure account.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ With Omise none 3-D Secure account, set `3-D Secure` option at the Magento payment setting page to `yes`. Then, try to make a charge as normal (both `authorize` and `authorize and capture`). It should work as normal.

#### 4. Impact of the change

No.

#### 5. Priority of change

Normal

#### 6. Additional Notes

No
