### PR TITLE
MAG1: Introduce WebHooks feature

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/src/app/code/community/Omise/Gateway/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -1,0 +1,8 @@
+<?php
+class Omise_Gateway_Block_Adminhtml_System_Config_Form_Field_Webhook extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+        return Mage::getUrl('omise/callback_webhook');
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Api/Event.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Event.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @property string $object
+ * @property string $id
+ * @property bool   $livemode
+ * @property string $location
+ * @property string $key
+ * @property string $created
+ * @property Object $data
+ * @see      https://www.omise.co/events-api
+ */
+class Omise_Gateway_Model_Api_Event extends Omise_Gateway_Model_Api_Object
+{
+    /**
+     * @param  string $id
+     *
+     * @return Omise_Gateway_Model_Api_Event|Omise_Gateway_Model_Api_Error
+     */
+    public function find($id)
+    {
+        try {
+            $event         = OmiseEvent::retrieve($id);
+            $event['data'] = $this->transformDataToObject($event['data']);
+
+            $this->refresh($event);
+        } catch (Exception $e) {
+            return Mage::getModel(
+                'omise_gateway/api_error',
+                array(
+                    'code'    => 'not_found',
+                    'message' => $e->getMessage(),
+                )
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  json-object $data
+     *
+     * @return Omise_Gateway_Model_Api_Object|json-object
+     */
+    protected function transformDataToObject($data)
+    {
+        switch ($data['object']) {
+            case 'charge':
+                $data = Mage::getModel('omise_gateway/api_charge')->find($data['id']);
+                break;
+        }
+
+        return $data;
+    }
+}
+

--- a/src/app/code/community/Omise/Gateway/Model/Event.php
+++ b/src/app/code/community/Omise/Gateway/Model/Event.php
@@ -1,0 +1,32 @@
+<?php
+class Omise_Gateway_Model_Event
+{
+    /**
+     * @var array  of event classes that we can handle.
+     */
+    protected $events = array();
+
+    public function __construct() {
+        $events = array(
+            'charge_complete'
+        );
+
+        foreach ($events as $event) {
+            $clazz = Mage::getModel('omise_gateway/event_' . $event);
+            $this->events[$clazz->event] = $clazz;
+        }
+    }
+
+    /**
+     * @param  Omise_Gateway_Model_Api_Event $event
+     *
+     * @return mixed
+     */
+    public function handle($event) {
+        if (! isset($this->events[$event->key])) {
+            return;
+        }
+
+        return $this->events[$event->key]->handle($event);
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
+++ b/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
@@ -1,0 +1,47 @@
+<?php
+class Omise_Gateway_Model_Event_Charge_Complete
+{
+    /**
+     * @var string  of an event name.
+     */
+    public $event = 'charge.complete';
+
+    /**
+     * There are several cases with the following payment methods
+     * that would trigger the 'charge.complete' event.
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Alipay
+     * charge data in payload:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Internet Banking
+     * charge data in payload:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Credit Card (3-D Secure)
+     * CAPTURE = FALSE
+     * charge data in payload could be one of these sets:
+     *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * CAPTURE = TRUE
+     * charge data in payload could be one of these sets:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * @param  Omise_Gateway_Model_Api_Event $event
+     *
+     * @return void
+     */
+    public function handle($event)
+    {
+        echo "COMPLETE";
+
+        return;
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -122,7 +122,10 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 'description' => 'Charge a card from Magento that order id is ' . $order->getIncrementId(),
                 'capture'     => $this->isAutoCapture() ? true : false,
                 'card'        => $payment->getAdditionalInformation('omise_token'),
-                'return_uri'  => $this->getThreeDSecureCallbackUri()
+                'return_uri'  => $this->getThreeDSecureCallbackUri(),
+                'metadata'    => array(
+                    'order_id' => $order->getIncrementId()
+                )
             )
         );
     }
@@ -148,7 +151,10 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 'description' => 'Charge a card from Magento that order id is ' . $order->getIncrementId(),
                 'capture'     => false,
                 'card'        => $payment->getAdditionalInformation('omise_token'),
-                'return_uri'  => ($this->isThreeDSecureNeeded() ? $this->getThreeDSecureCallbackUri() : null)
+                'return_uri'  => ($this->isThreeDSecureNeeded() ? $this->getThreeDSecureCallbackUri() : null),
+                'metadata'    => array(
+                    'order_id' => $order->getIncrementId()
+                )
             )
         );
 
@@ -186,7 +192,10 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 'description' => 'Charge a card from Magento that order id is ' . $order->getIncrementId(),
                 'capture'     => true,
                 'card'        => $payment->getAdditionalInformation('omise_token'),
-                'return_uri'  => ($this->isThreeDSecureNeeded() ? $this->getThreeDSecureCallbackUri() : null)
+                'return_uri'  => ($this->isThreeDSecureNeeded() ? $this->getThreeDSecureCallbackUri() : null),
+                'metadata'    => array(
+                    'order_id' => $order->getIncrementId()
+                )
             )
         );
 

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
@@ -81,7 +81,10 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
                 'currency'    => $order->getOrderCurrencyCode(),
                 'description' => 'Processing payment with Internet Banking. Magento order ID: ' . $order->getIncrementId(),
                 'offsite'     => $payment->getAdditionalInformation('offsite'),
-                'return_uri'  => $this->getCallbackUri()
+                'return_uri'  => $this->getCallbackUri(),
+                'metadata'    => array(
+                    'order_id' => $order->getIncrementId()
+                )
             )
         );
     }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
@@ -1,0 +1,8 @@
+<?php
+class Omise_Gateway_Callback_WebhookController extends Omise_Gateway_Controllers_Callback_Base
+{
+    public function indexAction()
+    {
+        echo "TEST";
+    }
+}

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
@@ -3,6 +3,21 @@ class Omise_Gateway_Callback_WebhookController extends Omise_Gateway_Controllers
 {
     public function indexAction()
     {
-        echo "TEST";
+        if (! $this->getRequest()->isPost()) {
+            return $this->norouteAction();
+        }
+
+        $payload = json_decode(file_get_contents('php://input'));
+
+        if ($payload->object !== 'event' || ! $payload->id) {
+            return $this->norouteAction();
+        }
+
+        $event = Mage::getModel('omise_gateway/api_event')->find($payload->id);
+        if ($event instanceof Omise_Gateway_Model_Api_Error) {
+            return; $this->norouteAction();
+        }
+
+        $result = Mage::getModel('omise_gateway/event')->handle($event);
     }
 }

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -11,10 +11,21 @@
                     <show_in_store>0</show_in_store>
                     <frontend_class>complex</frontend_class>
                     <fields>
+                        <webhook translate="label,comment">
+                            <label>Webhook endpoint</label>
+                            <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>
+                            <sort_order>680</sort_order>
+                            <frontend_type>label</frontend_type>
+                            <frontend_model>omise_gateway/adminhtml_system_config_form_field_webhook</frontend_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </webhook>
+
                         <omise_gateway type="group">
                             <label>Credit Card</label>
                             <comment>Powerful payment features that allows you to easily and securely accept credit/debit card payments on your store.</comment>
-                            <sort_order>680</sort_order>
+                            <sort_order>690</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
@@ -104,7 +115,7 @@
                         <omise_offsite_internet_banking type="group">
                             <label>Internet Banking</label>
                             <comment>Enables customers of a bank to easily conduct financial transactions through a bank-operated website (only available in Thailand).</comment>
-                            <sort_order>690</sort_order>
+                            <sort_order>700</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>


### PR DESCRIPTION
#### 1. Objective

There are some cases that we need to consider using WebHooks feature.

- **An order that has been placed at Magento store with `payment_action=authorize only`. Then later, merchant performs `capture` action at Omise dashboard instead.**

    Without Webhook, Magento store will never knew that that charge transaction has been _captured_ already at Omise dashboard.
    Means, we are going to need something like a callback feature to tell Magento store that that `captured` event is triggered. So Magento store can update an order status according to the result. 

- **Some offsite payments don't resolve users' payment at a time they (user) complete their payment process. For example, Internet Banking, sometimes Bank cannot response the payment result back to Omise API at a time user 'submit' their payment.**

    User will be redirected back to Magento store with `charge.status = pending` causing that an order status won't be changed to `processing` nor `failed` until merchant manual change it.

    Again, we are going to need something like a callback feature to tell Magento store that that `charge transaction` is resolved. So Magento store can update an order status either to make it as 'canceled' or 'completed'. 

#### 2. Description of change

1. Display Webhook enpoint at the payment setting page ('Omise Payment' tab).

![screen shot 2560-10-29 at 4 46 36 pm](https://user-images.githubusercontent.com/2154669/32142368-d5eda460-bcc8-11e7-8f4c-4b00c7b58809.png)

2. Handle **`charge.complete`** event.
    Note that there are 3 cases that would trigger this event.
    2.1 Alipay payment, when buyer complete the redirection flow (either success or fail).
    2.2 Internet Banking payment, when buyer complete the redirection flow (either success or fail).
    2.3 Credit Card payment (with/without auto capture), when buyer complete the redirection flow (either success or fail).

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Magento**: `v1.9.2.4`,`v1.9.3.6`
- **PHP**: `v5.6.30`

**✏️ Details:**

> Note. These tests are using [ngrok](https://ngrok.com) to expose a local server to make it be able to be set into Omise's endpoint.

**1. Setup Webhook**
At your Magento admin page, go to `Omise > Module Setting` then, scroll to the bottom most of the page. You will see `Omise Payment Gateway` tab with `Webhook`'s url.

Copy the url to set into your Omise account (https://dashboard.omise.co/test/webhooks)
![screen shot 2560-10-29 at 8 27 53 pm](https://user-images.githubusercontent.com/2154669/32144193-abcfa1f0-bce7-11e7-9ecd-776400653af6.png)

**2. Make sure that a `payment-review` order can be updated to a proper status by Webhook feature**
> To test this one, you will need to do hardcode at `src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php` file. Around line 28th and 36th, you gonna need to comment those lines out to make `offsite callback` falls into the condition that set an order status to `payment-review`.
> <img width="530" alt="screen shot 2560-11-12 at 11 27 01 pm" src="https://user-images.githubusercontent.com/2154669/32701019-15427652-c801-11e7-8165-f88db08a80ef.png">

2.1 Make charge with internet banking and set it to 'failed'.
  Your order will be set to `canceled`, invoiced status will also be set to `canceled`, and transaction's isClosed will be set to `true`.
![screen shot 2560-11-13 at 1 15 39 am](https://user-images.githubusercontent.com/2154669/32701900-47a16392-c810-11e7-9d65-a2776a5837a4.png)

2.2 Make charge with internet banking and set it to 'successful'.
  Your order will be set to `processing`, invoiced status will also be set to `paid`, and transaction's isClosed will be set to `true`.
![screen shot 2560-11-13 at 1 22 15 am](https://user-images.githubusercontent.com/2154669/32701940-1ef95912-c811-11e7-8b8d-2bfc07033032.png)

#### 4. Impact of the change

No

#### 5. Priority of change

Normal

#### 6. Additional Notes

- There are some events that this PR hasn't implemented yet (i.e. `charge.create`, `charge.capture`, `charge.reverse`, `refund.create`).
    For more information, please check https://www.omise.co/api-webhooks.