### PR TITLE
Fixes issue with orders not being updated after an order 'cancelled' by closing browser tab/window

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
+++ b/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
@@ -50,12 +50,14 @@ class Omise_Gateway_Model_Event_Charge_Complete
             return;
         }
 
-        if ($order->isPaymentReview() && ($charge->isSuccessful() || $charge->isAwaitCapture())) {
+        $isPendingOrReview = $order->isPaymentReview() || $order->isPaymentPending();
+
+        if ($isPendingOrReview && ($charge->isSuccessful() || $charge->isAwaitCapture())) {
             $order->getPayment()->accept();
             return $order->save();
         }
 
-        if ($order->isPaymentReview() && $charge->isFailed()) {
+        if ($isPendingOrReview && $charge->isFailed()) {
             $order->getPayment()->deny();
             return $order->save();
         }

--- a/src/app/code/community/Omise/Gateway/Model/Order.php
+++ b/src/app/code/community/Omise/Gateway/Model/Order.php
@@ -16,6 +16,16 @@ class Omise_Gateway_Model_Order extends Mage_Sales_Model_Order
     }
 
     /**
+     * Check whether the payment is in payment pending state
+     *
+     * @return bool
+     */
+    public function isPaymentPending()
+    {
+        return $this->getState() === Mage_Sales_Model_Order::STATE_PENDING_PAYMENT;
+    }
+
+    /**
      * @return self
      */
     public function loadBySession()


### PR DESCRIPTION
#### 1. Fix the problem where Webhook was not updating order status if `return_uri` was never hit

Some merchants had found the problem where a customer had 'cancelled' an order by closing a browser window at the internet banking stage. This was a situation not handled correctly in the code

#### 2. Description of change

The webhook will now change the status of an order if it is marked as pending payment, or pending review.

#### 3. Quality assurance

Tested on Magento 1.9.3.9

**✏️ Details:**

Block access to your local site during the payment process so that `return_uri` is never hit for the order. Then, grab the JSON from the webhook 'complete' event and manually post it to the webhook on your site. The order should be cancelled.

#### 4. Impact of the change

Orders 'cancelled' in this manner should now be successfully cancelled in Magento

#### 5. Priority of change

Normal

#### 6. Additional Notes

¯\_(ツ)_/¯