### PR TITLE
Refactoring, renamed class OmiseCommandPool to OmiseCreditCardCommandPool

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -163,12 +163,12 @@
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseCreditCardCommandPool</argument>
         </arguments>
     </virtualType>
 
     <!-- Credit Card :: Command Pool -->
-    <virtualType name="OmiseCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
+    <virtualType name="OmiseCreditCardCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="initialize" xsi:type="string">OmiseCreditCardInitializeCommand</item>
@@ -182,7 +182,7 @@
 
     <virtualType name="OmiseCreditCardInitializeCommand" type="Omise\Payment\Gateway\Command\CreditCardStrategyCommand">
         <arguments>
-            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseCreditCardCommandPool</argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
### 1. Objective
To make code more readable changed `OmiseCommandPool` class name to `OmiseCreditCardCommandPool` in `di.xml`

This class concerns Credit Card functionality only. This name was designed when there were not other payment methods, so naming with general name was acceptable.
Now we have more classes specifying different command pools.

So:

- Internet Banking Command Pool is described in class named `OmiseOffsiteInternetbankingCommandPool`,

- Alipay Command Pool is described in class named `OmiseOffsiteAlipayCommandPool`

- but Credit Card Command Pool was described in `OmiseCommandPool`, that name is too general, and proposition is to change it to `OmiseCreditCardCommandPool`.

### 2. Description of change

- Just renaming class name.

### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4
- **PHP version**: 7.0.29.

**✏️ Details:**

- Before any testing flush cache by running `bin/magento cache:flush`.
- Make sure that we can still create a charge using `credit card` payment method.

### 4. Impact of the change

- N/A

### 5. Priority of change

Normal

### 6. Additional Notes

N/A