### PR TITLE
Removed dev flags for incoming 2.3 release

### DIFF
--- a/Model/Omise.php
+++ b/Model/Omise.php
@@ -73,7 +73,7 @@ class Omise
             define(
                 'OMISE_USER_AGENT_SUFFIX',
                 sprintf(
-                    'OmiseMagento/%s-dev Magento/%s',
+                    'OmiseMagento/%s Magento/%s',
                     $this->getModuleVersion(),
                     $this->getMagentoVersion()
                 )

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.3.0-dev",
+    "version": "2.3.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",


### PR DESCRIPTION
#### 1. Objective

Remove `dev` flags for upcoming 2.3 release.

#### 2. Description of change

Update `composer.json` with correct version of plugin.

Update plugin version in Omise Model, to be properly displayed in backend statistics.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.3-dev.
- **PHP version**: 7.0.29.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

Next version will be 2.4-dev, should be replaced soon after release.