### PR TITLE
Fix that case-sensitive file name cannot be loaded in some servers.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Controller/Base.php
+++ b/src/app/code/community/Omise/Gateway/Controller/Base.php
@@ -1,5 +1,5 @@
 <?php
-abstract class Omise_Gateway_Controllers_Callback_Base extends Mage_Core_Controller_Front_Action
+abstract class Omise_Gateway_Controller_Base extends Mage_Core_Controller_Front_Action
 {
     protected function _construct()
     {

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -1,5 +1,5 @@
 <?php
-class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Omise_Gateway_Controllers_Callback_Base
+class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Omise_Gateway_Controller_Base
 {
     public function indexAction()
     {

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -1,5 +1,5 @@
 <?php
-class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gateway_Controllers_Callback_Base
+class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gateway_Controller_Base
 {
     public function indexAction()
     {

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/WebhookController.php
@@ -1,5 +1,5 @@
 <?php
-class Omise_Gateway_Callback_WebhookController extends Omise_Gateway_Controllers_Callback_Base
+class Omise_Gateway_Callback_WebhookController extends Omise_Gateway_Controller_Base
 {
     public function indexAction()
     {


### PR DESCRIPTION
#### 1. Objective

![screen shot 2560-11-15 at 4 21 11 pm](https://user-images.githubusercontent.com/2154669/32828217-0a436f96-ca21-11e7-9d7b-0984fd093e05.png)

From `lib/Varien/Autoload.php` (above screenshot)
Because Magento's autoload class turns every classes to be 'first-capital-letter' before include it at the boot-up process causing some servers that strict with case-sensitive cannot load those classes properly and it breaks the plugin (at callback validation step).

For example: class `omise_gateway_controllers_callback_base`.
1. Magento does `ucwords(str_replace('_', ' ', $class))`. So we get:
> **output**: Omise Gateway Controllers Callback Base

2. Then, Magento replaces space with slash (`/`). So we get:
> **output**: `Omise/Gateway/Controllers/Callback/Base`

3. Then, suffix with `.php` and include it. So we get:
> **output**: `include Omise/Gateway/Controllers/Callback/Base.php`

At this step, Magento cannot find `Controllers` from plugin properly (because we have only `controllers`).

**Related information**:
Related issue(s): #99

#### 2. Description of change

1. Separate a custom controller to new folder 'Controller'.

Note that Magento recommended developer to have `controllers` to contain controller-like classes.
But then, I went through Magento core code and saw that they also have `Controller` folder to house those abstract controller classes.

![screen shot 2560-11-15 at 4 30 27 pm](https://user-images.githubusercontent.com/2154669/32828700-7b9f0956-ca22-11e7-8d0a-f69bc2fbd1a7.png)

So, this idea came from those implementations.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. Test place order with credit card 3-D Secure payment and it should work properly (no `error 500` at any steps)

#### 4. Impact of the change

No

#### 5. Priority of change

High.

#### 6. Additional Notes

No