### PR TITLE
Switches on 'showInStore' for all config options to allow full multi-store functionality

### DIFF
--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -45,12 +45,19 @@ class PaymentDataBuilder implements BuilderInterface
         $payment = SubjectReader::readPayment($buildSubject);
         $order   = $payment->getOrder();
 
+        $store_id = $order->getStoreId();
+        $om = \Magento\Framework\App\ObjectManager::getInstance();
+        $manager = $om->get('Magento\Store\Model\StoreManagerInterface');
+        $store_name = $manager->getStore($store_id)->getName();
+
         return [
             self::AMOUNT      => $this->omiseHelper->omiseAmountFormat($order->getCurrencyCode(), $order->getGrandTotalAmount()),
             self::CURRENCY    => $order->getCurrencyCode(),
             self::DESCRIPTION => 'Magento 2 Order id ' . $order->getOrderIncrementId(),
             self::METADATA    => [
-                'order_id' => $order->getOrderIncrementId()
+                'order_id' => $order->getOrderIncrementId(),
+                'store_id' => $order->getStoreId(),
+                'store_name' => $store_name
             ]
         ];
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -4,32 +4,32 @@
         <section id="payment">
             <group id="omise" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Omise Payment Gateway</label>
-                <field id="basic_settings" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="basic_settings" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Basic Setting</label>
                     <frontend_model>Magento\Config\Block\System\Config\Form\Field\Heading</frontend_model>
                 </field>
-                <field id="sandbox_status" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="sandbox_status" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Sandbox</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Enabling sandbox means that all your transactions will be in TEST mode.</comment>
                 </field>
-                <field id="test_public_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="test_public_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public key for test</label>
                     <comment>The "Test" mode public key can be found in Omise Dashboard.</comment>
                 </field>
-                <field id="test_secret_key" translate="label" type="password" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="test_secret_key" translate="label" type="password" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secret key for test</label>
                     <comment>The "Test" mode secret key can be found in Omise Dashboard.</comment>
                 </field>
-                <field id="live_public_key" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="live_public_key" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public key for live</label>
                     <comment>The "Live" mode public key can be found in Omise Dashboard.</comment>
                 </field>
-                <field id="live_secret_key" translate="label" type="password" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="live_secret_key" translate="label" type="password" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Secret key for live</label>
                     <comment>The "Live" mode secret key can be found in Omise Dashboard.</comment>
                 </field>
-                <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Webhook endpoint</label>
                     <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook</frontend_model>
@@ -38,23 +38,23 @@
                 <group id="omise_cc" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Credit Card Solution</label>
                     <comment>Powerful payment features that allows you to easily and securely accept credit/debit card payments on your store.</comment>
-                    <field id="active" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label comment" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
                         <comment>Enable Omise Credit Card Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_cc/active</config_path>
                     </field>
-                    <field id="payment_action" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <field id="payment_action" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Payment Action</label>
                         <source_model>Omise\Payment\Model\Source\PaymentAction</source_model>
                         <config_path>payment/omise_cc/payment_action</config_path>
                     </field>
-                    <field id="title" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="title" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_cc/title</config_path>
                     </field>
-                    <field id="3ds" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="3ds" translate="label comment" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>3-D Secure support</label>
                         <comment>Enable or disable 3-D Secure for the account. (Japan-based accounts are not eligible for the service.).</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -65,13 +65,13 @@
                 <group id="omise_offsite_internetbanking" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Internet Banking Solution</label>
                     <comment>Enables customers of a bank to easily conduct financial transactions through a bank-operated website (only available in Thailand).</comment>
-                    <field id="active" translate="label comment" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label comment" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
                         <comment>Enable Omise Internet Banking Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_internetbanking/active</config_path>
                     </field>
-                    <field id="title" translate="label" type="text" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="title" translate="label" type="text" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_internetbanking/title</config_path>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -80,13 +80,13 @@
                 <group id="omise_offsite_alipay" translate="label" sortOrder="160" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Alipay Solution</label>
                     <comment>Enables customers to pay using Alipay method</comment>
-                    <field id="active" translate="label comment" type="select" sortOrder="170" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label comment" type="select" sortOrder="170" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
                         <comment>Enable Alipay Peyment Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_alipay/active</config_path>
                     </field>
-                    <field id="title" translate="label" type="text" sortOrder="180" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="title" translate="label" type="text" sortOrder="180" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_alipay/title</config_path>


### PR DESCRIPTION
#### 1. Objective

Make sure all config settings for Omise Magento are available down to the store level - to facilitate full multistore capability. Also add some details about the current store in the charge metadata

#### 2. Description of change

`adminhtml/system.xml` modified to turn on all `showInStore` switches.
`paymentdatabuilder.php` modified to add store info to charge metadata

#### 3. Quality assurance

I set up a sample site with multiple stores and views, and different Omise Magento settings for each store view. I then made an order from each store view, checking that the payment options were correct for each view, and that the correct store info had been added to the charge metadata in each case

#### 4. Impact of the change

No visible changes will be seen when this update is installed unless installed on a site that has multiple stores/views - in which case the merchant will have control over the plugin on a per store basis

![image](https://user-images.githubusercontent.com/1510194/40900646-c6ee249c-67f6-11e8-98dc-6ae44db4ed11.png)

👆 When you select any 'scope' after the update, the Omise options will be available for changing. They were only available at the top level before


#### 5. Priority of change

Normal

#### 6. Additional Notes

It's not raining today, but wow is it hot! 🔥