### PR TITLE
Switch to consistent naming of `private` and `protected` class members

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Form/Cc.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Cc.php
@@ -11,7 +11,7 @@ class Omise_Gateway_Block_Form_Cc extends Mage_Payment_Block_Form
      */
     protected function _prepareLayout()
     {
-        if ($this->isApplicable()) {
+        if ($this->_isApplicable()) {
             $this->setTemplate('payment/form/omise/omisecc.phtml');
         } else {
             $this->setTemplate('payment/form/omise/omise-inapplicable-method.phtml');
@@ -35,15 +35,15 @@ class Omise_Gateway_Block_Form_Cc extends Mage_Payment_Block_Form
      *
      * @return bool
      */
-    protected function isApplicable()
+    protected function _isApplicable()
     {
-        return $this->isStoreCurrencySupported();
+        return $this->_isStoreCurrencySupported();
     }
 
     /**
      * @return bool
      */
-    protected function isStoreCurrencySupported()
+    protected function _isStoreCurrencySupported()
     {
         return in_array(
             Mage::app()->getStore()->getBaseCurrencyCode(),

--- a/src/app/code/community/Omise/Gateway/Controller/Base.php
+++ b/src/app/code/community/Omise/Gateway/Controller/Base.php
@@ -10,7 +10,7 @@ abstract class Omise_Gateway_Controller_Base extends Mage_Core_Controller_Front_
     /**
      * @return \Omise_Gateway_Model_Order
      */
-    protected function getOrder()
+    protected function _getOrder()
     {
         $id = $this->getRequest()->getParam('order_id') ? $this->getRequest()->getParam('order_id') : null;
 

--- a/src/app/code/community/Omise/Gateway/Model/Api/Charge.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Charge.php
@@ -34,7 +34,7 @@ class Omise_Gateway_Model_Api_Charge extends Omise_Gateway_Model_Api_Object
     public function find($id)
     {
         try {
-            $this->refresh(OmiseCharge::retrieve($id));
+            $this->_refresh(OmiseCharge::retrieve($id));
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',
@@ -56,7 +56,7 @@ class Omise_Gateway_Model_Api_Charge extends Omise_Gateway_Model_Api_Object
     public function create($params)
     {
         try {
-            $this->refresh(OmiseCharge::create($params));
+            $this->_refresh(OmiseCharge::create($params));
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',
@@ -76,7 +76,7 @@ class Omise_Gateway_Model_Api_Charge extends Omise_Gateway_Model_Api_Object
     public function capture()
     {
         try {
-            $this->refresh($this->object->capture());
+            $this->_refresh($this->_object->capture());
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',
@@ -98,7 +98,7 @@ class Omise_Gateway_Model_Api_Charge extends Omise_Gateway_Model_Api_Object
     public function refund($params)
     {
         try {
-            return Mage::getModel('omise_gateway/api_refund', $this->object->refunds()->create($params));
+            return Mage::getModel('omise_gateway/api_refund', $this->_object->refunds()->create($params));
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',
@@ -126,7 +126,7 @@ class Omise_Gateway_Model_Api_Charge extends Omise_Gateway_Model_Api_Object
     public function reverse()
     {
         try {
-            $this->refresh($this->object->reverse());
+            $this->_refresh($this->_object->reverse());
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',

--- a/src/app/code/community/Omise/Gateway/Model/Api/Error.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Error.php
@@ -4,29 +4,29 @@ class Omise_Gateway_Model_Api_Error extends Omise_Gateway_Model_Api_Object
     /**
      * @var string
      */
-    protected $code    = '';
-    protected $message = '';
+    protected $_code    = '';
+    protected $_message = '';
 
     public function __construct($error = array())
     {
-        $this->setCode((isset($error['code']) ? $error['code'] : 'unexpected_error'));
-        $this->setMessage((isset($error['message']) ? $error['message'] : 'An unexpected error occurred, please contact our support team for further investigation.'));
+        $this->_setCode((isset($error['code']) ? $error['code'] : 'unexpected_error'));
+        $this->_setMessage((isset($error['message']) ? $error['message'] : 'An unexpected error occurred, please contact our support team for further investigation.'));
     }
 
     /**
      * @param string $code
      */
-    protected function setCode($code)
+    protected function _setCode($code)
     {
-        $this->code = $code;
+        $this->_code = $code;
     }
 
     /**
      * @param string $message
      */
-    protected function setMessage($message)
+    protected function _setMessage($message)
     {
-        $this->message = $message;
+        $this->_message = $message;
     }
 
     /**
@@ -34,7 +34,7 @@ class Omise_Gateway_Model_Api_Error extends Omise_Gateway_Model_Api_Object
      */
     public function getCode()
     {
-        return $this->code;
+        return $this->_code;
     }
 
     /**
@@ -42,6 +42,6 @@ class Omise_Gateway_Model_Api_Error extends Omise_Gateway_Model_Api_Object
      */
     public function getMessage()
     {
-        return $this->message;
+        return $this->_message;
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Api/Event.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Event.php
@@ -20,9 +20,9 @@ class Omise_Gateway_Model_Api_Event extends Omise_Gateway_Model_Api_Object
     {
         try {
             $event         = OmiseEvent::retrieve($id);
-            $event['data'] = $this->transformDataToObject($event['data']);
+            $event['data'] = $this->_transformDataToObject($event['data']);
 
-            $this->refresh($event);
+            $this->_refresh($event);
         } catch (Exception $e) {
             return Mage::getModel(
                 'omise_gateway/api_error',
@@ -41,7 +41,7 @@ class Omise_Gateway_Model_Api_Event extends Omise_Gateway_Model_Api_Object
      *
      * @return Omise_Gateway_Model_Api_Object|json-object
      */
-    protected function transformDataToObject($data)
+    protected function _transformDataToObject($data)
     {
         switch ($data['object']) {
             case 'charge':

--- a/src/app/code/community/Omise/Gateway/Model/Api/Object.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Object.php
@@ -4,23 +4,23 @@ class Omise_Gateway_Model_Api_Object
     /**
      * @var mixed
      */
-    protected $object;
+    protected $_object;
 
     /**
      * @param  mixed $object
      *
      * @return self
      */
-    protected function refresh($object = null)
+    protected function _refresh($object = null)
     {
-        if (is_null($this->object) && is_null($object)) {
+        if (is_null($this->_object) && is_null($object)) {
             return $this;
         }
 
         if (! is_null($object)) {
-            $this->object = $object;
-        } elseif (method_exists($this->object, 'refresh')) {
-            $this->object->refresh();
+            $this->_object = $object;
+        } elseif (method_exists($this->_object, 'refresh')) {
+            $this->_object->refresh();
         }
 
         return $this;
@@ -33,8 +33,8 @@ class Omise_Gateway_Model_Api_Object
      */
     public function __get($key)
     {
-        if (isset($this->object[$key])) {
-            return $this->object[$key];
+        if (isset($this->_object[$key])) {
+            return $this->_object[$key];
         }
 
         throw new Exception("Error Processing Request", 1);

--- a/src/app/code/community/Omise/Gateway/Model/Api/Refund.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Refund.php
@@ -25,7 +25,7 @@ class Omise_Gateway_Model_Api_Refund extends Omise_Gateway_Model_Api_Object
             throw new Exception("Error Processing Request", 1);
         }
 
-        $this->refresh($resource);
+        $this->_refresh($resource);
     }
 }
 

--- a/src/app/code/community/Omise/Gateway/Model/Event.php
+++ b/src/app/code/community/Omise/Gateway/Model/Event.php
@@ -4,7 +4,7 @@ class Omise_Gateway_Model_Event
     /**
      * @var array  of event classes that we can handle.
      */
-    protected $events = array();
+    protected $_events = array();
 
     public function __construct() {
         $events = array(
@@ -13,7 +13,7 @@ class Omise_Gateway_Model_Event
 
         foreach ($events as $event) {
             $clazz = Mage::getModel('omise_gateway/event_' . $event);
-            $this->events[$clazz->event] = $clazz;
+            $this->_events[$clazz->event] = $clazz;
         }
     }
 
@@ -23,10 +23,10 @@ class Omise_Gateway_Model_Event
      * @return mixed
      */
     public function handle($event) {
-        if (! isset($this->events[$event->key])) {
+        if (! isset($this->_events[$event->key])) {
             return;
         }
 
-        return $this->events[$event->key]->handle($event);
+        return $this->_events[$event->key]->handle($event);
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Omise.php
+++ b/src/app/code/community/Omise/Gateway/Model/Omise.php
@@ -4,7 +4,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     /**
      * @var \Omise_Gateway_Model_Config
      */
-    protected $config;
+    protected $_config;
 
     /**
      * Load necessary file and setup Omise keys
@@ -21,7 +21,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
         require_once(Mage::getBaseDir('lib') . '/omise-php/lib/Omise.php');
 
         // Retrieve Omise's keys from table.
-        $this->config = Mage::getModel('omise_gateway/config')->load(1);
+        $this->_config = Mage::getModel('omise_gateway/config')->load(1);
     }
 
     /**
@@ -29,7 +29,7 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
      */
     public function isTestMode()
     {
-        return $this->config->test_mode;
+        return $this->_config->test_mode;
     }
 
     /**
@@ -38,10 +38,10 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     public function getPublicKey()
     {
         if ($this->isTestMode()) {
-            return $this->config->public_key_test;
+            return $this->_config->public_key_test;
         }
 
-        return $this->config->public_key;
+        return $this->_config->public_key;
     }
 
     /**
@@ -50,10 +50,10 @@ class Omise_Gateway_Model_Omise extends Mage_Core_Model_Abstract
     public function getSecretKey()
     {
         if ($this->isTestMode()) {
-            return $this->config->secret_key_test;
+            return $this->_config->secret_key_test;
         }
 
-        return $this->config->secret_key;
+        return $this->_config->secret_key;
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -39,6 +39,14 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
 
     /**
      * @param string $transaction_id
+     */
+    public function isInvoicePaid($transaction_id)
+    {
+        return $this->getInvoice($transaction_id)->getState() == Mage_Sales_Model_Order_Invoice::STATE_PAID;
+    }
+
+    /**
+     * @param string $transaction_id
      * @param string $state
      * @param string $message
      */

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -9,7 +9,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     /**
      * @var array
      */
-    private $currency_subunits = array(
+    private $_currency_subunits = array(
         'JPY' => 1,
         'THB' => 100,
         'SGD' => 100,
@@ -36,7 +36,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     protected function _isCurrencySupport($currency)
     {
-        if (isset($this->currency_subunits[strtoupper($currency)])) {
+        if (isset($this->_currency_subunits[strtoupper($currency)])) {
             return true;
         }
 
@@ -52,7 +52,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     public function getAmountInSubunits($amount, $currency)
     {
         if ($this->_isCurrencySupport($currency)) {
-            return $this->currency_subunits[$currency] * $amount;
+            return $this->_currency_subunits[$currency] * $amount;
         }
 
         return $amount;

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -4,7 +4,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     /**
      * @var \Omise_Gateway_Model_Omise
      */
-    protected $omise;
+    protected $_omise;
 
     /**
      * @var array
@@ -25,8 +25,8 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     public function __construct()
     {
-        $this->omise = Mage::getModel('omise_gateway/omise');
-        $this->omise->initNecessaryConstant();
+        $this->_omise = Mage::getModel('omise_gateway/omise');
+        $this->_omise->initNecessaryConstant();
     }
 
     /**
@@ -34,7 +34,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      *
      * @return bool
      */
-    protected function isCurrencySupport($currency)
+    protected function _isCurrencySupport($currency)
     {
         if (isset($this->currency_subunits[strtoupper($currency)])) {
             return true;
@@ -51,7 +51,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     public function getAmountInSubunits($amount, $currency)
     {
-        if ($this->isCurrencySupport($currency)) {
+        if ($this->_isCurrencySupport($currency)) {
             return $this->currency_subunits[$currency] * $amount;
         }
 
@@ -66,7 +66,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      *
      * @throws Mage_Core_Exception
      */
-    protected function process(Varien_Object $payment, $params)
+    protected function _process(Varien_Object $payment, $params)
     {
         $charge = Mage::getModel('omise_gateway/api_charge')->create($params);
 
@@ -85,7 +85,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
         }
 
         if ($charge->isAwaitPayment()) {
-            $this->setRedirectFlow($payment, $charge);
+            $this->_setRedirectFlow($payment, $charge);
         }
 
         $this->getInfoInstance()->setAdditionalInformation('omise_charge_id', $charge->id);
@@ -106,7 +106,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     {
         parent::acceptPayment($payment);
 
-        $this->closeTransaction($payment);
+        $this->_closeTransaction($payment);
 
         return true;
     }
@@ -124,7 +124,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     {
         parent::denyPayment($payment);
 
-        $this->closeTransaction($payment);
+        $this->_closeTransaction($payment);
 
         return true;
     }
@@ -132,7 +132,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     /**
      * @param Varien_Object $payment
      */
-    protected function closeTransaction(Varien_Object $payment)
+    protected function _closeTransaction(Varien_Object $payment)
     {
         $transaction = $payment->getTransaction($payment->getLastTransId());
         if ($transaction->getTxnType() === Mage_Sales_Model_Order_Payment_Transaction::TYPE_CAPTURE) {
@@ -149,7 +149,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      * @param Varien_Object                  $payment
      * @param Omise_Gateway_Model_Api_Charge $charge
      */
-    protected function setRedirectFlow(Varien_Object $payment, Omise_Gateway_Model_Api_Charge $charge)
+    protected function _setRedirectFlow(Varien_Object $payment, Omise_Gateway_Model_Api_Charge $charge)
     {
         $payment->setIsTransactionPending(true);
 
@@ -165,7 +165,7 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      *
      * @throws Mage_Core_Exception
      */
-    protected function suspectToBeFailed(Varien_Object $payment)
+    protected function _suspectToBeFailed(Varien_Object $payment)
     {
         $message = 'Payment failed. Please note that your payment and order might (or might not) have already been processed. Please contact our support team using your order reference number (' . $payment->getOrder()->getIncrementId() . ') to confirm your payment.';
         Mage::throwException(Mage::helper('payment')->__($message));

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -103,7 +103,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
             return;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**
@@ -116,7 +116,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
     {
         $order = $payment->getOrder();
 
-        return $this->process(
+        return $this->_process(
             $payment,
             array(
                 'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
@@ -145,7 +145,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
         Mage::log('Omise: authorizing payment.');
 
         $order  = $payment->getOrder();
-        $charge = $this->process(
+        $charge = $this->_process(
             $payment,
             array(
                 'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
@@ -166,7 +166,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
             return $this;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**
@@ -186,7 +186,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
         }
 
         $order  = $payment->getOrder();
-        $charge = $this->process(
+        $charge = $this->_process(
             $payment,
             array(
                 'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
@@ -205,7 +205,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
             return $this;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**
@@ -246,7 +246,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
             return $this;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitealipay.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitealipay.php
@@ -52,7 +52,7 @@ class Omise_Gateway_Model_Payment_Offsitealipay extends Omise_Gateway_Model_Paym
         $invoice = $order->prepareInvoice();
         $invoice->setIsPaid(false)->register();
 
-        $charge = $this->process($payment, $invoice->getBaseGrandTotal());
+        $charge = $this->_process($payment, $invoice->getBaseGrandTotal());
 
         $payment->setCreatedInvoice($invoice)
                 ->setIsTransactionClosed(false)
@@ -74,7 +74,7 @@ class Omise_Gateway_Model_Payment_Offsitealipay extends Omise_Gateway_Model_Paym
             return;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitealipay.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitealipay.php
@@ -52,7 +52,7 @@ class Omise_Gateway_Model_Payment_Offsitealipay extends Omise_Gateway_Model_Paym
         $invoice = $order->prepareInvoice();
         $invoice->setIsPaid(false)->register();
 
-        $charge = $this->_process($payment, $invoice->getBaseGrandTotal());
+        $charge = $this->process($payment, $invoice->getBaseGrandTotal());
 
         $payment->setCreatedInvoice($invoice)
                 ->setIsTransactionClosed(false)
@@ -87,7 +87,7 @@ class Omise_Gateway_Model_Payment_Offsitealipay extends Omise_Gateway_Model_Paym
     {
         $order = $payment->getOrder();
 
-        return parent::process(
+        return parent::_process(
             $payment,
             array(
                 'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
@@ -52,7 +52,7 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
         $invoice = $order->prepareInvoice();
         $invoice->setIsPaid(false)->register();
 
-        $charge = $this->_process($payment, $invoice->getBaseGrandTotal());
+        $charge = $this->process($payment, $invoice->getBaseGrandTotal());
 
         $payment->setCreatedInvoice($invoice)
                 ->setIsTransactionClosed(false)
@@ -87,7 +87,7 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
     {
         $order = $payment->getOrder();
 
-        return parent::process(
+        return parent::_process(
             $payment,
             array(
                 'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsiteinternetbanking.php
@@ -52,7 +52,7 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
         $invoice = $order->prepareInvoice();
         $invoice->setIsPaid(false)->register();
 
-        $charge = $this->process($payment, $invoice->getBaseGrandTotal());
+        $charge = $this->_process($payment, $invoice->getBaseGrandTotal());
 
         $payment->setCreatedInvoice($invoice)
                 ->setIsTransactionClosed(false)
@@ -74,7 +74,7 @@ class Omise_Gateway_Model_Payment_Offsiteinternetbanking extends Omise_Gateway_M
             return;
         }
 
-        $this->suspectToBeFailed($payment);
+        $this->_suspectToBeFailed($payment);
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
@@ -4,7 +4,7 @@ class Omise_Gateway_Callback_ValidateoffsitealipayController extends Omise_Gatew
     public function indexAction()
     {
         // Callback validation.
-        $order = $this->getOrder();
+        $order = $this->_getOrder();
 
         if (! $payment = $order->getPayment()) {
             Mage::getSingleton('core/session')->addError(

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidateoffsitealipayController extends Omise_Gatew
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -4,7 +4,7 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
     public function indexAction()
     {
         // Callback validation.
-        $order = $this->getOrder();
+        $order = $this->_getOrder();
 
         if (! $payment = $order->getPayment()) {
             Mage::getSingleton('core/session')->addError(

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -4,7 +4,7 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
     public function indexAction()
     {
         // Callback validation.
-        $order = $this->getOrder();
+        $order = $this->_getOrder();
 
         if (! $payment = $order->getPayment()) {
             Mage::getSingleton('core/session')->addError(

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -37,9 +37,11 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
 
         if ($charge->isSuccessful()) {
             $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
 
-            $order->markAsPaid(
-                $payment->getLastTransId(),
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('Captured amount of %s online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );


### PR DESCRIPTION
#### 1. Objective

I noticed that we were randomly enforcing a naming convention of using an underscore prefix for `private` and `protected` class members. This should be enforced right across the plugin

#### 2. Description of change

Renamed all affected class members so that they now have the required underscore prefix

#### 3. Quality assurance

Re-tested all plugin functionality after making the changes

#### 4. Impact of the change

Now easier to see at a glance whether a class member is public or not

#### 5. Priority of change

Normal

#### 6. Additional Notes

👾👾👾