### PR TITLE
Fix for not working webhooks due to script compilation error

### DIFF
--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -68,7 +68,7 @@ class Complete
             return;
         }
 
-        if ($order->isPaymentReview() || $order->getState() === Order::STATE_PENDING_PAYMENT) {
+        if ($order->isPaymentReview() || $order->getState() === MagentoOrder::STATE_PENDING_PAYMENT) {
             if ($charge->isFailed()) {
                 if ($order->hasInvoices()) {
                     $invoice = $order->getInvoiceCollection()->getLastItem();


### PR DESCRIPTION
#### 1. Objective

Fix for not working webhooks

#### 2. Description of change

Changed invalid class constants.
`STATE_PENDING_PAYMENT` does not exist in:
`Omise\Payment\Model\Order;`

but exists in:
`Magento\Sales\Model\Order` that is used via `MagentoOrder` alias

All other constants are used from `MagentoOrder` class.


#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.3.
- **PHP version**: 7.0.29.

**✏️ Details:**

To test it, make order using Tesco Lotus Payment, and mark later as paid in _Omise Dashboard_.
Observe proper status changes.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A