### PR TITLE
Offsite refactoring, changed Offsite names to APM

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -9,8 +9,8 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Omise\Payment\Model\Omise;
 use Omise\Payment\Model\Api\Charge;
-use Omise\Payment\Model\Config\Offsite\Internetbanking;
-use Omise\Payment\Model\Config\Offsite\Alipay;
+use Omise\Payment\Model\Config\Internetbanking;
+use Omise\Payment\Model\Config\Alipay;
 
 class Offsite extends Action
 {

--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -8,7 +8,7 @@ use Omise\Payment\Model\Config\Alipay;
 use Omise\Payment\Model\Config\Internetbanking;
 use Omise\Payment\Observer\InternetbankingDataAssignObserver;
 
-class PaymentAPMBuilder implements BuilderInterface
+class APMBuilder implements BuilderInterface
 {
 
     /**

--- a/Gateway/Request/CreditCardAuthorizeBuilder.php
+++ b/Gateway/Request/CreditCardAuthorizeBuilder.php
@@ -3,7 +3,7 @@ namespace Omise\Payment\Gateway\Request;
 
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
-class PaymentAuthorizeBuilder implements BuilderInterface
+class CreditCardAuthorizeBuilder implements BuilderInterface
 {
     /**
      * @var string

--- a/Gateway/Request/CreditCardAuthorizeCaptureBuilder.php
+++ b/Gateway/Request/CreditCardAuthorizeCaptureBuilder.php
@@ -3,7 +3,7 @@ namespace Omise\Payment\Gateway\Request;
 
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
-class PaymentAuthorizeCaptureBuilder implements BuilderInterface
+class CreditCardAuthorizeCaptureBuilder implements BuilderInterface
 {
     /**
      * @var string

--- a/Gateway/Request/CreditCardThreeDSecureBuilder.php
+++ b/Gateway/Request/CreditCardThreeDSecureBuilder.php
@@ -4,7 +4,7 @@ namespace Omise\Payment\Gateway\Request;
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
-class PaymentThreeDSecureBuilder implements BuilderInterface
+class CreditCardThreeDSecureBuilder implements BuilderInterface
 {
     /**
      * @var string

--- a/Gateway/Request/PaymentAPMBuilder.php
+++ b/Gateway/Request/PaymentAPMBuilder.php
@@ -4,11 +4,11 @@ namespace Omise\Payment\Gateway\Request;
 use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Omise\Payment\Model\Config\Offsite\Alipay;
-use Omise\Payment\Model\Config\Offsite\Internetbanking;
-use Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver;
+use Omise\Payment\Model\Config\Alipay;
+use Omise\Payment\Model\Config\Internetbanking;
+use Omise\Payment\Observer\InternetbankingDataAssignObserver;
 
-class PaymentOffsiteBuilder implements BuilderInterface
+class PaymentAPMBuilder implements BuilderInterface
 {
 
     /**
@@ -60,7 +60,7 @@ class PaymentOffsiteBuilder implements BuilderInterface
                 break;
             case Internetbanking::CODE:
                 $paymentInfo[self::SOURCE] = [
-                    self::SOURCE_TYPE => $method->getAdditionalInformation(OffsiteInternetbankingDataAssignObserver::OFFSITE)
+                    self::SOURCE_TYPE => $method->getAdditionalInformation(InternetbankingDataAssignObserver::OFFSITE)
                 ];
                 break;
         }

--- a/Gateway/Validator/OmiseAPMInitializeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAPMInitializeCommandResponseValidator.php
@@ -5,7 +5,7 @@ use Omise\Payment\Gateway\Validator\CommandResponseValidator;
 use Omise\Payment\Gateway\Validator\Message\Invalid as ErrorInvalid;
 use Omise\Payment\Model\Api\Charge;
 
-class OmiseOffsiteInitializeCommandResponseValidator extends CommandResponseValidator
+class OmiseAPMInitializeCommandResponseValidator extends CommandResponseValidator
 {
     /**
      * @param  \Omise\Payment\Model\Api\Charge $charge

--- a/Model/Config/Alipay.php
+++ b/Model/Config/Alipay.php
@@ -1,5 +1,5 @@
 <?php
-namespace Omise\Payment\Model\Config\Offsite;
+namespace Omise\Payment\Model\Config;
 
 use Omise\Payment\Model\Config\Config;
 

--- a/Model/Config/Internetbanking.php
+++ b/Model/Config/Internetbanking.php
@@ -1,5 +1,5 @@
 <?php
-namespace Omise\Payment\Model\Config\Offsite;
+namespace Omise\Payment\Model\Config;
 
 use Omise\Payment\Model\Config\Config;
 

--- a/Observer/InternetbankingDataAssignObserver.php
+++ b/Observer/InternetbankingDataAssignObserver.php
@@ -5,7 +5,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
 
-class OffsiteInternetbankingDataAssignObserver extends AbstractDataAssignObserver
+class InternetbankingDataAssignObserver extends AbstractDataAssignObserver
 {
     /**
      * @var string

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -22,7 +22,7 @@
             <omise_offsite_internetbanking>
                 <active>0</active>
                 <title>Internet Banking</title>
-                <model>OmiseOffsiteInternetbankingAdapter</model>
+                <model>OmiseInternetbankingAdapter</model>
                 <is_gateway>1</is_gateway>
                 <can_initialize>1</can_initialize>
                 <can_use_checkout>1</can_use_checkout>
@@ -34,7 +34,7 @@
             <omise_offsite_alipay>
                 <active>0</active>
                 <title>Alipay</title>
-                <model>OmiseOffsiteAlipayAdapter</model>
+                <model>OmiseAlipayAdapter</model>
                 <is_gateway>1</is_gateway>
                 <can_initialize>1</can_initialize>
                 <can_use_checkout>1</can_use_checkout>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,106 +4,106 @@
     <preference for="Omise\Payment\Api\PaymentInformationInterface" type="Omise\Payment\Model\PaymentInformation" />
 
     <!-- Internet Banking payment solution -->
-    <virtualType name="OmiseOffsiteInternetbankingAdapter" type="Magento\Payment\Model\Method\Adapter">
+    <virtualType name="OmiseInternetbankingAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
-            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Offsite\Internetbanking::CODE</argument>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Internetbanking::CODE</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
-            <argument name="valueHandlerPool" xsi:type="object">OmiseOffsiteInternetbankingValueHandlerPool</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseAPMInternetbankingValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseOffsiteCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
 
     <!-- Internet Banking :: Value Handler Pool -->
-    <virtualType name="OmiseOffsiteInternetbankingValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+    <virtualType name="OmiseAPMInternetbankingValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>
             <argument name="handlers" xsi:type="array">
-                <item name="default" xsi:type="string">OmiseOffsiteInternetbankingConfigValueHandler</item>
+                <item name="default" xsi:type="string">OmiseAPMInternetbankingConfigValueHandler</item>
             </argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteInternetbankingConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+    <virtualType name="OmiseAPMInternetbankingConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
-            <argument name="configInterface" xsi:type="object">OmiseOffsiteInternetbankingConfig</argument>
+            <argument name="configInterface" xsi:type="object">OmiseAPMInternetbankingConfig</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteInternetbankingConfig" type="Magento\Payment\Gateway\Config\Config">
+    <virtualType name="OmiseAPMInternetbankingConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Offsite\Internetbanking::CODE</argument>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Internetbanking::CODE</argument>
         </arguments>
     </virtualType>
     <!-- /Value Handler -->
 
     <!--  Alipay payment solution-->
-    <virtualType name="OmiseOffsiteAlipayAdapter" type="Magento\Payment\Model\Method\Adapter">
+    <virtualType name="OmiseAlipayAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
-            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Offsite\Alipay::CODE</argument>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Alipay::CODE</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
-            <argument name="valueHandlerPool" xsi:type="object">OmiseOffsiteAlipayValueHandlerPool</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseAPMAlipayValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
-            <argument name="commandPool" xsi:type="object">OmiseOffsiteCommandPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
 
     <!-- Alipay :: Value Handler Pool -->
-    <virtualType name="OmiseOffsiteAlipayValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+    <virtualType name="OmiseAPMAlipayValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>
             <argument name="handlers" xsi:type="array">
-                <item name="default" xsi:type="string">OmiseOffsiteAlipayConfigValueHandler</item>
+                <item name="default" xsi:type="string">OmiseAPMAlipayConfigValueHandler</item>
             </argument>
         </arguments>
     </virtualType>
     
-    <virtualType name="OmiseOffsiteAlipayConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+    <virtualType name="OmiseAPMAlipayConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
-            <argument name="configInterface" xsi:type="object">OmiseOffsiteAlipayConfig</argument>
+            <argument name="configInterface" xsi:type="object">OmiseAPMAlipayConfig</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteAlipayConfig" type="Magento\Payment\Gateway\Config\Config">
+    <virtualType name="OmiseAPMAlipayConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
-            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Offsite\Alipay::CODE</argument>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Alipay::CODE</argument>
         </arguments>
     </virtualType>
     <!-- /Value Handler -->
 
-    <!-- Offsite :: Command Pool -->
-    <virtualType name="OmiseOffsiteCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
+    <!-- APM :: Command Pool -->
+    <virtualType name="OmiseAPMCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="initialize" xsi:type="string">OmiseOffsiteInitializeCommand</item>
+                <item name="initialize" xsi:type="string">OmiseAPMInitializeCommand</item>
             </argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteInitializeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+    <virtualType name="OmiseAPMInitializeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
-            <argument name="requestBuilder" xsi:type="object">OmiseOffsiteRequest</argument>
+            <argument name="requestBuilder" xsi:type="object">OmiseAPMRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseOffsiteResponseHandler</argument>
-            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseOffsiteInitializeCommandResponseValidator</argument>
+            <argument name="handler" xsi:type="object">OmiseAPMResponseHandler</argument>
+            <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAPMInitializeCommandResponseValidator</argument>
         </arguments>
     </virtualType>
     <!-- /Command Pool -->
 
-    <!-- Offsite Request -->
-    <virtualType name="OmiseOffsiteRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+    <!-- APM Request -->
+    <virtualType name="OmiseAPMRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentOffsiteBuilder</item>
+                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAPMBuilder</item>
             </argument>
         </arguments>
     </virtualType>
-    <!-- /Offsite Request -->
+    <!-- /APM Request -->
 
-    <!-- Offsite Response Handlers -->
-     <virtualType name="OmiseOffsiteResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+    <!-- APM Response Handlers -->
+     <virtualType name="OmiseAPMResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
@@ -113,7 +113,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseOffsiteAuthorizeResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+    <virtualType name="OmiseAPMAuthorizeResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="paymentDetails" xsi:type="string">Omise\Payment\Gateway\Response\PaymentDetailsHandler</item>
@@ -121,7 +121,7 @@
             </argument>
         </arguments>
     </virtualType>
-    <!-- /Offsite Response Handlers-->
+    <!-- /APM Response Handlers-->
 
     <!-- Response Handler -->
     <virtualType name="OmiseResponseHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
@@ -171,7 +171,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseOffsiteAuthorizeResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseAPMAuthorizeResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
     </virtualType>
@@ -194,7 +194,7 @@
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">OmiseCharge</argument>
-            <argument name="handler" xsi:type="object">OmiseOffsiteResponseHandler</argument>
+            <argument name="handler" xsi:type="object">OmiseAPMResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -96,7 +96,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAPMBuilder</item>
+                <item name="offsite" xsi:type="string">Omise\Payment\Gateway\Request\APMBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -181,8 +181,8 @@
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuilder</item>
-                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
-                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardAuthorizeBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -204,8 +204,8 @@
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuilder</item>
-                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
-                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\PaymentThreeDSecureBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardAuthorizeCaptureBuilder</item>
+                <item name="threedsecure" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardThreeDSecureBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -257,7 +257,7 @@
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuilder</item>
-                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardAuthorizeBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -279,7 +279,7 @@
             <argument name="builders" xsi:type="array">
                 <item name="payment" xsi:type="string">Omise\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="creditcard" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardBuilder</item>
-                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\PaymentAuthorizeCaptureBuilder</item>
+                <item name="capture" xsi:type="string">Omise\Payment\Gateway\Request\CreditCardAuthorizeCaptureBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -4,6 +4,6 @@
     </event>
 
     <event name="payment_method_assign_data_omise_offsite_internetbanking">
-        <observer name="omise_data_assign" instance="Omise\Payment\Observer\OffsiteInternetbankingDataAssignObserver" />
+        <observer name="omise_data_assign" instance="Omise\Payment\Observer\InternetbankingDataAssignObserver" />
     </event>
 </config>


### PR DESCRIPTION
Tesco lotus uses the same functionality as all other methods except CC, and tesco is not offsite method, so we need to change names for more fitting to offsite and offline payments.

So now now since Offsite functionality is common also for Offline payments like Tesco Lotus, and future payments like Installment this PR is proposal is to have 2 descriptions.
OmiseAPMXXXXXX - for `offsite` and `offline` methods
and OmiseCCXXXXX - for `CC` credit card related methods

#### 1. Objective

This PR is necessary as for offline _tesco lotus_ functionality to use the same parts of code as offsite payments (alipay internet banking).


#### 2. Description of change

Just names of classes,


#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.29.

**✏️ Details:**

To properly test it you need to make payments with offsite Alipay, Internet Banking, and with Credit Card method.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A