### PR TITLE
Offsite Refactoring

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -9,8 +9,8 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Omise\Payment\Model\Omise;
 use Omise\Payment\Model\Api\Charge;
-use Omise\Payment\Model\Config\Offsite\Internetbanking;
-use Omise\Payment\Model\Config\Offsite\Alipay;
+use Omise\Payment\Model\Config\Internetbanking;
+use Omise\Payment\Model\Config\Alipay;
 
 class Offsite extends Action
 {

--- a/Gateway/Request/PaymentBuilder.php
+++ b/Gateway/Request/PaymentBuilder.php
@@ -4,11 +4,11 @@ namespace Omise\Payment\Gateway\Request;
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Omise\Payment\Model\Config\Offsite\Alipay;
-use Omise\Payment\Model\Config\Offsite\Internetbanking;
-use Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver;
+use Omise\Payment\Model\Config\Alipay;
+use Omise\Payment\Model\Config\Internetbanking;
+use Omise\Payment\Observer\InternetbankingDataAssignObserver;
 
-class PaymentOffsiteBuilder implements BuilderInterface
+class PaymentBuilder implements BuilderInterface
 {
 
     /**
@@ -60,7 +60,7 @@ class PaymentOffsiteBuilder implements BuilderInterface
                 break;
             case Internetbanking::CODE:
                 $paymentInfo[self::SOURCE] = [
-                    self::SOURCE_TYPE => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE)
+                    self::SOURCE_TYPE => $method->getAdditionalInformation(InternetbankingDataAssignObserver::OFFSITE)
                 ];
                 break;
         }

--- a/Gateway/Validator/OmiseInitializeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseInitializeCommandResponseValidator.php
@@ -5,7 +5,7 @@ use Omise\Payment\Gateway\Validator\CommandResponseValidator;
 use Omise\Payment\Gateway\Validator\Message\Invalid as ErrorInvalid;
 use Omise\Payment\Model\Api\Charge;
 
-class OmiseOffsiteInitializeCommandResponseValidator extends CommandResponseValidator
+class OmiseInitializeCommandResponseValidator extends CommandResponseValidator
 {
     /**
      * @param  \Omise\Payment\Model\Api\Charge $charge

--- a/Model/Config/Alipay.php
+++ b/Model/Config/Alipay.php
@@ -1,5 +1,5 @@
 <?php
-namespace Omise\Payment\Model\Config\Offsite;
+namespace Omise\Payment\Model\Config;
 
 use Omise\Payment\Model\Config\Config;
 

--- a/Model/Config/Internetbanking.php
+++ b/Model/Config/Internetbanking.php
@@ -1,5 +1,5 @@
 <?php
-namespace Omise\Payment\Model\Config\Offsite;
+namespace Omise\Payment\Model\Config;
 
 use Omise\Payment\Model\Config\Config;
 

--- a/Observer/InternetbankingDataAssignObserver.php
+++ b/Observer/InternetbankingDataAssignObserver.php
@@ -5,7 +5,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 
-class OffsiteInternetbankingDataAssignObserver extends AbstractDataAssignObserver
+class InternetbankingDataAssignObserver extends AbstractDataAssignObserver
 {
     /**
      * @var string

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -6,12 +6,12 @@
     <!-- Internet Banking payment solution -->
     <virtualType name="OmiseOffsiteInternetbankingAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
-            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Offsite\Internetbanking::CODE</argument>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Internetbanking::CODE</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseOffsiteInternetbankingValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseOffsiteCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
         </arguments>
     </virtualType>
 
@@ -32,7 +32,7 @@
 
     <virtualType name="OmiseOffsiteInternetbankingConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Offsite\Internetbanking::CODE</argument>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Internetbanking::CODE</argument>
         </arguments>
     </virtualType>
     <!-- /Value Handler -->
@@ -40,63 +40,63 @@
     <!--  Alipay payment solution-->
     <virtualType name="OmiseOffsiteAlipayAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
-            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Offsite\Alipay::CODE</argument>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Alipay::CODE</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
-            <argument name="valueHandlerPool" xsi:type="object">OmiseOffsiteAlipayValueHandlerPool</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseAlipayValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseOffsiteCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseCommandPool</argument>
         </arguments>
     </virtualType>
 
     <!-- Alipay :: Value Handler Pool -->
-    <virtualType name="OmiseOffsiteAlipayValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+    <virtualType name="OmiseAlipayValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>
             <argument name="handlers" xsi:type="array">
-                <item name="default" xsi:type="string">OmiseOffsiteAlipayConfigValueHandler</item>
+                <item name="default" xsi:type="string">OmiseAlipayConfigValueHandler</item>
             </argument>
         </arguments>
     </virtualType>
     
-    <virtualType name="OmiseOffsiteAlipayConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+    <virtualType name="OmiseAlipayConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
-            <argument name="configInterface" xsi:type="object">OmiseOffsiteAlipayConfig</argument>
+            <argument name="configInterface" xsi:type="object">OmiseAlipayConfig</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteAlipayConfig" type="Magento\Payment\Gateway\Config\Config">
+    <virtualType name="OmiseAlipayConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Offsite\Alipay::CODE</argument>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Alipay::CODE</argument>
         </arguments>
     </virtualType>
     <!-- /Value Handler -->
 
     <!-- Offsite :: Command Pool -->
-    <virtualType name="OmiseOffsiteCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
+    <virtualType name="OmiseCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="initialize" xsi:type="string">OmiseOffsiteInitializeCommand</item>
+                <item name="initialize" xsi:type="string">OmiseInitializeCommand</item>
             </argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteInitializeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+    <virtualType name="OmiseInitializeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">OmiseOffsiteRequest</argument>
+            <argument name="requestBuilder" xsi:type="object">OmiseRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
             <argument name="handler" xsi:type="object">OmiseOffsiteResponseHandler</argument>
-            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseOffsiteInitializeCommandResponseValidator</argument>
+            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseInitializeCommandResponseValidator</argument>
         </arguments>
     </virtualType>
     <!-- /Command Pool -->
 
     <!-- Offsite Request -->
-    <virtualType name="OmiseOffsiteRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+    <virtualType name="OmiseRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentOffsiteBuilder</item>
+                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -122,16 +122,6 @@
         </arguments>
     </virtualType>
     <!-- /Offsite Response Handlers-->
-
-    <!-- Response Handler -->
-    <virtualType name="OmiseResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
-        <arguments>
-            <argument name="handlers" xsi:type="array">
-                <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
-            </argument>
-        </arguments>
-    </virtualType>
-    <!-- /Response Handler-->
 
     <!-- Credit Card payment solution -->
     <virtualType name="OmiseCcAdapter" type="Magento\Payment\Model\Method\Adapter">
@@ -240,13 +230,23 @@
         </arguments>
     </virtualType>
 
+    <!-- Response CC Handler -->
+    <virtualType name="OmiseCCResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <!-- /Response Handler-->
+
     <!-- OmiseAuthorize Command -->
     <virtualType name="OmiseAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseCCResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator</argument>
         </arguments>
     </virtualType>
@@ -268,7 +268,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseCCResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator</argument>
         </arguments>
     </virtualType>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,6 +4,6 @@
     </event>
 
     <event name="payment_method_assign_data_omise_offsite_internetbanking">
-        <observer name="omise_data_assign" instance="Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver" />
+        <observer name="omise_data_assign" instance="Omise\Payment\Observer\InternetbankingDataAssignObserver" />
     </event>
 </config>


### PR DESCRIPTION
Tesco lotus uses the same functionality, and tesco is not offsite method, so we need to change names for more general.

we are not sure how will look future api calls for new payment methods,
Now Offsite functionality is common also for Offline payments like Tesco Lotus,
that is why in this PR my proposal is to have 2 general descriptions.
OmiseXXXXXX
and OmiseCCXXXXX

I can't find better name for offline/offsite functionalities, so I put it to general ones.
and just simply removed _offsite_ word from common functionalities.

#### 1. Objective

This PR is necessary as for offline _tesco lotus_ functionality to use the same parts of code as offsite payments (alipay internet banking).


#### 2. Description of change

Just names of classes,


#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.29.

**✏️ Details:**

To properly test it you need to make payments with offsite Alipay, Internet Banking, and with Credit Card method.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A