### PR TITLE
Proper set Magento payment object's transaction id after create a new charge / capture an authorized charge.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -79,6 +79,8 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
             );
         }
 
+        $payment->setTransactionId($charge->id);
+
         if ($charge->isFailed()) {
             Mage::throwException(Mage::helper('payment')->__($charge->failure_message));
         }

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -52,6 +52,8 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
         );
 
         if ($charge->isAwaitPayment() || $charge->isAwaitCapture()) {
+            $payment->setIsTransactionClosed(false);
+
             return $this;
         }
 


### PR DESCRIPTION
#### 1. Objective

There is a proper way to keep record payment gateway's transaction with Magento order system which is, transaction feature.

This reference id (transaction id) will be used in various situations i.e. you can't make a refund or void without have a transaction id as a reference.

For example:
1. Invoice tab
![screen shot 2560-11-07 at 9 00 27 pm](https://user-images.githubusercontent.com/2154669/32497314-bda06c84-c3fe-11e7-8c26-4c2d5a7bfbaa.png)

2. Transaction tab
![screen shot 2560-11-07 at 9 00 29 pm](https://user-images.githubusercontent.com/2154669/32497316-bdd50c8c-c3fe-11e7-856f-c9e4b3091483.png)

If you take a look on those screenshots, you will see that this order has an invoice but transaction hasn't been recorded properly. 

#### 2. Description of change

1. Set transaction id into payment object with Omise charge id.

Then, transaction between Omise and Magento will be recorded at the order's transaction tab.
![screen shot 2560-11-07 at 9 07 41 pm](https://user-images.githubusercontent.com/2154669/32498054-255ace58-c401-11e7-8fc9-8536d7cfc75b.png)

Also, transaction id will be recorded at order history section.
![screen shot 2560-11-07 at 9 07 50 pm](https://user-images.githubusercontent.com/2154669/32498065-2df7744e-c401-11e7-9bc2-9c1918736892.png)

#### 3. Quality assurance

**🔧 Environments:**

- **Magento CE**:  `v1.9.3.6`.
- **PHP**: `v5.6.30`.

**✏️ Details:**

1. Create charge with Credit Card payment method.
- Authorize only
- Authorize and capture
- 3-D Secure payment: Authorize only
- 3-D Secure payment: Authorize and capture

2. Create charge with Internet Banking payment method.

3. Capture an authorized charge.

Transaction object will be created and attached to Magento's payment object in any of above cases.

#### 4. Impact of the change

None.

#### 5. Priority of change

Normal

#### 6. Additional Notes

None.