### PR TITLE
MAG1 : Use 'order increment id' as a reference in charge description instead of 'id'.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Omise.php
+++ b/src/app/code/community/Omise/Gateway/Model/Omise.php
@@ -105,7 +105,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     public function defineUserAgent()
     {
         if (! defined('OMISE_USER_AGENT_SUFFIX')) {
-            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.12 Magento/' . Mage::getVersion());
+            define('OMISE_USER_AGENT_SUFFIX', 'OmiseMagento/1.13-dev Magento/' . Mage::getVersion());
         }
     }
 

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeStrategy.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeStrategy extends Omise_Gateway_Mod
         return OmiseCharge::create(array(
             'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
-            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getOrder()->getIncrementId(),
             'capture'     => false,
             'card'        => $info->getAdditionalInformation('omise_token')
         ));

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/AuthorizeThreeDSecureStrategy.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Model_Strategies_AuthorizeThreeDSecureStrategy extends Omise
         return OmiseCharge::create(array(
             'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
-            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getOrder()->getIncrementId(),
             'capture'     => false,
             'card'        => $info->getAdditionalInformation('omise_token'),
             'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureStrategy.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Model_Strategies_CaptureStrategy extends Omise_Gateway_Model
         return OmiseCharge::create(array(
             'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
-            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getOrder()->getIncrementId(),
             'capture'     => true,
             'card'        => $info->getAdditionalInformation('omise_token')
         ));

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/CaptureThreeDSecureStrategy.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Model_Strategies_CaptureThreeDSecureStrategy extends Omise_G
         return OmiseCharge::create(array(
             'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
-            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getOrder()->getIncrementId(),
             'capture'     => true,
             'card'        => $info->getAdditionalInformation('omise_token'),
             'return_uri'  => $payment->getThreeDSecureCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))

--- a/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
+++ b/src/app/code/community/Omise/Gateway/Model/Strategies/OffsiteInternetBankingStrategy.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Model_Strategies_OffsiteInternetBankingStrategy extends Omis
         return OmiseCharge::create(array(
             'amount'      => $payment->formatAmount($info->getOrder()->getOrderCurrencyCode(), $amount),
             'currency'    => $info->getOrder()->getOrderCurrencyCode(),
-            'description' => 'Charge a card from Magento that order id is ' . $info->getData('entity_id'),
+            'description' => 'Charge a card from Magento that order id is ' . $info->getOrder()->getIncrementId(),
             'offsite'     => $info->getAdditionalInformation('offsite'),
             'return_uri'  => $payment->getCallbackUri(array('order_id' => $info->getOrder()->getIncrementId()))
         ));


### PR DESCRIPTION
#### 1. Objective

There are 2 reference id(s) in Magento system. The first one is `order id`, that will be used as a reference to lookup from DB. And another one is `order increment id` which normally will be used as a reference for merchant when check at the dashboard or order list page (searchable).

It will be more useful for merchant if Omise-Magento use `order increment id` as an order reference in the charge description instead of just `order id`.

#### 2. Description of change

- Use `order increment id` instead of 'order id' in the charge description when create a new charge.

#### 3. Quality assurance

**🔧 Environments:**

- **Magento CE**: `v1.9.2.4`, `v1.9.3.6`
- **PHP version**: `v5.6.30`

**✏️ Details:**

1. **Creates a new charge, then check at Omise Dashboard, charge detail page. You will see now Omise-Magento assigns 'order increment id' into the charge description.**

![screen shot 2560-10-19 at 2 26 06 pm](https://user-images.githubusercontent.com/2154669/31758930-ad23c2d6-b4d9-11e7-962a-ca33ef1c8802.png)
 
![screen shot 2560-10-19 at 2 26 47 pm](https://user-images.githubusercontent.com/2154669/31758947-bb1aae22-b4d9-11e7-8e0c-c4f093b2b774.png)

#### 4. Impact of the change

- Information in the charge description will be changed.

#### 5. Priority of change

Normal

#### 6. Additional Notes

No
