### PR TITLE
MAG2: Force plugin to use a specific API version (2015-11-17) when make a request to Omise API.

### DIFF
--- a/Gateway/Http/Client/Payment.php
+++ b/Gateway/Http/Client/Payment.php
@@ -67,6 +67,18 @@ class Payment implements ClientInterface
     }
 
     /**
+     * @param  string $version
+     *
+     * @return void
+     */
+    public function defineApiVersion($version = '2015-11-17')
+    {
+        if (! defined('OMISE_API_VERSION')) {
+            define('OMISE_API_VERSION', $version);
+        }
+    }
+
+    /**
      * Define configuration constant for Omise PHP library
      *
      * @return void
@@ -113,6 +125,7 @@ class Payment implements ClientInterface
     public function placeRequest(TransferInterface $transferObject)
     {
         $this->defineUserAgent();
+        $this->defineApiVersion();
         $this->defineApiKeys();
 
         try {


### PR DESCRIPTION
#### 1. Objective

This plugin has been developed and designed to specifically support Omise API version `2015-11-17`. 
In the other hand, this plugin could be broken if there are any breaking-changes happen in a new API version in the future. So we need to do something to prevent that coming future!

#### 2. Description of change

Luckily, we don't need to worry about that at all since we can easily tell the API at which version you want to deal (make a request / get response) with.

1. Use a certain API version to prevent any breaking-changes that may occur from a different API versions.

#### 3. Quality assurance

**🔧 Environments:**

- **Magento CE**:  `v2.1.9`.
- **PHP**: `v7.0.16`.

**✏️ Details:**

- [x] Try create a new charge to check if 'OMISE_API_VERSION' is passed through a request header.
    ![screen shot 2560-11-02 at 1 27 47 am](https://user-images.githubusercontent.com/2154669/32290591-20b9673a-bf6d-11e7-970d-2f96d1119625.png)

#### 4. Impact of the change

No.

#### 5. Priority of change

High (A new API version is coming)

#### 6. Additional Notes

No.
