### PR TITLE
change plugin version from 2.4.0-dev to 2.4.0 - to release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.4.0-dev",
+    "version": "2.4.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",


### PR DESCRIPTION
#### 1. Objective

Change plugin version in `composer.json`

For release


#### 2. Description of change

Just remove `-dev` part.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.5.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.29.

**✏️ Details:**

Use compser json to install plugin.

#### 4. Impact of the change

none

#### 5. Priority of change

Immediate

#### 6. Additional Notes

None