### PR TITLE
Fix that credit card payment method cannot raise an error onto the form properly.

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
         <payment>
             <omise>
                 <sandbox_status>0</sandbox_status>
-                <model>OmiseCcAdapter</model>
+                <model>OmiseAdapter</model>
             </omise>
 
             <omise_cc>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -241,4 +241,10 @@
     </virtualType>
 
     <virtualType name="OmiseCharge" type="Omise\Payment\Gateway\Http\Client\Payment"></virtualType>
+
+    <virtualType name="OmiseAdapter" type="OmiseCcAdapter">
+        <arguments>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Config::CODE</argument>
+        </arguments>
+    </virtualType>
 </config>


### PR DESCRIPTION
#### 1. Objective

To fix that credit card payment method cannot raise an error onto the form properly.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

1. Don't use the same `payment code` with 2 nodes.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.0.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. ✅ Test checkout as normal, but at the step of filling card information. Use **[failed test card](https://www.omise.co/api-testing)** to make a charge fail, and an error will be appeared at the checkout form.

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

No
