### PR TITLE
Set plugin version base version for upcoming development - 2.4-dev

### DIFF
--- a/Model/Omise.php
+++ b/Model/Omise.php
@@ -73,7 +73,7 @@ class Omise
             define(
                 'OMISE_USER_AGENT_SUFFIX',
                 sprintf(
-                    'OmiseMagento/%s Magento/%s',
+                    'OmiseMagento/%s-dev Magento/%s',
                     $this->getModuleVersion(),
                     $this->getMagentoVersion()
                 )

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.3.0",
+    "version": "2.4.0-dev",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.3.0">
+    <module name="Omise_Payment" setup_version="2.4.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

Changed version of plugin for upcoming development.
Previous version: 2.3
Current version: 2.4-dev

#### 2. Description of change

Changed plugin version in composer.json,
also in `Model/Omise.php`, changed flag used to reporting plugin version usage on backend.

Additionally add the reasoning for change details if they're complex or abstract.

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.3.
- **PHP version**: 7.0.16.


#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A