### PR TITLE
MAG2x: Add a capability to remember user's credit card and use it for a second-time purchase

### DIFF
--- a/Gateway/Request/CreditCardBuilder.php
+++ b/Gateway/Request/CreditCardBuilder.php
@@ -22,8 +22,16 @@ class CreditCardBuilder implements BuilderInterface
     {
         $payment = SubjectReader::readPayment($buildSubject);
         $method  = $payment->getPayment();
+        $card    = $method->getAdditionalInformation(CreditCardDataObserver::CARD);
 
         if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
+            if ($card) {
+                return [
+                    self::CARD     => $card,
+                    self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)
+                ];
+            }
+
             return [ self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER) ];
         }
 

--- a/Gateway/Request/CreditCardBuilder.php
+++ b/Gateway/Request/CreditCardBuilder.php
@@ -22,17 +22,12 @@ class CreditCardBuilder implements BuilderInterface
     {
         $payment = SubjectReader::readPayment($buildSubject);
         $method  = $payment->getPayment();
-        $card    = $method->getAdditionalInformation(CreditCardDataObserver::CARD);
 
         if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
-            if ($card) {
-                return [
-                    self::CARD     => $card,
-                    self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)
-                ];
-            }
-
-            return [ self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER) ];
+            return [
+                self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER),
+                self::CARD     => $method->getAdditionalInformation(CreditCardDataObserver::CARD)
+            ];
         }
 
         return [ self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN) ];

--- a/Gateway/Request/CreditCardBuilder.php
+++ b/Gateway/Request/CreditCardBuilder.php
@@ -10,7 +10,8 @@ class CreditCardBuilder implements BuilderInterface
     /**
      * @var string
      */
-    const CARD = 'card';
+    const CARD     = 'card';
+    const CUSTOMER = 'customer';
 
     /**
      * @param  array $buildSubject
@@ -22,8 +23,10 @@ class CreditCardBuilder implements BuilderInterface
         $payment = SubjectReader::readPayment($buildSubject);
         $method  = $payment->getPayment();
 
-        return [
-            self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN)
-        ];
+        if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
+            return [ self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER) ];
+        }
+
+        return [ self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN) ];
     }
 }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -68,8 +68,8 @@ class Customer extends Object
     /**
      * TODO: Need to refactor a bit
      */
-    public function cards()
+    public function cards($options = array())
     {
-        return $this->object->cards();
+        return $this->object->cards($options);
     }
 }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -8,6 +8,25 @@ use OmiseCustomer;
 class Customer extends Object
 {
     /**
+     * @param  string $id
+     *
+     * @return Omise\Payment\Model\Api\Error|self
+     */
+    public function find($id)
+    {
+        try {
+            $this->refresh(OmiseCustomer::retrieve($id));
+        } catch (Exception $e) {
+            return new Error([
+                'code'    => 'not_found',
+                'message' => $e->getMessage()
+            ]);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param  array $params
      *
      * @return Omise\Payment\Model\Api\Error|self
@@ -24,5 +43,13 @@ class Customer extends Object
         }
 
         return $this;
+    }
+
+    /**
+     * TODO: Need to refactor a bit
+     */
+    public function cards()
+    {
+        return $this->object->cards();
     }
 }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -45,6 +45,26 @@ class Customer extends Object
         return $this;
     }
 
+     /**
+     * @param  array $params
+     *
+     * @return \Omise\Payment\Model|\Api\Error|self
+     */
+    public function update($params)
+    {
+        try {
+            $this->object->update($params);
+            $this->refresh($this->object);
+        } catch (Exception $e) {
+            return new Error([
+                'code'    => 'bad_request',
+                'message' => $e->getMessage()
+            ]);
+        }
+
+        return $this;
+    }
+
     /**
      * TODO: Need to refactor a bit
      */

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Omise\Payment\Model\Api;
+
+use Exception;
+use OmiseCustomer;
+
+class Customer extends Object
+{
+    /**
+     * @param  array $params
+     *
+     * @return Omise\Payment\Model\Api\Error|self
+     */
+    public function create($params)
+    {
+        try {
+            $this->refresh(OmiseCustomer::create($params));
+        } catch (Exception $e) {
+            return new Error([
+                'code'    => 'bad_request',
+                'message' => $e->getMessage()
+            ]);
+        }
+
+        return $this;
+    }
+}

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -49,24 +49,34 @@ class Customer
         $this->omise->defineApiKeys();
     }
 
-    public function createOmiseCustomer($cardToken)
+    public function createOmiseCustomer()
     {
-        $omiseCustomer = $this->omiseCustomer->create([
+        $customer = $this->omiseCustomer->create([
             'email'       => $this->customer->getEmail(),
-            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname()),
-            'card'        => $cardToken
+            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname())
         ]);
 
-        $this->customer->setData('omise_customer_id', $omiseCustomer->id);
+        $this->customer->setData('omise_customer_id', $customer->id);
         $this->magentoCustomerResource->saveAttribute($this->customer, 'omise_customer_id');
 
-        return $omiseCustomer;
+        return $customer;
+    }
+
+    public function attachCard($cardToken)
+    {
+        if (! $this->getOmiseCustomerId()) {
+            $customer = $this->createOmiseCustomer();
+        } else {
+            $customer = $this->omiseCustomer->find($this->getOmiseCustomerId());
+        }
+
+        return $customer->update(array('card' => $cardToken));
     }
 
     /**
      * @return string
      */
-    public function id()
+    public function getOmiseCustomerId()
     {
         return $this->customer->getData('omise_customer_id');
     }

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -81,10 +81,10 @@ class Customer
         return $this->customer->getData('omise_customer_id');
     }
 
-    public function cards()
+    public function cards($options = array())
     {
         $customer = $this->omiseCustomer->find($this->customer->getData('omise_customer_id'));
 
-        return $customer->cards();
+        return $customer->cards($options);
     }
 }

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -42,11 +42,12 @@ class Customer
         $this->omise->defineApiKeys();
     }
 
-    public function create()
+    public function createOmiseCustomer($cardToken)
     {
         return $this->omiseCustomer->create([
             'email'       => $this->customer->getEmail(),
-            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname())
+            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname()),
+            'card'        => $cardToken
         ]);
     }
 }

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -63,6 +63,14 @@ class Customer
         return $omiseCustomer;
     }
 
+    /**
+     * @return string
+     */
+    public function id()
+    {
+        return $this->customer->getData('omise_customer_id');
+    }
+
     public function cards()
     {
         $customer = $this->omiseCustomer->find($this->customer->getData('omise_customer_id'));

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -1,0 +1,52 @@
+<?php
+namespace Omise\Payment\Model;
+
+use Magento\Customer\Model\Session as MagentoCustomerSession;
+use Omise\Payment\Model\Api\Customer as OmiseCustomer;
+use Omise\Payment\Model\Omise;
+
+class Customer
+{
+    /**
+     * @var \Magento\Customer\Model\Session
+     */
+    protected $magentoCustomerSession;
+
+    /**
+     * @var \Magento\Customer\Model\Customer
+     */
+    protected $customer;
+
+    /**
+     * @var \Omise\Payment\Model\Api\Customer
+     */
+    protected $omiseCustomer;
+
+    /**
+     * @var \Omise\Payment\Model\Omise
+     */
+    protected $omise;
+
+    public function __construct(
+        MagentoCustomerSession $magentoCustomerSession,
+        Omise                  $omise,
+        OmiseCustomer          $omiseCustomer
+    ) {
+        $this->magentoCustomerSession = $magentoCustomerSession;
+        $this->customer               = $this->magentoCustomerSession->getCustomer();
+        $this->omise                  = $omise;
+        $this->omiseCustomer          = $omiseCustomer;
+
+        $this->omise->defineUserAgent();
+        $this->omise->defineApiVersion();
+        $this->omise->defineApiKeys();
+    }
+
+    public function create()
+    {
+        return $this->omiseCustomer->create([
+            'email'       => $this->customer->getEmail(),
+            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname())
+        ]);
+    }
+}

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -62,4 +62,11 @@ class Customer
 
         return $omiseCustomer;
     }
+
+    public function cards()
+    {
+        $customer = $this->omiseCustomer->find($this->customer->getData('omise_customer_id'));
+
+        return $customer->cards();
+    }
 }

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -1,12 +1,23 @@
 <?php
 namespace Omise\Payment\Model;
 
-use Magento\Customer\Model\Session as MagentoCustomerSession;
-use Omise\Payment\Model\Api\Customer as OmiseCustomer;
+use Magento\Customer\Model\ResourceModel\Customer as MagentoCustomerResource;
+use Magento\Customer\Model\Session                as MagentoCustomerSession;
+use Omise\Payment\Model\Api\Customer              as OmiseCustomerAPI;
 use Omise\Payment\Model\Omise;
 
 class Customer
 {
+    /**
+     * @var string
+     */
+    const OMISE_CUSTOMER_ID_FIELD = 'omise_customer_id';
+
+    /**
+     * @var \Magento\Customer\Model\Customer
+     */
+    protected $magentoCustomer;
+
     /**
      * @var \Magento\Customer\Model\ResourceModel\Customer
      */
@@ -18,73 +29,139 @@ class Customer
     protected $magentoCustomerSession;
 
     /**
-     * @var \Magento\Customer\Model\Customer
-     */
-    protected $customer;
-
-    /**
-     * @var \Omise\Payment\Model\Api\Customer
-     */
-    protected $omiseCustomer;
-
-    /**
      * @var \Omise\Payment\Model\Omise
      */
     protected $omise;
 
+    /**
+     * @var \Omise\Payment\Model\Api\Customer
+     */
+    protected $customerAPI;
+
     public function __construct(
-        \Magento\Customer\Model\ResourceModel\Customer $magentoCustomerResource,
-        MagentoCustomerSession $magentoCustomerSession,
-        Omise                  $omise,
-        OmiseCustomer          $omiseCustomer
+        MagentoCustomerResource $magentoCustomerResource,
+        MagentoCustomerSession  $magentoCustomerSession,
+        Omise                   $omise,
+        OmiseCustomerAPI        $customerAPI
     ) {
         $this->magentoCustomerResource = $magentoCustomerResource;
         $this->magentoCustomerSession  = $magentoCustomerSession;
-        $this->customer                = $this->magentoCustomerSession->getCustomer();
+        $this->magentoCustomer         = $this->magentoCustomerSession->getCustomer();
         $this->omise                   = $omise;
-        $this->omiseCustomer           = $omiseCustomer;
+        $this->customerAPI             = $customerAPI;
 
         $this->omise->defineUserAgent();
         $this->omise->defineApiVersion();
         $this->omise->defineApiKeys();
-    }
 
-    public function createOmiseCustomer()
-    {
-        $customer = $this->omiseCustomer->create([
-            'email'       => $this->customer->getEmail(),
-            'description' => trim($this->customer->getFirstname() . ' ' . $this->customer->getLastname())
-        ]);
-
-        $this->customer->setData('omise_customer_id', $customer->id);
-        $this->magentoCustomerResource->saveAttribute($this->customer, 'omise_customer_id');
-
-        return $customer;
-    }
-
-    public function attachCard($cardToken)
-    {
-        if (! $this->getOmiseCustomerId()) {
-            $customer = $this->createOmiseCustomer();
-        } else {
-            $customer = $this->omiseCustomer->find($this->getOmiseCustomerId());
-        }
-
-        return $customer->update(array('card' => $cardToken));
+        $this->initializeObject();
     }
 
     /**
-     * @return string
+     * Check whether the executor is logged in or not.
+     *
+     * @return bool
      */
-    public function getOmiseCustomerId()
+    public function isLoggedIn()
     {
-        return $this->customer->getData('omise_customer_id');
+        return $this->getMagentoCustomerId() ? true : false;
     }
 
+    /**
+     * Get an Omise customer id that belongs to
+     * a specific user who execute the method.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->magentoCustomer->getData(self::OMISE_CUSTOMER_ID_FIELD);
+    }
+
+    /**
+     * Get a Magento customer id that belongs to
+     * a specific user who execute the method.
+     *
+     * @return int|null
+     *
+     * @see    magento/module-customer/Model/Session.php
+     */
+    public function getMagentoCustomerId()
+    {
+        return $this->magentoCustomerSession->getCustomerId();
+    }
+
+    /**
+     * Create an Omise customer, then assigning its Omise customer id
+     * back to the customer's attribute who execute the method.
+     *
+     * @return self
+     */
+    public function create(array $params)
+    {
+        $this->customerAPI = $this->customerAPI->create($params);
+
+        $this->magentoCustomer->setData(self::OMISE_CUSTOMER_ID_FIELD, $this->customerAPI->id);
+        $this->magentoCustomerResource->saveAttribute($this->magentoCustomer, self::OMISE_CUSTOMER_ID_FIELD);
+
+        return $this;
+    }
+
+    /**
+     * Attach an Omise Token to a Customer object.
+     *
+     * @param string $cardToken
+     *
+     * @return self
+     */
+    public function addCard($cardToken)
+    {
+        if (! $this->getId()) {
+            $this->create(array(
+                'email'       => $this->magentoCustomer->getEmail(),
+                'description' => trim($this->magentoCustomer->getFirstname() . ' ' . $this->magentoCustomer->getLastname())
+            ));
+        }
+
+        $this->customerAPI = $this->customerAPI->update(array('card' => $cardToken));
+
+        return $this;
+    }
+
+    /**
+     * Retrieve all cards that belong to a specific Omise Customer object.
+     *
+     * @param  array $options
+     *
+     * @return \OmiseCardList
+     *
+     * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCardList.php
+     */
     public function cards($options = array())
     {
-        $customer = $this->omiseCustomer->find($this->customer->getData('omise_customer_id'));
+        return $this->customerAPI->cards($options);
+    }
 
-        return $customer->cards($options);
+    /**
+     * @return array  of Omise card object.
+     *
+     * @see    https://www.omise.co/cards-api
+     */
+    public function getLatestCard()
+    {
+        $cards = $this->cards(array('order' => 'reverse_chronological'));
+
+        return $cards['total'] > 0 ? $cards['data'][0] : null;
+    }
+
+    /**
+     * Load and prepare Omise customer object
+     * when the class is being executed.
+     */
+    protected function initializeObject()
+    {
+        if ($this->getId()) {
+            $this->customerAPI = $this->customerAPI->find($this->getId());
+        }
     }
 }

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -23,11 +23,21 @@ class CcConfigProvider implements ConfigProviderInterface
      */
     protected $omiseCcConfig;
 
-    public function __construct(MagentoCustomerSession $magentoCustomerSession, MagentoCcConfig $magentoCcConfig, OmiseCcConfig $omiseCcConfig)
+    /**
+     * @var Omise\Payment\Model\Customer
+     */
+    protected $customer;
+
+    public function __construct(
+        MagentoCustomerSession        $magentoCustomerSession,
+        MagentoCcConfig               $magentoCcConfig,
+        OmiseCcConfig                 $omiseCcConfig,
+        \Omise\Payment\Model\Customer $customer)
     {
         $this->magentoCustomerSession = $magentoCustomerSession;
         $this->magentoCcConfig        = $magentoCcConfig;
         $this->omiseCcConfig          = $omiseCcConfig;
+        $this->customer               = $customer;
     }
 
     /**
@@ -46,9 +56,29 @@ class CcConfigProvider implements ConfigProviderInterface
                 OmiseCcConfig::CODE => [
                     'publicKey'          => $this->omiseCcConfig->getPublicKey(),
                     'offsitePayment'     => $this->omiseCcConfig->is3DSecureEnabled(),
-                    'isCustomerLoggedIn' => $this->magentoCustomerSession->getCustomerId() ? true : false
+                    'isCustomerLoggedIn' => $this->magentoCustomerSession->getCustomerId() ? true : false,
+                    'cards'              => $this->getCards(),
                 ],
             ]
         ];
+    }
+
+    /**
+     * @return  array
+     */
+    public function getCards()
+    {
+        $cards = $this->customer->cards();
+        $data = [];
+
+        foreach($cards['data'] as $card) {
+            $label = $card['brand'] . ' **** ' . $card['last_digits'];
+            $data[] = [
+                'value' => $card['id'],
+                'label' => $label
+            ];
+        }
+
+        return $data;
     }
 }

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -62,16 +62,16 @@ class CcConfigProvider implements ConfigProviderInterface
     public function getCards()
     {
         if (! $this->customer->getMagentoCustomerId() || ! $this->customer->getId()) {
-            return [];
+            return array();
         }
 
         $cards = $this->customer->cards(array('order' => 'reverse_chronological'));
 
         if (! $cards) {
-            return [];
+            return array();
         }
 
-        $data = [];
+        $data = array();
 
         foreach($cards['data'] as $card) {
             $label = $card['brand'] . ' **** ' . $card['last_digits'];

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -69,6 +69,11 @@ class CcConfigProvider implements ConfigProviderInterface
     public function getCards()
     {
         $cards = $this->customer->cards();
+
+        if (! $cards) {
+            return [];
+        }
+
         $data = [];
 
         foreach($cards['data'] as $card) {

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -68,7 +68,7 @@ class CcConfigProvider implements ConfigProviderInterface
      */
     public function getCards()
     {
-        $cards = $this->customer->cards();
+        $cards = $this->customer->cards(array('order' => 'reverse_chronological'));
 
         if (! $cards) {
             return [];

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -2,11 +2,17 @@
 namespace Omise\Payment\Model\Ui;
 
 use Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\Customer\Model\Session as MagentoCustomerSession;
 use Magento\Payment\Model\CcConfig as MagentoCcConfig;
 use Omise\Payment\Model\Config\Cc as OmiseCcConfig;
 
 class CcConfigProvider implements ConfigProviderInterface
 {
+    /**
+     * @var \Magento\Customer\Model\Session
+     */
+    protected $magentoCustomerSession;
+
     /**
      * @var \Magento\Payment\Model\CcConfig
      */
@@ -17,10 +23,11 @@ class CcConfigProvider implements ConfigProviderInterface
      */
     protected $omiseCcConfig;
 
-    public function __construct(MagentoCcConfig $magentoCcConfig, OmiseCcConfig $omiseCcConfig)
+    public function __construct(MagentoCustomerSession $magentoCustomerSession, MagentoCcConfig $magentoCcConfig, OmiseCcConfig $omiseCcConfig)
     {
-        $this->magentoCcConfig = $magentoCcConfig;
-        $this->omiseCcConfig   = $omiseCcConfig;
+        $this->magentoCustomerSession = $magentoCustomerSession;
+        $this->magentoCcConfig        = $magentoCcConfig;
+        $this->omiseCcConfig          = $omiseCcConfig;
     }
 
     /**
@@ -37,8 +44,9 @@ class CcConfigProvider implements ConfigProviderInterface
                     'years'  => [OmiseCcConfig::CODE => $this->magentoCcConfig->getCcYears()],
                 ],
                 OmiseCcConfig::CODE => [
-                    'publicKey'      => $this->omiseCcConfig->getPublicKey(),
-                    'offsitePayment' => $this->omiseCcConfig->is3DSecureEnabled()
+                    'publicKey'          => $this->omiseCcConfig->getPublicKey(),
+                    'offsitePayment'     => $this->omiseCcConfig->is3DSecureEnabled(),
+                    'isCustomerLoggedIn' => $this->magentoCustomerSession->getCustomerId() ? true : false
                 ],
             ]
         ];

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -24,7 +24,8 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     protected $additionalInformationList = [
         self::TOKEN,
         self::CARD,
-        self::REMEMBER_CARD
+        self::REMEMBER_CARD,
+        self::CUSTOMER
     ];
 
     /**
@@ -56,6 +57,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
             return;
         }
 
+        $this->useExistingCardIfNeeded($additionalData);
         $this->saveCustomerCardIfNeeded($additionalData);
         $this->setPaymentAdditionalInformation($this->readPaymentModelArgument($observer), $additionalData);
     }
@@ -75,6 +77,18 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
                     $additionalData[$additionalInformationKey]
                 );
             }
+        }
+    }
+
+    /**
+     * @param  array &$additionalData
+     *
+     * @return void
+     */
+    protected function useExistingCardIfNeeded(array &$additionalData)
+    {
+        if (isset($additionalData[self::CARD]) && $additionalData[self::CARD] != '') {
+            $additionalData[self::CUSTOMER] = $this->customer->getOmiseCustomerId();
         }
     }
 

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -14,6 +14,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      */
     const TOKEN         = 'omise_card_token';
     const REMEMBER_CARD = 'omise_save_card';
+    const CUSTOMER      = 'customer';
 
 
     /**
@@ -84,7 +85,12 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     protected function saveCustomerCardIfNeeded(InfoInterface $paymentInfo, array $additionalData)
     {
         if (isset($additionalData[self::REMEMBER_CARD])) {
-            $customer = $this->customer->create();
+            $customer = $this->customer->createOmiseCustomer($additionalData[self::TOKEN]);
+
+            $paymentInfo->setAdditionalInformation(
+                self::CUSTOMER,
+                $customer->id
+            );
         }
     }
 }

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -87,7 +87,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     protected function saveCustomerCardIfNeeded(InfoInterface $paymentInfo, array $additionalData)
     {
         if (isset($additionalData[self::REMEMBER_CARD])) {
-            $customer = $this->customer->createOmiseCustomer($additionalData[self::TOKEN]);
+            $customer = $this->customer->attachCard($additionalData[self::TOKEN]);
 
             $paymentInfo->setAdditionalInformation(
                 self::CUSTOMER,

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -70,7 +70,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      */
     protected function maybeUseExistingCard(array &$additionalData)
     {
-        if (isset($additionalData[self::CARD]) && $additionalData[self::CARD] != '') {
+        if (! empty($additionalData[self::CARD])) {
             $additionalData[self::CUSTOMER] = $this->customer->getId();
         }
     }
@@ -84,7 +84,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      */
     protected function maybeSaveCustomerCard(array &$additionalData)
     {
-        if (isset($additionalData[self::REMEMBER_CARD]) && $additionalData[self::REMEMBER_CARD]) {
+        if (! empty($additionalData[self::REMEMBER_CARD])) {
             $customer = $this->customer->addCard($additionalData[self::TOKEN]);
             $card     = $customer->getLatestCard();
 

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -5,6 +5,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Payment\Model\InfoInterface;
+use Omise\Payment\Model\Customer;
 
 class CreditCardDataObserver extends AbstractDataAssignObserver
 {
@@ -22,6 +23,16 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
         self::TOKEN,
         self::REMEMBER_CARD
     ];
+
+    /**
+     * @var Omise\Payment\Model\Customer
+     */
+    protected $customer;
+
+    public function __construct(Customer $customer)
+    {
+        $this->customer = $customer;
+    }
 
     /**
      * Handle 'payment_method_assign_data_omise_cc' event.
@@ -42,6 +53,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
             return;
         }
 
+        $this->saveCustomerCardIfNeeded($this->readPaymentModelArgument($observer), $additionalData);
         $this->setPaymentAdditionalInformation($this->readPaymentModelArgument($observer), $additionalData);
     }
 
@@ -60,6 +72,19 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
                     $additionalData[$additionalInformationKey]
                 );
             }
+        }
+    }
+
+    /**
+     * @param  \Magento\Payment\Model\InfoInterface $paymentInfo
+     * @param  array                                $additionalData
+     *
+     * @return void
+     */
+    protected function saveCustomerCardIfNeeded(InfoInterface $paymentInfo, array $additionalData)
+    {
+        if (isset($additionalData[self::REMEMBER_CARD])) {
+            $customer = $this->customer->create();
         }
     }
 }

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -84,7 +84,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      */
     protected function maybeSaveCustomerCard(array &$additionalData)
     {
-        if (isset($additionalData[self::REMEMBER_CARD])) {
+        if (isset($additionalData[self::REMEMBER_CARD]) && $additionalData[self::REMEMBER_CARD]) {
             $customer = $this->customer->addCard($additionalData[self::TOKEN]);
             $card     = $customer->getLatestCard();
 

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -13,6 +13,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      * @var string
      */
     const TOKEN         = 'omise_card_token';
+    const CARD          = 'omise_card';
     const REMEMBER_CARD = 'omise_save_card';
     const CUSTOMER      = 'customer';
 
@@ -22,6 +23,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
      */
     protected $additionalInformationList = [
         self::TOKEN,
+        self::CARD,
         self::REMEMBER_CARD
     ];
 

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -56,7 +56,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
             return;
         }
 
-        $this->saveCustomerCardIfNeeded($this->readPaymentModelArgument($observer), $additionalData);
+        $this->saveCustomerCardIfNeeded($additionalData);
         $this->setPaymentAdditionalInformation($this->readPaymentModelArgument($observer), $additionalData);
     }
 
@@ -79,20 +79,18 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     }
 
     /**
-     * @param  \Magento\Payment\Model\InfoInterface $paymentInfo
-     * @param  array                                $additionalData
+     * @param  array &$additionalData
      *
      * @return void
      */
-    protected function saveCustomerCardIfNeeded(InfoInterface $paymentInfo, array $additionalData)
+    protected function saveCustomerCardIfNeeded(array &$additionalData)
     {
         if (isset($additionalData[self::REMEMBER_CARD])) {
             $customer = $this->customer->attachCard($additionalData[self::TOKEN]);
+            $cards    = $customer->cards(array('order' => 'reverse_chronological'));
 
-            $paymentInfo->setAdditionalInformation(
-                self::CUSTOMER,
-                $customer->id
-            );
+            $additionalData[self::CUSTOMER] = $customer->id;
+            $additionalData[self::CARD]     = $cards['data'][0]['id'];
         }
     }
 }

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -11,13 +11,16 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     /**
      * @var string
      */
-    const TOKEN = 'omise_card_token';
+    const TOKEN         = 'omise_card_token';
+    const REMEMBER_CARD = 'omise_save_card';
+
 
     /**
      * @var array
      */
     protected $additionalInformationList = [
-        self::TOKEN
+        self::TOKEN,
+        self::REMEMBER_CARD
     ];
 
     /**

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -1,12 +1,39 @@
 <?php
 namespace Omise\Payment\Setup;
 
+use Magento\Customer\Model\Customer;
+use Magento\Eav\Setup\EavSetup;
 use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 
 class UpgradeData implements UpgradeDataInterface
 {
+    /**
+     * @var \Magento\Eav\Setup\EavSetupFactory
+     */
+    private $eavSetupFactory;
+
+    /**
+     * @var \Magento\Eav\Model\Config
+     */
+    private $eavConfig;
+
+    /**
+     * @var \Magento\Customer\Model\ResourceModel\Attribute
+     */
+    private $attributeResource;
+
+    public function __construct(
+        \Magento\Eav\Setup\EavSetupFactory              $eavSetupFactory,
+        \Magento\Eav\Model\Config                       $eavConfig,
+        \Magento\Customer\Model\ResourceModel\Attribute $attributeResource
+    ) {
+        $this->eavSetupFactory   = $eavSetupFactory;
+        $this->eavConfig         = $eavConfig;
+        $this->attributeResource = $attributeResource;
+    }
+
     /**
      * @param  ModuleDataSetupInterface $setup
      * @param  ModuleContextInterface   $context
@@ -43,6 +70,27 @@ class UpgradeData implements UpgradeDataInterface
                 ['path' => 'payment/omise_cc/payment_action'],
                 ['path = ?' => 'payment/omise/payment_action']
             );
+        }
+
+        if (version_compare($context->getVersion(), '2.4.0', '<')) {
+            $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+            $eavSetup->addAttribute(
+                Customer::ENTITY,
+                'omise_customer_id',
+                [
+                    'type'         => 'varchar',
+                    'label'        => 'Omise Customer ID',
+                    'input'        => 'text',
+                    'required'     => false,
+                    'visible'      => true,
+                    'user_defined' => false,
+                    'position'     => 0,
+                ]
+            );
+
+            $attribute = $this->eavConfig->getAttribute(Customer::ENTITY, 'omise_customer_id');
+            $attribute->setData('used_in_forms', ['adminhtml_customer']);
+            $this->attributeResource->save($attribute);
         }
 
         $setup->endSetup();

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -119,6 +119,20 @@ define(
             },
 
             /**
+             * @return {boolean}
+             */
+            isCustomerHasCard: function() {
+                return this.getCustomerCards().length > 0;
+            },
+
+            /**
+             * @return {array}
+             */
+            getCustomerCards: function() {
+                return window.checkoutConfig.payment.omise_cc.cards;
+            },
+
+            /**
              * Start performing place order action,
              * by disable a place order button and show full screen loader component.
              */

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -110,6 +110,13 @@ define(
             },
 
             /**
+             * @return {boolean}
+             */
+            isCustomerLoggedIn: function() {
+                return window.checkoutConfig.payment.omise_cc.isCustomerLoggedIn;
+            },
+
+            /**
              * Start performing place order action,
              * by disable a place order button and show full screen loader component.
              */

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -54,7 +54,8 @@ define(
                 return {
                     'method': this.item.method,
                     'additional_data': {
-                        'omise_card_token': this.omiseCardToken()
+                        'omise_card_token': this.omiseCardToken(),
+                        'omise_save_card': this.omiseSaveCard()
                     }
                 };
             },
@@ -81,7 +82,8 @@ define(
                         'omiseCardExpirationMonth',
                         'omiseCardExpirationYear',
                         'omiseCardSecurityCode',
-                        'omiseCardToken'
+                        'omiseCardToken',
+                        'omiseSaveCard'
                     ]);
 
                 return this;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -124,7 +124,7 @@ define(
              * @return {boolean}
              */
             isCustomerHasCard: function() {
-                return this.getCustomerCards().length > 0;
+                return this.getCustomerCards().length;
             },
 
             /**
@@ -246,8 +246,9 @@ define(
                     return false;
                 }
 
-                if ( this.omiseCard() ) {
-                    this.processOrderWithCard(this.omiseCard());
+                var card = this.omiseCard();
+                if ( card ) {
+                    this.processOrderWithCard(card);
                     return true;
                 }
 

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -37,19 +37,18 @@
 
             <!-- ko if: isCustomerHasCard() -->
                 <h4><!-- ko text: 'Select a card you want to proceed' --><!-- /ko --></h4>
-                <ul style="padding-left: 1.3em;">
+                <ul style="padding-left: 1.3em; margin-bottom: 2em;">
                     <!-- ko foreach: getCustomerCards() -->
                         <li style="list-style: none; margin-bottom: 2rem;">
-                            <!-- ko ifnot: $index -->
-                                <input type="radio" /> <label><!-- ko text: label --><!-- /ko --></label>
-                            <!-- /ko -->
-                            <!-- ko if: $index -->
-                                <input type="radio" /> <label><!-- ko text: label --><!-- /ko --></label>
-                            <!-- /ko -->
+                            <input name="payment[omise_card]" type="radio"
+                                data-bind="attr: {id: 'Card' + value}, checked: $parent.omiseCard, value: value"/>
+
+                            <label data-bind="attr: {for: 'Card' + value}"><!-- ko  text: label --><!-- /ko --></label>
+
                         </li>
                     <!-- /ko -->
                     <li style="list-style: none;">
-                        <input type="radio" name="payment[omise_card_id]" /> <label><!-- ko i18n: 'Use a new card'--><!-- /ko --></label>
+                        <input id="chargeWithNewCard" name="payment[omise_card]" type="radio" data-bind="click: chargeWithNewCard.bind($data, $element), checked: omiseCard, value: ''" /> <label for="chargeWithNewCard"><!-- ko i18n: 'Use a new card'--><!-- /ko --></label>
                     </li>
                 </ul>
             <!-- /ko -->

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -127,6 +127,17 @@
                                value: omiseCardSecurityCode"/>
                     </div>
                 </div>
+
+                <!-- ko if: isCustomerLoggedIn() -->
+                    <div class="field">
+                        <input  type="checkbox"
+                                data-bind="attr: {
+                                id: getCode() + 'SaveCard',
+                                },
+                                value: 1"/>
+                        <label data-bind="attr: {for: getCode() + 'SaveCard'}"><!-- ko i18n: 'Remember this card' --><!-- /ko --></label>
+                    </div>
+                <!-- /ko -->
             </fieldset>
         </form>
         <div class="checkout-agreements-block">

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -134,7 +134,7 @@
                                 data-bind="attr: {
                                 id: getCode() + 'SaveCard',
                                 },
-                                value: 1"/>
+                                checked: omiseSaveCard"/>
                         <label data-bind="attr: {for: getCode() + 'SaveCard'}"><!-- ko i18n: 'Remember this card' --><!-- /ko --></label>
                     </div>
                 <!-- /ko -->

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -34,7 +34,27 @@
                    'data-container': getCode() + '-cc-token',
                    },
                    value: omiseCardToken"/>
-            <fieldset data-bind="attr: {class: 'fieldset payment items ccard ' + getCode(), id: 'payment_form_' + getCode()}">
+
+            <!-- ko if: isCustomerHasCard() -->
+                <h4><!-- ko text: 'Select a card you want to proceed' --><!-- /ko --></h4>
+                <ul style="padding-left: 1.3em;">
+                    <!-- ko foreach: getCustomerCards() -->
+                        <li style="list-style: none; margin-bottom: 2rem;">
+                            <!-- ko ifnot: $index -->
+                                <input type="radio" /> <label><!-- ko text: label --><!-- /ko --></label>
+                            <!-- /ko -->
+                            <!-- ko if: $index -->
+                                <input type="radio" /> <label><!-- ko text: label --><!-- /ko --></label>
+                            <!-- /ko -->
+                        </li>
+                    <!-- /ko -->
+                    <li style="list-style: none;">
+                        <input type="radio" name="payment[omise_card_id]" /> <label><!-- ko i18n: 'Use a new card'--><!-- /ko --></label>
+                    </li>
+                </ul>
+            <!-- /ko -->
+
+            <fieldset data-bind="attr: {class: 'fieldset payment items ccard ' + getCode(), id: 'payment_form_' + getCode()}, visible: !isCustomerHasCard()">
                 <div class="field number required">
                     <label data-bind="attr: {for: getCode() + 'CardNumber'}" class="label">
                         <span><!-- ko i18n: 'Card number'--><!-- /ko --></span>


### PR DESCRIPTION
### 1. Objective

One of a powerful credit card feature is to "remember user's credit card".
This would make the payment process with credit card even faster by allowing users to save their credit card information with their Magento user account so users don't need to re-fill the credit card form again when they come to a second purchase.

> Note: According to a security-best-practice, in fact, we do not save any informations of a user's card into a merchant's store. Instead, we do exchange the user's credit card information with Omise service via Omise Customer API at the very first moment when user purchase a product with `save card` checked.
> Then, Omise will send back a Customer Object with a `customer.id`, which Omise-Magento plugin will only keep this `customer.id` to use to refer back to a specific Customer Object and its card.
 
### 2. Description of change

- New option at the checkout page, credit card payment method, `remember this card`.
- Users will be able to save their credit card information and retrieve it back for a second-time purchase.
- User will be able to charge with an existing card (1-click payment)

### 3. Quality assurance

**🔧 Environments:**

- **PHP version**: v7.1.16.
- **Platform version**: Magento Open Source v2.2.5.

**✏️ Details:**
**3.1). Make sure that user can create a charge with a guest-cart (not logged-in user) properly (on both auth only and auth and capture payment).**
- As a normal process, user must be able to checkout using Omise Credit Card payment either authorise only or authorise and capture payment action.

_[1] The credit card payment form should be shown as normal._
<img width="1358" alt="screen shot 2561-08-17 at 17 46 59" src="https://user-images.githubusercontent.com/2154669/44262534-96b9c400-a245-11e8-9d7f-129fc3929a43.png">

_[2] And user must be able to check out an order without having any problem with a guest-cart._
<img width="1552" alt="screen shot 2561-08-17 at 17 47 42" src="https://user-images.githubusercontent.com/2154669/44262562-a76a3a00-a245-11e8-9c98-09730d2af2cb.png">

_[3] Transaction will be appeared at the admin Magento order detail page._
<img width="1552" alt="screen shot 2561-08-17 at 17 48 47" src="https://user-images.githubusercontent.com/2154669/44262604-d54f7e80-a245-11e8-8c46-025584b053f0.png">

_[4] Omise received the charge request and processed it correctly (authorise and capture)._
<img width="1552" alt="screen shot 2561-08-17 at 17 52 46" src="https://user-images.githubusercontent.com/2154669/44262776-6a527780-a246-11e8-9fd6-c668fafa8b24.png">

_[5] Omise received the charge request and processed it correctly (authorise only)._
<img width="1552" alt="screen shot 2561-08-17 at 17 55 34" src="https://user-images.githubusercontent.com/2154669/44262877-d2a15900-a246-11e8-8e64-c7342709c86b.png">

**3.2). Make sure that user can create a charge using their Magento account (on both auth only and auth and capture payment).**
- Create a new account on the Magento store
- Logged in to the store and proceed the check out process as normal.
- As a normal process, user must be able to checkout using Omise Credit Card payment either authorise only or authorise and capture payment action.

_[1] Create a new account on the test-store._
<img width="1364" alt="screen shot 2561-08-17 at 18 14 44" src="https://user-images.githubusercontent.com/2154669/44263521-7855c780-a249-11e8-9e42-47d82a404888.png">

_[2] Logged in to the store and check out an order as normal._
<img width="1552" alt="screen shot 2561-08-17 at 18 17 38" src="https://user-images.githubusercontent.com/2154669/44263702-25c8db00-a24a-11e8-9ef4-c7fb44b4510b.png">

_[3] Omise received the charge request and processed it correctly (authorise only)._
<img width="1552" alt="screen shot 2561-08-17 at 18 21 12" src="https://user-images.githubusercontent.com/2154669/44263755-56a91000-a24a-11e8-9c50-79aff3a732dd.png">

_[4] Omise received the charge request and processed it correctly (authorise and capture)._
<img width="1552" alt="screen shot 2561-08-17 at 18 22 38" src="https://user-images.githubusercontent.com/2154669/44263806-89eb9f00-a24a-11e8-9a54-00e97394b39b.png">


**3.3). Make sure that the `save card` option will not be showing up on a screen with a guest account (not logged-in user).**
_[1] If you are not logged-in to the store, the `remember this card` option will not appear._
<img width="1358" alt="screen shot 2561-08-17 at 17 46 59" src="https://user-images.githubusercontent.com/2154669/44263887-da62fc80-a24a-11e8-852f-534b8808b5d4.png">


**3.4). Make sure that the `save card` option will be showed up on a screen if user is logged in to the store.**
_[1] The `remember this card` option will be appeared only when you logged-in to the store._
<img width="1552" alt="screen shot 2561-08-17 at 18 28 12" src="https://user-images.githubusercontent.com/2154669/44264137-9a504980-a24b-11e8-98f2-42ff2c29aac7.png">


**3.5). Make sure that the `remember this card` feature is working properly (user can be able to save their card for the next-time purchase).**
- Logged in to the store
- Check out an order, but this time, check on `remember this card` option.
- OmiseCustomer object must be created
- An Omise Token will be attached to the OmiseCustomer object.
- Then, the charge will be created using a specific `OmiseCustomer.id`.

_[1] If the `remember this card` is checked, an OmiseCustomer object will be created with a card attached._
<img width="1552" alt="screen shot 2561-08-17 at 18 35 24" src="https://user-images.githubusercontent.com/2154669/44264574-4cd4dc00-a24d-11e8-87fa-8ac186e11244.png">

_[2] User will be charged with a specific card (`OmiseCustomer.id` and `OmiseCard.id` will be assigned at the charge creation process)_
<img width="1552" alt="screen shot 2561-08-18 at 23 29 01" src="https://user-images.githubusercontent.com/2154669/44301293-a963f400-a33e-11e8-9e88-87fa08e8bd36.png">


**3.6). Make sure that existing cards will be listed up properly on the checkout page if user once saved their card.**
<img width="1370" alt="screen shot 2561-08-17 at 19 09 33" src="https://user-images.githubusercontent.com/2154669/44266908-7fcf9d80-a256-11e8-8239-8f55b470a10c.png">


**3.7). Make sure that user can always charge with a new card (not the saved ones).**
- Logged in to the store
- At the checkout page, user must always be able to choose to charge with a new card.

_[1] At the checkout page, you can enter a new card._
<img width="1370" alt="screen shot 2561-08-17 at 19 22 29" src="https://user-images.githubusercontent.com/2154669/44266885-662e5600-a256-11e8-8d0a-b873a5581a97.png">

_[2] A new card will be charged (as a normal tokenisation process)._
<img width="1552" alt="screen shot 2561-08-17 at 20 07 22" src="https://user-images.githubusercontent.com/2154669/44267697-6845e400-a259-11e8-8084-0154990f9c42.png">

**3.8). Make sure that user charge with any existing cards that they saved.**
- Logged in to the store.
- To test this case, you have to make an order about 2-3 times, and choose to `remember this card` every time. So the cards will be listed up on a screen.
- At the checkout page, you will see all of cards that you saved, choose to place an order with any card.

_[1] Once you saved your cards, it will be listed up at the checkout page._
<img width="1364" alt="screen shot 2561-08-18 at 23 39 38" src="https://user-images.githubusercontent.com/2154669/44301437-db765580-a340-11e8-9bf1-c1ad4575e00d.png">

_[2] From [1], there are 2 cards, and I made a charge with the MasterCard one._
<img width="1552" alt="screen shot 2561-08-18 at 23 43 58" src="https://user-images.githubusercontent.com/2154669/44301442-ffd23200-a340-11e8-9a51-8e0c6bef610d.png">

_[3] Make sure that the plugin charges to the right card, bring the `card.id` from the [2] to search at the Omise customer detail page_
<img width="1552" alt="screen shot 2561-08-18 at 23 44 14" src="https://user-images.githubusercontent.com/2154669/44301448-27c19580-a341-11e8-87a3-9d27b3434a50.png">

### 4. Impact of the change

There will be one new parameter on the Magento database.

### 5. Priority of change

Normal

### 6. Additional Notes

Not for now.