### PR TITLE
Adds required code to fix order emails not being sent in all 'redirect' scenarios

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
+++ b/src/app/code/community/Omise/Gateway/Model/Event/Charge/Complete.php
@@ -54,6 +54,7 @@ class Omise_Gateway_Model_Event_Charge_Complete
 
         if ($isPendingOrReview && ($charge->isSuccessful() || $charge->isAwaitCapture())) {
             $order->getPayment()->accept();
+            $order->sendNewOrderEmail();
             return $order->save();
         }
 

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -81,7 +81,6 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                             false,
                             Mage::helper('omise_gateway')->__('Capturing an amount of %s via Omise 3-D Secure payment.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
                         );
-
                 $order->addRelatedObject($invoice);
                 break;
 

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitealipayController.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Callback_ValidateoffsitealipayController extends Omise_Gatew
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );
-
+            $order->sendNewOrderEmail();
             return $this->_redirect('checkout/onepage/success');
         }
 

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsiteinternetbankingController.php
@@ -45,7 +45,7 @@ class Omise_Gateway_Callback_ValidateoffsiteinternetbankingController extends Om
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );
-
+            $order->sendNewOrderEmail();
             return $this->_redirect('checkout/onepage/success');
         }
 

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidatethreedsecureController.php
@@ -31,7 +31,7 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('Authorized amount of %s.', $order->getBaseCurrency()->formatTxt($order->getBaseTotalDue()))
             );
-
+            $order->sendNewOrderEmail();
             return $this->_redirect('checkout/onepage/success');
         }
 
@@ -45,7 +45,7 @@ class Omise_Gateway_Callback_ValidatethreedsecureController extends Omise_Gatewa
                 Mage_Sales_Model_Order::STATE_PROCESSING,
                 Mage::helper('omise_gateway')->__('Captured amount of %s online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );
-
+            $order->sendNewOrderEmail();
             return $this->_redirect('checkout/onepage/success');
         }
 


### PR DESCRIPTION
#### 1. Objective

Fixes the issue with order emails not being sent out. It appears that any payment using a method involving a redirect (3D secure, Alipay, Internet Banking) was not sending out an order email after payment.

**Related information**:
Related issue(s): #89 

#### 2. Description of change

Added `$order->sendNewOrderEmail();` in all required places

#### 3. Quality assurance

Tested on Magento 1.9.3.9

Tested all payment methods available in Omise, both in `authorise` and `authorise and capture` modes. Also tested with webhooks on/off to make sure all cases handled correctly (no duplicate emails etc.)

Emails should look like this:
<img width="620" alt="screenshot 2018-11-07 at 12 35 25" src="https://user-images.githubusercontent.com/1510194/48113856-4f186680-e28f-11e8-9ce3-b29f239a9c0b.png">


This [plugin](https://github.com/aschroder/Magento-SMTP-Pro-Email-Extension) is particularly useful for setting up email in Magento so you can test easily. It also logs all emails

#### 4. Impact of the change

Order emails should now be sent out correctly in all cases

#### 5. Priority of change

Normal

#### 6. Additional Notes

This issue also affects Magento 2 - hopefully the fix will be similar.