### PR TITLE
MAG1: Correct order state/status and payment flow behavior

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -26,15 +26,81 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
     }
 
     /**
+     * @param string $transaction_id
+     * @param string $state
      * @param string $message
      */
-    public function markAsFailed($message = null)
+    public function markAsAwaitPayment($transaction_id, $state = null, $message = null)
     {
         $this
+            ->setState(($state ? $state : Mage_Sales_Model_Order::STATE_PROCESSING), true, $message)
+            ->save();
+    }
+
+    /**
+     * @param string $transaction_id
+     * @param string $state
+     * @param string $message
+     */
+    public function markAsPaid($transaction_id, $state = null, $message = null)
+    {
+        if ($invoice = $this->getInvoice($transaction_id)) {
+            $invoice->pay();
+            $invoice->setIsPaid(true);
+
+            $this->addRelatedObject($invoice);
+        }
+
+        $payment     = $this->getPayment();
+        $transaction = $payment->getTransaction($payment->getLastTransId());
+        $transaction->closeCapture();
+
+        $this
+            ->addRelatedObject($transaction)
+            ->setState(($state ? $state : Mage_Sales_Model_Order::STATE_PROCESSING), true, $message)
+            ->save();
+    }
+
+    /**
+     * @param string $transaction_id
+     * @param string $message
+     */
+    public function markAsFailed($transaction_id, $message = null)
+    {
+        if ($invoice = $this->getInvoice($transaction_id)) {
+            $invoice->cancel();
+
+            $this->addRelatedObject($invoice);
+        }
+
+        $payment     = $this->getPayment();
+        $transaction = $payment->getTransaction($payment->getLastTransId());
+        $transaction->closeCapture();
+
+        $this
             ->registerCancellation($message, false)
+            ->addRelatedObject($transaction)
             ->save();
 
         Mage::getSingleton('core/session')->addError($message);
+    }
+
+    /**
+     * @param  string $transaction_id
+     *
+     * @return \Mage_Sales_Model_Order_Invoice
+     */
+    public function getInvoice($transaction_id)
+    {
+        foreach ($this->getInvoiceCollection() as $invoice) {
+            if ($invoice->getTransactionId() == $transaction_id) {
+                $invoice->load($invoice->getId());
+
+                return $invoice;
+            }
+        }
+
+        return;
     }
 }
 

--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -1,0 +1,40 @@
+<?php
+class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
+{
+    /**
+     * @param  string $id
+     *
+     * @return self
+     */
+    public function getOrder($id = null)
+    {
+        if ($id) {
+            return $this->loadByIncrementId($id);
+        }
+
+        return $this->loadBySession();
+    }
+
+    /**
+     * @return self
+     */
+    public function loadBySession()
+    {
+        $this->load(Mage::getSingleton('checkout/session')->getLastOrderId());
+
+        return $this;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function markAsFailed($message = null)
+    {
+        $this
+            ->registerCancellation($message, false)
+            ->save();
+
+        Mage::getSingleton('core/session')->addError($message);
+    }
+}
+

--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -53,7 +53,11 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
 
         $payment     = $this->getPayment();
         $transaction = $payment->getTransaction($payment->getLastTransId());
-        $transaction->closeCapture();
+        if ($transaction->getTxnType() === Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE) {
+            $transaction->closeCapture();
+        } else {
+            $transaction->close();
+        }
 
         $this
             ->addRelatedObject($transaction)
@@ -75,7 +79,11 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
 
         $payment     = $this->getPayment();
         $transaction = $payment->getTransaction($payment->getLastTransId());
-        $transaction->closeCapture();
+        if ($transaction->getTxnType() === Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE) {
+            $transaction->closeCapture();
+        } else {
+            $transaction->close();
+        }
 
         $this
             ->registerCancellation($message, false)

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -95,6 +95,55 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     }
 
     /**
+     * Attempt to accept a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function acceptPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::acceptPayment($payment);
+
+        $this->closeTransaction($payment);
+
+        return true;
+    }
+
+    /**
+     * Attempt to deny a payment that us under review
+     *
+     * @param  Mage_Payment_Model_Info $payment
+     *
+     * @return bool
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function denyPayment(Mage_Payment_Model_Info $payment)
+    {
+        parent::denyPayment($payment);
+
+        $this->closeTransaction($payment);
+
+        return true;
+    }
+
+    /**
+     * @param Varien_Object $payment
+     */
+    protected function closeTransaction(Varien_Object $payment)
+    {
+        $transaction = $payment->getTransaction($payment->getLastTransId());
+        if ($transaction->getTxnType() === Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE) {
+            $transaction->closeCapture();
+        } else {
+            $transaction->close();
+        }
+    }
+
+    /**
      * Execute this method when buyer makes a payment with those
      * 'redirect' payments (3-D Secure, InternetBanking, Alipay).
      *

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -239,38 +239,6 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
     }
 
     /**
-     * Attempt to accept a payment that us under review
-     *
-     * @param  Mage_Payment_Model_Info $payment
-     *
-     * @return bool
-     *
-     * @throws Mage_Core_Exception
-     */
-    public function acceptPayment(Mage_Payment_Model_Info $payment)
-    {
-        parent::acceptPayment($payment);
-
-        return true;
-    }
-
-    /**
-     * Attempt to deny a payment that us under review
-     *
-     * @param  Mage_Payment_Model_Info $payment
-     *
-     * @return bool
-     *
-     * @throws Mage_Core_Exception
-     */
-    public function denyPayment(Mage_Payment_Model_Info $payment)
-    {
-        parent::denyPayment($payment);
-
-        return true;
-    }
-
-    /**
      * Assign data to info model instance
      *
      * @param   mixed $data

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -93,7 +93,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 break;
         }
 
-        if ($charge->isAwaitPayment()) {
+        if ($charge->isAwaitPayment() || $charge->isAwaitCapture() || $charge->isSuccessful()) {
             $state_object->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
             $state_object->setStatus($order->getConfig()->getStateDefaultStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT));
             $state_object->setIsNotified(false);

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -27,6 +27,40 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
     protected $_canReviewPayment = true;
 
     /**
+     * flag if we need to run payment initialize while order place
+     *
+     * @return bool
+     */
+    public function isInitializeNeeded()
+    {
+        if ($this->isThreeDSecureNeeded()) {
+            return true;
+        }
+
+        return parent::isInitializeNeeded();
+    }
+
+    /**
+     * Instantiate state and set it to state object
+     *
+     * @param string        $payment_action
+     * @param Varien_Object $state_object
+     */
+    public function initialize($payment_action, $state_object)
+    {
+        $payment = $this->getInfoInstance();
+        $order   = $payment->getOrder();
+
+        if (! $order->canInvoice()) {
+            Mage::throwException(Mage::helper('payment')->__('Cannot create invoice'));
+        }
+
+        $state_object->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        $state_object->setStatus($order->getConfig()->getStateDefaultStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT));
+        $state_object->setIsNotified(false);
+    }
+
+    /**
      * Authorize payment
      *
      * @param  Varien_Object $payment

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -51,7 +51,6 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
         $payment = $this->getInfoInstance();
         $order   = $payment->getOrder();
 
-
         switch ($payment_action) {
             case Mage_Payment_Model_Method_Abstract::ACTION_AUTHORIZE:
                 $charge = $this->processPayment($payment, $order->getBaseTotalDue());

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
@@ -89,30 +89,6 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
     /**
      * {@inheritDoc}
      *
-     * @see app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
-     */
-    public function acceptPayment(Mage_Payment_Model_Info $payment)
-    {
-        parent::acceptPayment($payment);
-
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
-     */
-    public function denyPayment(Mage_Payment_Model_Info $payment)
-    {
-        parent::denyPayment($payment);
-
-        return true;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see app/code/core/Mage/Payment/Model/Method/Abstract.php
      */
     public function assignData($data)

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/Base.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/Base.php
@@ -8,33 +8,12 @@ abstract class Omise_Gateway_Controllers_Callback_Base extends Mage_Core_Control
     }
 
     /**
-     * @return \Mage_Sales_Model_Order
+     * @return \Omise_Gateway_Model_Order
      */
     protected function getOrder()
     {
-        if ($this->getRequest()->getParam('order_id')) {
-            return Mage::getModel('sales/order')->loadByIncrementId($this->getRequest()->getParam('order_id'));
-        }
+        $id = $this->getRequest()->getParam('order_id') ? $this->getRequest()->getParam('order_id') : null;
 
-        return Mage::getModel('sales/order')->load(Mage::getSingleton('checkout/session')->getLastOrderId());
-    }
-
-    /**
-     * @param  \Mage_Sales_Model_Order $order
-     * @param  string                  $message
-     *
-     * @return self
-     */
-    protected function markOrderAsFailed($order, $message)
-    {
-        $order->getPayment()
-            ->setPreparedMessage($message)
-            ->deny();
-
-        $order->save();
-
-        Mage::getSingleton('core/session')->addError($message);
-
-        return $this->_redirect('checkout/cart');
+        return Mage::getModel('omise_gateway/order')->getOrder($id);
     }
 }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -29,7 +29,7 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
             $order->markAsAwaitPayment(
                 $payment->getLastTransId(),
                 Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
-                Mage::helper('omise_gateway')->__('The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or up-to an hour. Please click "Accept" or "Denied" the payment manually once the result has been updated (you can check at Omise Dashboard).')
+                Mage::helper('omise_gateway')->__('The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or up-to an hour. Please click "Accept" or "Deny" the payment manually once the result has been updated (you can check at Omise Dashboard).')
             );
 
             return $this->_redirect('checkout/onepage/success');

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -25,18 +25,33 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
             return $this->_redirect('checkout/cart');
         }
 
-        // TODO: Sometimes Internet Banking will return status 'pending' instead of 'successful'
-        //       So, we are going to need to have this condition here, to keep order as 'pending review'.
-        if ($charge->isSuccessful()) {
-            $payment->accept();
-            $order->save();
+        if ($charge->isAwaitPayment()) {
+            $order->markAsAwaitPayment(
+                $payment->getLastTransId(),
+                Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+                Mage::helper('omise_gateway')->__('The payment has been processing.<br/>Due to the Bank process, this might takes a few seconds or up-to an hour. Please click "Accept" or "Denied" the payment manually once the result has been updated (you can check at Omise Dashboard).')
+            );
 
             return $this->_redirect('checkout/onepage/success');
         }
 
-        return $this->markOrderAsFailed(
-            $order,
-            $this->__('The payment was invalid, ' . $charge->failure_message . ' (' . $charge->failure_code . ').')
+        if ($charge->isSuccessful()) {
+            $invoice = $order->getInvoice($payment->getLastTransId());
+
+            $order->markAsPaid(
+                $payment->getLastTransId(),
+                Mage_Sales_Model_Order::STATE_PROCESSING,
+                Mage::helper('omise_gateway')->__('An amount %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
+            );
+
+            return $this->_redirect('checkout/onepage/success');
+        }
+
+        $order->markAsFailed(
+            $payment->getLastTransId(),
+            $this->__('The payment was invalid, %s (%s)', $charge->failure_message, $charge->failure_code)
         );
+
+        return $this->_redirect('checkout/cart');
     }
 }

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -10,6 +10,7 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
             Mage::getSingleton('core/session')->addError(
                 $this->__('3-D Secure validation was invalid, cannot retrieve your payment information. Please contact our support to confirm the payment.')
             );
+
             $this->_redirect('checkout/cart');
             return;
         }
@@ -24,16 +25,33 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
             return $this->_redirect('checkout/cart');
         }
 
-        if ($charge->isAwaitCapture() || $charge->isSuccessful()) {
-            $payment->accept();
-            $order->save();
+        if ($charge->isAwaitCapture()) {
+            $order->markAsAwaitPayment(
+                $payment->getLastTransId(),
+                Mage_Sales_Model_Order::STATE_PROCESSING,
+                Mage::helper('omise_gateway')->__('Authorized amount of %s.', $order->getBaseCurrency()->formatTxt($order->getBaseTotalDue()))
+            );
 
             return $this->_redirect('checkout/onepage/success');
         }
 
-        return $this->markOrderAsFailed(
-            $order,
-            $this->__('The payment was invalid, ' . $charge->failure_message . ' (' . $charge->failure_code . ').')
+        if ($charge->isSuccessful()) {
+            $invoice = $order->getInvoice($payment->getLastTransId());
+
+            $order->markAsPaid(
+                $payment->getLastTransId(),
+                Mage_Sales_Model_Order::STATE_PROCESSING,
+                Mage::helper('omise_gateway')->__('Captured amount of %s online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
+            );
+
+            return $this->_redirect('checkout/onepage/success');
+        }
+
+        $order->markAsFailed(
+            $payment->getLastTransId(),
+            $this->__('The payment was invalid, %s (%s)', $charge->failure_message, $charge->failure_code)
         );
+
+        return $this->_redirect('checkout/cart');
     }
 }


### PR DESCRIPTION
#### 1. Objective

There are various ways to handle payment flow and order status behavior in Magento world.
After tons of researches have been passed on a possibility to proper handle a checkout flow. From the begin, at placing order step to the end, invoiced an order (there are still some more, 'shipped order', 'completed' for example. But we aren't gonna mention here since it's not payment related).

So, this PR aims to clean up, and correcting behavior of payment flow and order status.

#### 2. Description of change

From all payment methods that we have, we can separate them and focus on one by one to see their behaviors as follows:

**# Credit Card Payment**
From the checkout step until completed payment process, order state/status will be set to either `processing` or `pending` depends on what you've set in the payment setting page.
  
But note that:
For payment action `auth only`:
- A transaction[type: AUTH] object will be created with `isClosed = false`.

For payment action `auth and capture`:
- A transaction[type: CAPTURE] object will be created with `isClosed = true`.
- An invoice object will be created with `status = paid`.

..

**# Credit Card 3-D Secure Payment**
1. After place an order at the checkout step, an order state/status will be set to `pending-payment`
2. Then, once buyer finish his/her 3-D Secure process, they will be redirected back to merchant's store. 
3. Here, order state/status will be set to either `processing/pending` (depends on your setting) if payment is successful or `canceled` if payment is failed.

Also note that:
For payment action `auth only`:
- A transaction[type: AUTH] object will be created with `isClosed = false` and stay `false` even after finish 3-D Secure process.

For payment action `auth and capture`:
- A transaction[type: CAPTURE] object will be created with `isClosed = false` at first, then `isClosed = true` when finish 3-D Secure process.
- An invoice object will be created with `status = pending`, then `status` will be either `paid` or `canceled` depends on the 3-D Secure result.

..

**# Internet Banking Payment**

1. After place an order at the checkout step, an order state/status will be set to `pending-payment`
2. Then, once buyer finish his/her internet banking process, they will be redirected back to merchant's store. 
3. Here, order state/status will be set to either `processing/pending` (depends on your setting) if payment is successful, `canceled` if payment is failed or `payment-review` if payment is still in process.

> ⚠️ IMPORTANT: For `payment-review` state/status.
> This case might happen sometimes due to bank(s) process, it might take a little bit time before resolve the payment and return us a result.
> So in this case, order state/status will be set to `payment-review`. And that will allow merchant to review the payment result manually at Omise Dashboard before either 'accept' or 'denied' that payment (note that Webhook feature is coming and it will make this process to be automatic).

Also note that:
- A transaction[type: ORDER] object will be created with `isClosed = false` and turns to `isClosed = true` once buyer finish their internet banking process.
- An invoice object will be created with `status = pending`, and turns to `status = processing` once buyer finish their internet banking process.

> Note that **Alipay Payment** (coming feature) will behave the same as **Internet Banking Payment**

#### 3. Quality assurance

**🔧 Environments:**

- **Magento CE**:  `v1.9.3.6`
- **PHP**: `v5.6.30`

**✏️ Details:**

**Internet Banking Payment**
Make sure that invoice and transaction objects are created properly when place an order with internet banking payment.

_BEFORE USER COMPLETE INTERNET BANKING PROCESS_
- An **invoice object** will be created at this step, with `status=pending`.
- A **transaction object** will be created at this step, with `isClosed=false` and `type=ORDER`.
- An **order object**'s state/status will be set to `pending-payment`.
![tab: order information](https://user-images.githubusercontent.com/2154669/32696655-69c46c86-c7b0-11e7-8954-4b6185a61786.png)
![tab: invoice](https://user-images.githubusercontent.com/2154669/32696676-f9ff0306-c7b0-11e7-83a5-29bb59bc907c.png)
![tab: transaction](https://user-images.githubusercontent.com/2154669/32696677-fa3b1044-c7b0-11e7-8c95-5dcc49d9ef75.png)

_SUCCESSFUL CASE_
- Invoice's status will be set to `paid`.
- Transaction's isClosed will be set to `true`.
- An **order object**'s state/status will be set to `processing`.
![006](https://user-images.githubusercontent.com/2154669/32696731-75d29b68-c7b2-11e7-86f8-e7bf3cb7c3da.png)

 _FAILED CASE_
- Invoice's status will be set to `canceled`.
- Transaction's isClosed will be set to `true`.
- An **order object**'s state/status will be set to `processing` then `canceled`.
![007](https://user-images.githubusercontent.com/2154669/32696748-fe2f010e-c7b2-11e7-8fe8-a4bc3fd0e6bf.png)

_PENDING CASE_
- Invoice's status will still stay with `pending`.
- Transaction's isClosed will still stay with `false`.
- An **order object**'s state/status will be set to `payment-review`.
![008](https://user-images.githubusercontent.com/2154669/32696786-d0af88ec-c7b3-11e7-94c9-e3d1ca45d1c5.png)

> Note that if you click `Accept Payment`, it goes to **SUCCESSFUL CASE**. In the other hand, `Deny Payment` will go to **FAILED CASE**.

**Credit Card Payment**
Make sure that invoice and transaction objects are created properly when place an order with credit card payment (without 3-D Secure).

**3-D Secure Payment**
Make sure that invoice and transaction objects are created properly when place an order with 3-D Secure payment.

_Payment Action: Auth only. PLACE ORDER_
When you first create charge with 3-D Secure payment method
- A **transaction object** will be created at this step, with `isClosed=false` and `type=AUTH`.
- An **order object**'s state/status will be set to `pending-payment`.
![009](https://user-images.githubusercontent.com/2154669/32697303-1869120a-c7c0-11e7-988d-8368ff1e54a3.png)
![010](https://user-images.githubusercontent.com/2154669/32697305-2191019e-c7c0-11e7-9aff-f298f54b0490.png)

_Payment Action: Auth only. SUCCESSFUL CASE_
- Transaction's isClosed still stay as `false`.
- An **order object**'s state/status will be set to `processing`.
![011](https://user-images.githubusercontent.com/2154669/32697335-e3546ea6-c7c0-11e7-822e-e3ae9264fbbe.png)

_Payment Action: Auth only. FAILED CASE_
- Transaction's isClosed will be set to `true`.
- An **order object**'s state/status will be set to `canceled`.
![012](https://user-images.githubusercontent.com/2154669/32697394-2d3b81c0-c7c2-11e7-8cea-55acfc48c4ef.png)

_Payment Action: Auth and Capture. PLACE ORDER_
- An **invoice object** will be created at this step, with `status=pending`.
- A **transaction object** will be created at this step, with `isClosed=false` and `type=CAPTURE`.
- An **order object**'s state/status will be set to `pending-payment`.
![014](https://user-images.githubusercontent.com/2154669/32697464-519bb9ee-c7c3-11e7-95c5-cc7463f7c7a4.png)
![015](https://user-images.githubusercontent.com/2154669/32697463-51680c0c-c7c3-11e7-8e52-5bf7066fc429.png)
![013](https://user-images.githubusercontent.com/2154669/32697465-51cfcc7a-c7c3-11e7-959b-6304d1bcbf46.png)

_Payment Action: Auth and Capture. SUCCESSFUL CASE_
- Invoice's status will be set to `paid`.
- Transaction's isClosed will be set to `true`.
- An **order object**'s state/status will be set to `processing`.
![016](https://user-images.githubusercontent.com/2154669/32697506-7e3f2eda-c7c4-11e7-8684-83d5c3ef002c.png)

_Payment Action: Auth and Capture. FAILED CASE_
- Invoice's status will be set to `canceled`.
- Transaction's isClosed will be set to `true`.
- An **order object**'s state/status will be set to `processing` then `canceled`.
![017](https://user-images.githubusercontent.com/2154669/32697532-f8565e82-c7c4-11e7-9a22-fb105d6c0e09.png)

#### 4. Impact of the change

None.

#### 5. Priority of change

Normal

#### 6. Additional Notes

None.