### PR TITLE
MAG2x: Changing long array syntax to the short syntax one.

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -77,7 +77,7 @@ class Offsite extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if (! in_array($payment->getMethod(), array(Alipay::CODE, Internetbanking::CODE))) {
+        if (! in_array($payment->getMethod(), [Alipay::CODE, Internetbanking::CODE])) {
             $this->invalid($order, __('Invalid payment method. Please contact our support if you have any questions.'));
 
             return $this->redirect(self::PATH_CART);

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -68,7 +68,7 @@ class Customer extends Object
     /**
      * TODO: Need to refactor a bit
      */
-    public function cards($options = array())
+    public function cards($options = [])
     {
         return $this->object->cards($options);
     }

--- a/Model/Api/Error.php
+++ b/Model/Api/Error.php
@@ -10,7 +10,7 @@ class Error extends Object
     protected $code    = 'unexpected_error';
     protected $message = 'There is an unexpected error happened, please contact our support for further investigation.';
 
-    public function __construct($error = array())
+    public function __construct($error = [])
     {
         isset($error['code']) ? $this->setCode($error['code']) : '';
         isset($error['message']) ? $this->setMessage($error['message']) : '';

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -117,13 +117,13 @@ class Customer
     public function addCard($cardToken)
     {
         if (! $this->getId()) {
-            $this->create(array(
+            $this->create([
                 'email'       => $this->magentoCustomer->getEmail(),
                 'description' => trim($this->magentoCustomer->getFirstname() . ' ' . $this->magentoCustomer->getLastname())
-            ));
+            ]);
         }
 
-        $this->customerAPI = $this->customerAPI->update(array('card' => $cardToken));
+        $this->customerAPI = $this->customerAPI->update(['card' => $cardToken]);
 
         return $this;
     }
@@ -137,7 +137,7 @@ class Customer
      *
      * @see    https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCardList.php
      */
-    public function cards($options = array())
+    public function cards($options = [])
     {
         return $this->customerAPI->cards($options);
     }
@@ -149,7 +149,7 @@ class Customer
      */
     public function getLatestCard()
     {
-        $cards = $this->cards(array('order' => 'reverse_chronological'));
+        $cards = $this->cards(['order' => 'reverse_chronological']);
 
         return $cards['total'] > 0 ? $cards['data'][0] : null;
     }

--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -62,16 +62,16 @@ class CcConfigProvider implements ConfigProviderInterface
     public function getCards()
     {
         if (! $this->customer->getMagentoCustomerId() || ! $this->customer->getId()) {
-            return array();
+            return [];
         }
 
-        $cards = $this->customer->cards(array('order' => 'reverse_chronological'));
+        $cards = $this->customer->cards(['order' => 'reverse_chronological']);
 
         if (! $cards) {
-            return array();
+            return [];
         }
 
-        $data = array();
+        $data = [];
 
         foreach($cards['data'] as $card) {
             $label = $card['brand'] . ' **** ' . $card['last_digits'];

--- a/Test/Unit/Model/Api/ObjectTest.php
+++ b/Test/Unit/Model/Api/ObjectTest.php
@@ -98,7 +98,7 @@ class MockObject extends Object
 class MockOmiseObject implements \ArrayAccess
 {
     // Store the attributes of the object.
-    protected $_values = array();
+    protected $_values = [];
 
     public function refresh()
     {


### PR DESCRIPTION
> ⚠️ **Note, this pull request requires PR #123 to be merged first.**

#### 1. Objective

<img width="571" alt="screen shot 2561-09-18 at 14 54 14" src="https://user-images.githubusercontent.com/2154669/45673661-7be4b300-bb55-11e8-97f1-4ef8d42ea330.png">

There are code standard provided by Magento that all extensions have to follow in order to submit the code to their Magento Marketplace.

This pull request is aiming to update one of the standard (array syntax) to a proper one that Magento requires.

#### 2. Description of change

- Update all long-syntax-array to the short one.

#### 3. Quality assurance

1. Install https://github.com/magento/marketplace-eqp.
2. Execute the command  `vendor/bin/phpcs /path/to/your/extension --standard=MEQP2`.
3. Search for a warning message `Short array syntax must be used to define arrays`.

**Before change, we should see these ones**
<img width="571" alt="screen shot 2561-09-18 at 14 54 14" src="https://user-images.githubusercontent.com/2154669/45673297-85b9e680-bb54-11e8-88b7-dddca173910b.png">

**After change, we should see none of them**
<img width="1550" alt="screen shot 2561-09-18 at 15 01 40" src="https://user-images.githubusercontent.com/2154669/45673322-9d916a80-bb54-11e8-9182-7286b4df3daa.png">

#### 4. Impact of the change

Nothing in a user perspective, but it will make our extension be able to pass the Magento Code Quality Standard and able to submit to the Magento Marketplace.

#### 5. Priority of change

Normal

#### 6. Additional Notes

-