### PR TITLE
Removes link/dependency with Authorize.net module

### DIFF
--- a/Model/Source/PaymentAction.php
+++ b/Model/Source/PaymentAction.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Omise\Payment\Model\Source;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class PaymentAction implements ArrayInterface
+{
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => \Magento\Payment\Model\Method\Cc::ACTION_AUTHORIZE,
+                'label' => __('Authorize Only'),
+            ],
+            [
+                'value' => \Magento\Payment\Model\Method\Cc::ACTION_AUTHORIZE_CAPTURE,
+                'label' => __('Authorize and Capture')
+            ]
+        ];
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -46,7 +46,7 @@
                     </field>
                     <field id="payment_action" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Payment Action</label>
-                        <source_model>Magento\Authorizenet\Model\Source\PaymentAction</source_model>
+                        <source_model>Omise\Payment\Model\Source\PaymentAction</source_model>
                         <config_path>payment/omise_cc/payment_action</config_path>
                     </field>
                     <field id="title" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">


### PR DESCRIPTION
#### 1. Objective

Remove a small link/dependency with the `authorize.net` module. It's risky leaving it there as we cannot guarantee the module will be present. This makes our module more self contained

#### 2. Description of change

Add a new class within our module to handle the `PaymentAction` dropdown for credit cards in the admin area (copied from the similar class in Authorize.net)

#### 3. Quality assurance

Go to the magento admin area and check the dropdown mentioned above is still functioning correctly

#### 4. Impact of the change

No noticeable change for users

#### 5. Priority of change

Normal

#### 6. Additional Notes

What causes thunder anyway?