### PR TITLE
MAG2: Code maintenance. Renaming class 'PaymentCcTokenBuilder' to 'CreditCardBuilder'.

### DIFF
--- a/Gateway/Request/CreditCardBuidler.php
+++ b/Gateway/Request/CreditCardBuidler.php
@@ -5,7 +5,7 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Omise\Payment\Observer\CreditCardDataObserver;
 
-class PaymentCcTokenBuilder implements BuilderInterface
+class CreditCardBuilder implements BuilderInterface
 {
     /**
      * @var string

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -201,7 +201,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuidler</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
                 <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
@@ -223,7 +223,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuidler</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
                 <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
             </argument>
@@ -274,7 +274,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuidler</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
             </argument>
         </arguments>
@@ -296,7 +296,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="cccard" xsi:type="string">Omise\Payment\Gateway\Request\PaymentCcTokenBuilder</item>
+                <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuidler</item>
                 <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
             </argument>
         </arguments>


### PR DESCRIPTION
### 1. Objective
Regarding to the coming 'save-card' feature.
There will be a condition where the card's value will be assigned either as a 'token' or as a 'card_id' depending on what buyer choose from the front-end.
Meaning that, 'PaymentCcTokenBuilder' name will not reflect with the above condition

So here, I think to rename this class to make it conform with its functionality is important one.

Note. Originally, this class has been designed to only serve for 'card = token_id' purpose (we didn't design this class to support save card feature) therefore we need to update it.

### 2. Description of change

- Simply renaming class name.

### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3
- **PHP version**: 7.1.16.

**✏️ Details:**

- **Make sure that we can still create a charge using `credit card` payment method.**
  Tested. It works.

### 4. Impact of the change

- If you have already installed Omise-Magento, you are going to need to at least, `flush` the store cache (there is a change in an xml file in this PR).
- If there is any problem during the check out after flushing your store's cache. Try run `composer dump-autoload` from the root folder of your Magento directory.

#### 5. Priority of change

Normal

#### 6. Additional Notes

- This one should me merged before PR #123.