### PR TITLE
MAG2: Introduce Webhook feature

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Omise\Payment\Block\Adminhtml\System\Config\Form\Field;
+
+class Webhook extends \Magento\Config\Block\System\Config\Form\Field
+{
+    /**
+     * @var \Magento\Framework\Url
+     */
+    protected $urlHelper;
+
+    /**
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Magento\Framework\Url                  $urlHelper
+     * @param array                                   $data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Url $urlHelper,
+        array $data = []
+    ) {
+        $this->urlHelper = $urlHelper;
+        parent::__construct($context, $data);
+    }
+
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        return $this->urlHelper->getRouteUrl('omise/callback/webhook', ['_secure' => true]);
+    }
+}

--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -2,7 +2,12 @@
 
 namespace Omise\Payment\Block\Adminhtml\System\Config\Form\Field;
 
-class Webhook extends \Magento\Config\Block\System\Config\Form\Field
+use Magento\Backend\Block\Template\Context;
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Url;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class Webhook extends Field
 {
     /**
      * @var \Magento\Framework\Url
@@ -15,15 +20,20 @@ class Webhook extends \Magento\Config\Block\System\Config\Form\Field
      * @param array                                   $data
      */
     public function __construct(
-        \Magento\Backend\Block\Template\Context $context,
-        \Magento\Framework\Url $urlHelper,
-        array $data = []
+        Context $context,
+        Url     $urlHelper,
+        array   $data = []
     ) {
         $this->urlHelper = $urlHelper;
         parent::__construct($context, $data);
     }
 
-    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    /**
+     * @param  \Magento\Framework\Data\Form\Element\AbstractElement $element
+     *
+     * @return string
+     */
+    protected function _getElementHtml(AbstractElement $element)
     {
         return $this->urlHelper->getRouteUrl('omise/callback/webhook', ['_secure' => true]);
     }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -54,12 +54,6 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if ($order->getState() !== Order::STATE_PENDING_PAYMENT) {
-            $this->invalid($order, __('Invalid order status, cannot validate the payment. Please contact our support if you have any questions.'));
-
-            return $this->redirect(self::PATH_CART);
-        }
-
         if (! $payment = $order->getPayment()) {
             $this->invalid($order, __('Cannot retrieve a payment detail from the request. Please contact our support if you have any questions.'));
 
@@ -77,6 +71,15 @@ class Threedsecure extends Action
             $this->session->restoreQuote();
 
             return $this->redirect(self::PATH_CART);
+        }
+
+        if ($order->getState() !== Order::STATE_PENDING_PAYMENT) {
+            if ($order->isCanceled()) {
+                $this->messageManager->addErrorMessage(__('This order has been canceled. Please contact our support if you have any questions.'));
+                return $this->redirect(self::PATH_CART);
+            }
+
+            return $this->redirect(self::PATH_SUCCESS);
         }
 
         try {

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -1,0 +1,37 @@
+<?php
+namespace Omise\Payment\Controller\Callback;
+
+use Exception;
+use Omise\Payment\Model\Config\Cc as Config;
+
+class Webhook extends \Magento\Framework\App\Action\Action
+{
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $session;
+
+    /**
+     * @var \Omise\Payment\Model\Config\Cc
+     */
+    protected $config;
+
+    public function __construct(
+        \Magento\Framework\App\Action\Context $context,
+        \Magento\Checkout\Model\Session $session,
+        Config  $config
+    ) {
+        parent::__construct($context);
+
+        $this->session = $session;
+        $this->config  = $config;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        
+    }
+}

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -1,30 +1,38 @@
 <?php
+
 namespace Omise\Payment\Controller\Callback;
 
-use Exception;
-use Omise\Payment\Model\Config\Cc as Config;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Omise\Payment\Model\Omise;
+use Omise\Payment\Model\Api\Event;
+use Omise\Payment\Model\Api\Error;
 
-class Webhook extends \Magento\Framework\App\Action\Action
+class Webhook extends Action
 {
     /**
-     * @var \Magento\Checkout\Model\Session
+     * @var Omise\Payment\Model\Omise
      */
-    protected $session;
+    protected $omise;
 
     /**
-     * @var \Omise\Payment\Model\Config\Cc
+     * @var \Omise\Payment\Model\Api\Event
      */
-    protected $config;
+    protected $event;
 
     public function __construct(
-        \Magento\Framework\App\Action\Context $context,
-        \Magento\Checkout\Model\Session $session,
-        Config  $config
+        Context $context,
+        Omise   $omise,
+        Event   $event
     ) {
+        $this->omise = $omise;
+        $this->event = $event;
+
         parent::__construct($context);
 
-        $this->session = $session;
-        $this->config  = $config;
+        $this->omise->defineUserAgent();
+        $this->omise->defineApiVersion();
+        $this->omise->defineApiKeys();
     }
 
     /**
@@ -32,6 +40,25 @@ class Webhook extends \Magento\Framework\App\Action\Action
      */
     public function execute()
     {
-        
+         if (! $this->getRequest()->isPost()) {
+            // TODO: Only accept for POST verb.
+            return;
+        }
+
+        $payload = json_decode(file_get_contents('php://input'));
+
+        if ($payload->object !== 'event' || ! $payload->id) {
+            // TODO: Handle in case of improper response structure.
+            return;
+        }
+
+        $event = $this->event->find($payload->id);
+
+        if ($event instanceof Error) {
+            // TODO: Handle in case can't retrieve an event object from '$payload->id'.
+            return;
+        }
+
+        var_dump($event); exit;
     }
 }

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -5,8 +5,9 @@ namespace Omise\Payment\Controller\Callback;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Omise\Payment\Model\Omise;
-use Omise\Payment\Model\Api\Event;
-use Omise\Payment\Model\Api\Error;
+use Omise\Payment\Model\Event;
+use Omise\Payment\Model\Api\Event as ApiEvent;
+use Omise\Payment\Model\Api\Error as ApiError;
 
 class Webhook extends Action
 {
@@ -21,9 +22,9 @@ class Webhook extends Action
     protected $event;
 
     public function __construct(
-        Context $context,
-        Omise   $omise,
-        Event   $event
+        Context  $context,
+        Omise    $omise,
+        ApiEvent $event
     ) {
         $this->omise = $omise;
         $this->event = $event;
@@ -54,11 +55,11 @@ class Webhook extends Action
 
         $event = $this->event->find($payload->id);
 
-        if ($event instanceof Error) {
+        if ($event instanceof ApiError) {
             // TODO: Handle in case can't retrieve an event object from '$payload->id'.
             return;
         }
 
-        var_dump($event); exit;
+        $result = (new Event)->handle($event);
     }
 }

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -13,6 +13,10 @@ class Webhook extends Action
      */
     protected $event;
 
+    /**
+     * @param \Magento\Framework\App\Action\Context $context
+     * @param \Omise\Payment\Model\Event            $event
+     */
     public function __construct(Context $context, Event $event)
     {
         $this->event = $event;

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -5,7 +5,6 @@ namespace Omise\Payment\Controller\Callback;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Omise\Payment\Model\Event;
-use Omise\Payment\Model\Api\Error as ApiError;
 
 class Webhook extends Action
 {
@@ -26,7 +25,7 @@ class Webhook extends Action
      */
     public function execute()
     {
-         if (! $this->getRequest()->isPost()) {
+        if (! $this->getRequest()->isPost()) {
             // TODO: Only accept for POST verb.
             return;
         }
@@ -38,13 +37,6 @@ class Webhook extends Action
             return;
         }
 
-        $event = $this->event->find($payload->id);
-
-        if ($event instanceof ApiError) {
-            // TODO: Handle in case can't retrieve an event object from '$payload->id'.
-            return;
-        }
-
-        $result = $this->event->handle($event);
+        $this->event->handle($payload);
     }
 }

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -4,36 +4,21 @@ namespace Omise\Payment\Controller\Callback;
 
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
-use Omise\Payment\Model\Omise;
 use Omise\Payment\Model\Event;
-use Omise\Payment\Model\Api\Event as ApiEvent;
 use Omise\Payment\Model\Api\Error as ApiError;
 
 class Webhook extends Action
 {
     /**
-     * @var Omise\Payment\Model\Omise
-     */
-    protected $omise;
-
-    /**
-     * @var \Omise\Payment\Model\Api\Event
+     * @var \Omise\Payment\Model\Event
      */
     protected $event;
 
-    public function __construct(
-        Context  $context,
-        Omise    $omise,
-        ApiEvent $event
-    ) {
-        $this->omise = $omise;
+    public function __construct(Context $context, Event $event)
+    {
         $this->event = $event;
 
         parent::__construct($context);
-
-        $this->omise->defineUserAgent();
-        $this->omise->defineApiVersion();
-        $this->omise->defineApiKeys();
     }
 
     /**
@@ -60,6 +45,6 @@ class Webhook extends Action
             return;
         }
 
-        $result = (new Event)->handle($event);
+        $result = $this->event->handle($event);
     }
 }

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -23,6 +23,11 @@ class PaymentDataBuilder implements BuilderInterface
     const DESCRIPTION = 'description';
 
     /**
+     * @var string
+     */
+    const METADATA = 'metadata';
+
+    /**
      * @param \Omise\Payment\Helper\OmiseHelper $omiseHelper
      */
     public function __construct(OmiseHelper $omiseHelper)
@@ -44,6 +49,9 @@ class PaymentDataBuilder implements BuilderInterface
             self::AMOUNT      => $this->omiseHelper->omiseAmountFormat($order->getCurrencyCode(), $order->getGrandTotalAmount()),
             self::CURRENCY    => $order->getCurrencyCode(),
             self::DESCRIPTION => 'Magento 2 Order id ' . $order->getOrderIncrementId(),
+            self::METADATA    => [
+                'order_id' => $order->getOrderIncrementId()
+            ]
         ];
     }
 }

--- a/Model/Api/Charge.php
+++ b/Model/Api/Charge.php
@@ -88,6 +88,16 @@ class Charge extends Object
     }
 
     /**
+     * @param  string $field
+     *
+     * @return mixed
+     */
+    public function getMetadata($field)
+    {
+        return (! is_null($this->metadata) && isset($this->metadata[$field])) ? $this->metadata[$field] : null;
+    }
+
+    /**
      * @return bool
      */
     public function isAuthorized()

--- a/Model/Api/Event.php
+++ b/Model/Api/Event.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omise\Payment\Model\Api;
+
+use Exception;
+use OmiseEvent;
+
+/**
+ * @property string $object
+ * @property string $id
+ * @property bool   $livemode
+ * @property string $location
+ * @property string $key
+ * @property string $created
+ * @property Object $data
+ * @see      https://www.omise.co/events-api
+ */
+class Event extends Object
+{
+    /**
+     * @param  string $id
+     *
+     * @return \Omise\Payment\Model\Api\Error|self
+     */
+    public function find($id)
+    {
+        try {
+            $event         = OmiseEvent::retrieve($id);
+            $event['data'] = $this->transformDataToObject($event['data']);
+            $this->refresh($event);
+        } catch (Exception $e) {
+            return new Error([
+                'code'    => 'not_found',
+                'message' => $e->getMessage()
+            ]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  json-object $data
+     *
+     * @return \Omise\Payment\Model\Api\Error|json-object
+     */
+    protected function transformDataToObject($data)
+    {
+        switch ($data['object']) {
+            case 'charge':
+                $data = (new Charge)->find($data['id']);
+                break;
+        }
+
+        return $data;
+    }
+}

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Omise\Payment\Model;
+
+use Omise\Payment\Model\Event\Charge\Complete as EventChargeComplete;
+
+class Event
+{
+    /**
+     * @var array  of event classes that we can handle.
+     */
+    protected $events = [
+        EventChargeComplete::CODE => EventChargeComplete::class
+    ];
+
+    /**
+     * @param  Omise_Gateway_Model_Api_Event $event
+     *
+     * @return mixed
+     */
+    public function handle($event)
+    {
+        if (! isset($this->events[$event->key])) {
+            return;
+        }
+
+        return (new $this->events[$event->key])->handle($event);
+    }
+}

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -2,6 +2,9 @@
 
 namespace Omise\Payment\Model;
 
+use Omise\Payment\Model\Omise;
+use Omise\Payment\Model\Order;
+use Omise\Payment\Model\Api\Event as ApiEvent;
 use Omise\Payment\Model\Event\Charge\Complete as EventChargeComplete;
 
 class Event
@@ -14,16 +17,44 @@ class Event
     ];
 
     /**
-     * @param  Omise_Gateway_Model_Api_Event $event
+     * @var \Omise\Payment\Model\Api\Event
+     */
+    protected $apiEvent;
+
+    public function __construct(
+        Omise    $omise,
+        Order    $order,
+        ApiEvent $apiEvent
+    ) {
+        $this->order    = $order;
+        $this->apiEvent = $apiEvent;
+
+        $omise->defineUserAgent();
+        $omise->defineApiVersion();
+        $omise->defineApiKeys();
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return \Omise\Payment\Model\Api\Event|\Omise\Payment\Model\Api\Error
+     */
+    public function find($id)
+    {
+        return $this->apiEvent->find($id);
+    }
+
+    /**
+     * @param  \Omise\Payment\Model\Api\Event $event
      *
      * @return mixed
      */
-    public function handle($event)
+    public function handle(ApiEvent $event)
     {
         if (! isset($this->events[$event->key])) {
             return;
         }
 
-        return (new $this->events[$event->key])->handle($event);
+        return (new $this->events[$event->key])->handle($event, $this->order);
     }
 }

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -21,6 +21,11 @@ class Event
      */
     protected $apiEvent;
 
+    /**
+     * @param \Omise\Payment\Model\Omise     $omise
+     * @param \Omise\Payment\Model\Order     $order
+     * @param \Omise\Payment\Model\Api\Event $apiEvent
+     */
     public function __construct(
         Omise    $omise,
         Order    $order,

--- a/Model/Event.php
+++ b/Model/Event.php
@@ -35,23 +35,21 @@ class Event
     }
 
     /**
-     * @param  string $id
-     *
-     * @return \Omise\Payment\Model\Api\Event|\Omise\Payment\Model\Api\Error
-     */
-    public function find($id)
-    {
-        return $this->apiEvent->find($id);
-    }
-
-    /**
-     * @param  \Omise\Payment\Model\Api\Event $event
+     * @param  Object $payload
      *
      * @return mixed
      */
-    public function handle(ApiEvent $event)
+    public function handle($payload)
     {
+        $event = $this->apiEvent->find($payload->id);
+
+        if (! $event instanceof ApiEvent) {
+            // TODO: Handle in case can't retrieve an event object from '$payload->id'.
+            return;
+        }
+
         if (! isset($this->events[$event->key])) {
+            // TODO: Handle in case can't retrieve an event object from '$payload->id'.
             return;
         }
 

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Omise\Payment\Model\Event\Charge;
+
+class Complete
+{
+    /**
+     * @var string  of an event name.
+     */
+    const CODE = 'charge.complete';
+
+    /**
+     * There are several cases with the following payment methods
+     * that would trigger the 'charge.complete' event.
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Alipay
+     * charge data in payload:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Internet Banking
+     * charge data in payload:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+     * Credit Card (3-D Secure)
+     * CAPTURE = FALSE
+     * charge data in payload could be one of these sets:
+     *     [status: 'pending'], [authorized: 'true'], [paid: 'false']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * CAPTURE = TRUE
+     * charge data in payload could be one of these sets:
+     *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
+     *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
+     *
+     * @param  Omise_Gateway_Model_Api_Event $event
+     *
+     * @return void
+     */
+    public function handle($event)
+    {
+        echo "charge.complete event is handled";
+        exit;
+    }
+}

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -2,6 +2,12 @@
 
 namespace Omise\Payment\Model\Event\Charge;
 
+use Magento\Sales\Model\Order as MagentoOrder;
+use Magento\Sales\Model\Order\Payment\Transaction;
+use Omise\Payment\Model\Order;
+use Omise\Payment\Model\Api\Event as ApiEvent;
+use Omise\Payment\Model\Api\Charge as ApiCharge;
+
 class Complete
 {
     /**
@@ -37,13 +43,65 @@ class Complete
      *     [status: 'successful'], [authorized: 'true'], [paid: 'true']
      *     [status: 'failed'], [authorized: 'false'], [paid: 'false']
      *
-     * @param  Omise_Gateway_Model_Api_Event $event
+     * @param  Omise\Payment\Model\Api\Event $event
+     * @param  Omise\Payment\Model\Order     $order
      *
      * @return void
      */
-    public function handle($event)
+    public function handle(ApiEvent $event, Order $order)
     {
-        echo "charge.complete event is handled";
-        exit;
+        $charge = $event->data;
+
+        if (! $charge instanceof ApiCharge || is_null($charge->getMetadata('order_id'))) {
+            // TODO: Handle in case of improper response structure.
+            return;
+        }
+
+        $order = $order->loadByIncrementId($charge->getMetadata('order_id'));
+        if (! $order->getId()) {
+            // TODO: Handle in case of improper response structure.
+            return;
+        }
+
+        if (! $payment = $order->getPayment()) {
+            // TODO: Handle in case of improper response structure.
+            return;
+        }
+
+        if ($order->isPaymentReview()) {
+            // Update order state and status.
+            $order->setState(MagentoOrder::STATE_PROCESSING);
+            $order->setStatus($order->getConfig()->getStateDefaultStatus(MagentoOrder::STATE_PROCESSING));
+
+            if ($charge->isSuccessful()) {
+                $invoice = $order->getInvoiceCollection()->getLastItem();
+                $invoice->setTransactionId($charge->id)->pay()->save();
+
+                // Add transaction.
+                $payment->addTransactionCommentsToOrder(
+                    $payment->addTransaction(Transaction::TYPE_PAYMENT, $invoice),
+                    __(
+                        'Amount of %1 has been paid via Omise Payment Gateway',
+                        $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal())
+                    )
+                );
+            }
+
+            if ($charge->isAwaitCapture()) {
+                $payment->addTransactionCommentsToOrder(
+                    $payment->addTransaction(Transaction::TYPE_AUTH),
+                    $payment->prependMessage(
+                        __(
+                            'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
+                            $order->getBaseCurrency()->formatTxt($order->getTotalDue())
+                        )
+                    )
+                );
+            }
+
+            $order->save();
+        }
+
+        return;
     }
 }

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -68,7 +68,7 @@ class Complete
             return;
         }
 
-        if ($order->isPaymentReview()) {
+        if ($order->isPaymentReview() || $order->getState() === Order::STATE_PENDING_PAYMENT) {
             // Update order state and status.
             $order->setState(MagentoOrder::STATE_PROCESSING);
             $order->setStatus($order->getConfig()->getStateDefaultStatus(MagentoOrder::STATE_PROCESSING));

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -117,7 +117,6 @@ class Complete
 
                 $order->save();
             }
-
         }
 
         return;

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Omise\Payment\Model;
+
+use Magento\Sales\Model\Order as MagentoOrder;
+
+class Order
+{
+    /** 
+     * @var \Magento\Sales\Model\Order
+     */
+    protected $order;
+
+    public function __construct(MagentoOrder $order)
+    {
+        $this->order = $order;
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return self
+     */
+    public function loadByIncrementId($id)
+    {
+        return $this->order->loadByIncrementId($id);
+    }
+}

--- a/Model/Order.php
+++ b/Model/Order.php
@@ -11,6 +11,9 @@ class Order
      */
     protected $order;
 
+    /**
+     * @param \Magento\Sales\Model\Order $order
+     */
     public function __construct(MagentoOrder $order)
     {
         $this->order = $order;
@@ -19,7 +22,7 @@ class Order
     /**
      * @param  string $id
      *
-     * @return self
+     * @return \Magento\Sales\Model\Order
      */
     public function loadByIncrementId($id)
     {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -29,27 +29,32 @@
                     <label>Secret key for live</label>
                     <comment>The "Live" mode secret key can be found in Omise Dashboard.</comment>
                 </field>
+                <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Webhook endpoint</label>
+                    <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>
+                    <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook</frontend_model>
+                </field>
 
-                <group id="omise_cc" translate="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+                <group id="omise_cc" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Credit Card Solution</label>
                     <comment>Powerful payment features that allows you to easily and securely accept credit/debit card payments on your store.</comment>
-                    <field id="active" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Enable/Disable</label>
                         <comment>Enable Omise Credit Card Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_cc/active</config_path>
                     </field>
-                    <field id="payment_action" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <field id="payment_action" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Payment Action</label>
                         <source_model>Magento\Authorizenet\Model\Source\PaymentAction</source_model>
                         <config_path>payment/omise_cc/payment_action</config_path>
                     </field>
-                    <field id="title" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="title" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_cc/title</config_path>
                     </field>
-                    <field id="3ds" translate="label comment" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="3ds" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>3-D Secure support</label>
                         <comment>Enable or disable 3-D Secure for the account. (Japan-based accounts are not eligible for the service.).</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -57,16 +62,16 @@
                     </field>
                 </group>
 
-                <group id="omise_offsite_internetbanking" translate="label" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
+                <group id="omise_offsite_internetbanking" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Internet Banking Solution</label>
                     <comment>Enables customers of a bank to easily conduct financial transactions through a bank-operated website (only available in Thailand).</comment>
-                    <field id="active" translate="label comment" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label comment" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Enable/Disable</label>
                         <comment>Enable Omise Internet Banking Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_internetbanking/active</config_path>
                     </field>
-                    <field id="title" translate="label" type="text" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="title" translate="label" type="text" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_internetbanking/title</config_path>


### PR DESCRIPTION
### 1. Objective

There are some cases that we need to consider using WebHooks feature.

- **An order that has been placed at Magento store with `payment_action=authorize only`. Then later, merchant performs `capture` action at Omise dashboard instead.**

    Without Webhook, Magento store will never knew that that charge transaction has been _captured_ already at Omise dashboard.
    Means, we are going to need something like a callback feature to tell Magento store that that `captured` event is triggered. So Magento store can update an order status according to the result. 

- **Some offsite payments don't resolve users' payment at a time they (user) complete their payment process. For example, Internet Banking, sometimes Bank cannot response the payment result back to Omise API at a time user 'submit' their payment.**

    User will be redirected back to Magento store with `charge.status = pending` causing that an order status won't be changed to `processing` nor `failed` until merchant manual change it.

    Again, we are going to need something like a callback feature to tell Magento store that that `charge transaction` is resolved. So Magento store can update an order status either to make it as 'canceled' or 'completed'. 

**Related information**:
Ref: https://www.omise.co/api-webhooks

### 2. Description of change

1. New field, `Webhook endpoint` at the payment setting page.
![001](https://user-images.githubusercontent.com/2154669/36298002-5af1f0c0-1328-11e8-89e1-f9dfb1c81106.png)

2. Add a new route `/omise/callback/webhook` to handle Omise Webhook's callback.

3. Add capability to handle Omise Webhook: `charge.complete` event.
    Once you enable the Webhook feature, Omise-Magento will be able to receive Omise Webhook's payload from the `charge.complete` event and proper update the order status according to the charge result.

### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento Open Source v2.2.2
- **PHP version**: 7.0.25.

**✏️ Details:**

1. **Make sure that a `payment-review` order gets update from the Omise Webhook: `charge.complete` event properly.**
    > Note: only **3-D Secure payment** and **Internet Banking Paymentv methods that can trigger the `charge.complete` event.

    1.1. For 3-D Secure payment case, the `Model\Event` handler class should do nothing. The `charge.complete` event should effect only a `payment-review` order (which shouldn't happen with 3-D Secure payment)

    1.2. For Internet Banking: successful case.
        Make sure that once Webhook's request arrives at the store, the order status, invoice, transaction will be updated to a proper status.

    1.3. For Internet Banking: failed case.
        Make sure that once Webhook's request arrives at the store, the order status, invoice, transaction will be updated to a proper status.

2. Once Omise Webhook is triggered and made a request back to the Magento store. Make sure that the event handler class won't be trigger if an order status isn't set to `payment-review`.
    In some case, especially Internet Banking payment: the payment result may be resolved at the time user is redirected back to the store, causing that the order status may be set to a proper status before the request from Webhook arrive.

    Means that we have to make sure that once the order status won't get update twice from above case.

#### 4. Impact of the change

None.

### 5. Priority of change

Normal

### 6. Additional Notes

- There are some events that this PR hasn't implemented yet (i.e. `charge.create`, `charge.capture`, `charge.reverse`, `refund.create`).
    For more information, please check https://www.omise.co/api-webhooks.