### PR TITLE
Mitigate issue caused by multiple hits on `return_uri`

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -39,6 +39,14 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
 
     /**
      * @param string $transaction_id
+     */
+    public function isInvoicePaid($transaction_id)
+    {
+        return $this->getInvoice($transaction_id)->getState() == Mage_Sales_Model_Order_Invoice::STATE_PAID;
+    }
+
+    /**
+     * @param string $transaction_id
      * @param string $state
      * @param string $message
      */

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidateoffsitealipayController extends Omise_Gatew
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('Captured amount of %s online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );


### PR DESCRIPTION
#### 1. Objective

An issue arose whereby payments were being recorded multiple times in Magento for an order, even though only one payment had been made through Omise. This appeared to be a strange edge case where the `return_uri` was somehow getting hit multiple times. We need to add some kind of check to make sure we only update the payment on the invoice if we have not previously done so.

#### 2. Description of change

A small check was added to each of the controllers hit by `return_uri` to make sure that the invoice was not already updated if we are attempting to update it.

The code to check the invoice state was added to the Omise Order model (`isInvoicePaid`)

#### 3. Quality assurance

Payments were retested for each type. The case of repeated hits to `return_uri` was also simulated to check the result was correct.

#### 4. Impact of the change

No observable changes to functionality or UI, but hopefully no more recurrences of this issue

#### 5. Priority of change

Normal

#### 6. Additional Notes

🛵