### PR TITLE
Simplify install process to just use Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,25 @@ Submit your requirement as an issue to [https://github.com/omise/omise-magento/i
 
 ### Installation Instructions
 
-#### Manually
+#### Via Composer
 
-The steps below shows how to install the module manually.
-This requires a user account with permission to write your Magento file system, execute the command line and [composer](https://getcomposer.org).
+Installing the extension is done via [composer](https://getcomposer.org/). Firstly, add the following line to the main `composer.json` file in the Magento folder:
 
-1. Download and extract the zip file from [Omise-Magento](https://github.com/omise/omise-magento/archive/v2.2.zip).
-2. On your Magento server, create a new folder `Omise/Payment` under the directory `app/code`.
-3. Copy all files to the directory `app/code/Omise/Payment` that you created in the step 2.
-    <p align="center"><a alt="omise-magento-install-manual-01" href='https://cloud.githubusercontent.com/assets/2154669/21450750/247ec3b6-c92c-11e6-92d5-3c036568f20b.png'><img src='https://cloud.githubusercontent.com/assets/2154669/21450750/247ec3b6-c92c-11e6-92d5-3c036568f20b.png'></a></p>
-4. Log in to your Magento server by using Terminal program, then change the current directory to your Magento root directory.
-5. Execute command `composer require omise/omise-php:2.8.0` to install Omise-PHP library.
-6. Execute `php bin/magento module:enable Omise_Payment --clear-static-content` to register `Omise_Payment` plugin to the Magento module system.
-    <img width="1074" alt="024" src="https://cloud.githubusercontent.com/assets/2154669/24037678/30c1f070-0b31-11e7-878b-b5a052f9a8ea.png">
-7. Then, execute the command, `php bin/magento setup:upgrade` to upgrade your Magento system (to install Omise-Magento plugin).
-8. Your installation is now completed. Check the [First Time Setup](https://github.com/omise/omise-magento#first-time-setup) to continue setting up your Omise account to Magento store.
+<pre>
+...
+"require": {
+  ...<b>,</b>
+  <b>"omise/omise-magento": "@stable"</b>
+},
+...
+</pre>
+Once this is done, simply run `composer update`, and the module should be automatically installed along with its dependencies. If you are installing the module to an existing (not new) Magento installation, you will probably need to run the following commands after running composer:
+
+<pre>
+php bin/magento module:enable Omise_Payment --clear-static-content
+php bin/magento setup:upgrade
+php bin/magento setup:di:compile
+</pre>
 
 ### First Time Setup
 
@@ -59,7 +63,7 @@ The table below is the settings for the module and the description for each sett
 | Secret key for test | Your TEST secret key can be found in your Dashboard.                                                                    |
 | Public key for live | Your LIVE public key can be found in your Dashboard.                                                                    |
 | Secret key for live | Your LIVE secret key can be found in your Dashboard.                                                                    |
-| Payment Action      | Set `Authorize Only` to only authorize a payment or `Authorize and Capture` to automatically capture after authroizing. |
+| Payment Action      | Set `Authorize Only` to only authorize a payment or `Authorize and Capture` to automatically capture after authorising. |
 | Title               | Title of Omise Payment gateway shown at checkout.                                                                       |
 
 - To enable the module, select the setting for `Enable/Disable` to `Yes`.

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,22 @@
 {
     "name": "omise/omise-magento",
-    "version": "2.3.0-dev",
+    "description": "Accept payments on your Magento 2 website with Omise",
+    "keywords": ["omise", "payment", "debitcard", "creditcard", "magento"],
+    "homepage": "https://github.com/omise/omise-magento",
+    "authors": [
+        {
+          "name": "Omise",
+          "email": "support@omise.co"
+        }
+    ],
+    "version": "2.4.0-dev",
+    "minimum-stability": "dev",
     "type": "magento2-module",
     "license": "MIT",
     "require": {
-        "omise/omise-php": "2.6.0"
+        "php": "~5.5.0|~5.6.0|~7",
+        "magento/magento-composer-installer": "*",
+        "omise/omise-php": "2.8.0"
     },
     "autoload": {
         "files": ["registration.php"],

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "omise/omise-magento",
     "description": "Accept payments on your Magento 2 website with Omise",
-    "keywords": ["omise", "payment", "debitcard", "creditcard", "magento"],
+    "keywords": ["omise", "payment", "debitcard", "creditcard", "internetbanking", "magento"],
     "homepage": "https://github.com/omise/omise-magento",
     "authors": [
         {
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.4.0-dev",
+    "version": "2.3.0-dev",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "version": "2.4.0-dev",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
#### 1. Objective

The previous install process was rather long winded and contained many unnecessary manual steps. Also, it was not the install method suggested/recommended by Magento

#### 2. Description of change

Modified `composer.json` with all necessary changes to allow full Composer-based installation (including dependencies). Also added keywords etc. to improve the discoverability of the plugin on Packagist

#### 3. Quality assurance

Before we go live with this, I would suggest at least a couple of people do an install from this `composer-install` branch. I have included the `composer.json` from my Magento project that I used to do this test install:
```
{
    "name": "magento/project-community-edition",
    "description": "eCommerce Platform for Growth (Community Edition)",
    "type": "project",
    "version": "2.2.2",
    "license": [
        "OSL-3.0",
        "AFL-3.0"
    ],
    "require": {
        "magento/product-community-edition": "2.2.2",
        "composer/composer": "@alpha",
        "omise/omise-magento": "dev-composer-install"
    },
    "require-dev": {
        "phpunit/phpunit": "~6.2.0",
        "squizlabs/php_codesniffer": "3.1.1",
        "phpmd/phpmd": "@stable",
        "pdepend/pdepend": "2.5.0",
        "friendsofphp/php-cs-fixer": "~2.2.0",
        "lusitanian/oauth": "~0.8.10",
        "sebastian/phpcpd": "2.0.4"
    },
    "autoload": {
        "psr-4": {
            "Magento\\Framework\\": "lib/internal/Magento/Framework/",
            "Magento\\Setup\\": "setup/src/Magento/Setup/",
            "Magento\\": "app/code/Magento/"
        },
        "psr-0": {
            "": [
                "app/code/"
            ]
        },
        "files": [
            "app/etc/NonComposerComponentRegistration.php"
        ],
        "exclude-from-classmap": [
            "**/dev/**",
            "**/update/**",
            "**/Test/**"
        ]
    },
    "autoload-dev": {
        "psr-4": {
            "Magento\\Sniffs\\": "dev/tests/static/framework/Magento/Sniffs/",
            "Magento\\Tools\\": "dev/tools/Magento/Tools/",
            "Magento\\Tools\\Sanity\\": "dev/build/publication/sanity/Magento/Tools/Sanity/",
            "Magento\\TestFramework\\Inspection\\": "dev/tests/static/framework/Magento/TestFramework/Inspection/",
            "Magento\\TestFramework\\Utility\\": "dev/tests/static/framework/Magento/TestFramework/Utility/"
        }
    },
    "minimum-stability": "stable",
    "repositories": [
        {
            "type": "composer",
            "url": "https://repo.magento.com/"
        },
        {
            "type": "git",
            "url": "https://github.com/omise/omise-magento.git",
            "packagist.org": false
        }
    ],
    "extra": {
        "magento-force": "override"
    },
    "config": {
        "cache-dir": "/var/www/html/.composer/cache"
    }
}
```
The relevant things here for doing the install from the GitHub branch are:

1. Adding the ‘git’ item in the repositories section
2. Adding `"omise/omise-magento": "dev-composer-install"` to the `require` section. This tells composer to user the `composer-install` branch from the repo

#### 4. Impact of the change
Obviously the install instructions for the merchants now be different, so the https://www.omise.co/magento-2 page will need to be updated to reflect this

#### 5. Priority of change

Normal.

#### 6. Additional Notes

Black Panther was better than I thought it would be 😄 