### PR TITLE
Fix for wrong spelling in Admin Panel

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -82,7 +82,7 @@
                     <comment>Enables customers to pay using Alipay method</comment>
                     <field id="active" translate="label comment" type="select" sortOrder="170" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
-                        <comment>Enable Alipay Peyment Solution.</comment>
+                        <comment>Enable Alipay Payment Solution.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_alipay/active</config_path>
                     </field>


### PR DESCRIPTION
#### 1. Objective

There is error in spelling in admin panel
there is *P**e**yment* instead of *P**a**yment*

<img width="709" alt="screen shot 2018-07-09 at 12 01 58" src="https://user-images.githubusercontent.com/10651523/42431539-5c1c4852-8370-11e8-80fa-58c75bfd6418.png">

#### 2. Description of change

Simply changed string value to *Payment*.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.4-dev.
- **PHP version**: 7.0.29.

**✏️ Details:**

Clear cache before testing, check if Alipay Payment is displayed correctly in admin panel.

#### 4. Impact of the change
N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A