### PR TITLE
2017-11-02 api support

### DIFF
--- a/Gateway/Request/PaymentOffsiteBuilder.php
+++ b/Gateway/Request/PaymentOffsiteBuilder.php
@@ -14,7 +14,12 @@ class PaymentOffsiteBuilder implements BuilderInterface
     /**
      * @var string
      */
-    const OFFSITE = 'offsite';
+    const SOURCE = 'source';
+
+    /**
+     * @var string
+     */
+    const SOURCE_TYPE = 'type';
 
     /**
      * @var string
@@ -49,12 +54,14 @@ class PaymentOffsiteBuilder implements BuilderInterface
         
         switch ($method->getMethod()) {
             case Alipay::CODE:
-                $paymentInfo[self::OFFSITE] = 'alipay';
+                $paymentInfo[self::SOURCE] = [
+                    self::SOURCE_TYPE => 'alipay'
+                ];
                 break;
             case Internetbanking::CODE:
-                $paymentInfo[self::OFFSITE] = $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE);
-                break;
-            default:
+                $paymentInfo[self::SOURCE] = [
+                    self::SOURCE_TYPE => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE)
+                ];
                 break;
         }
 

--- a/Model/Omise.php
+++ b/Model/Omise.php
@@ -55,7 +55,7 @@ class Omise
      *
      * @return void
      */
-    public function defineApiVersion($version = '2015-11-17')
+    public function defineApiVersion($version = '2017-11-02')
     {
         if (! defined('OMISE_API_VERSION')) {
             define('OMISE_API_VERSION', $version);


### PR DESCRIPTION
#### 1. Objective

Migration plugin to use new API 2017-11-02 to support new payment methods like: Bill Payment Tesco Lotus Solution

#### 2. Description of change

Used no create source approach, described in last sections of both documents named: *Creating a charge by adding attribute `source[type]`*.
https://www.omise.co/alipay
https://www.omise.co/offsite-payment

Most changes were done in request construction.
Renamed parameter used to send information about type of payment.
In old api it was called `offsite` in new api it is called `source[type]`

Charge is created in single api call.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.3.
- **PHP version**: 7.0.29.
- **Omise API Version**: 2017-11-02

**✏️ Details:**

To properly test it make successful payments using Internet Banking and Alipay method.

#### 4. Impact of the change

This change force all users using plugin `omise-magento` to use `API 2017-11-02`.
This change does not require from users to switch version of plugin in Omise Dashboard and is necessary for to make available new payment methods.

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A