### PR TITLE
Fixed problem that translation to 'Select a card you want to proceed'

### DIFF
--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -36,7 +36,7 @@
                    value: omiseCardToken"/>
 
             <!-- ko if: isCustomerHasCard() -->
-                <h4><!-- ko text: 'Select a card you want to proceed' --><!-- /ko --></h4>
+                <h4><!-- ko i18n: 'Select a card you want to proceed' --><!-- /ko --></h4>
                 <ul style="padding-left: 1.3em; margin-bottom: 2em;">
                     <!-- ko foreach: getCustomerCards() -->
                         <li style="list-style: none; margin-bottom: 2rem;">


### PR DESCRIPTION
#### 1. Objective

Make the translation work at the part where translation did not work.

#### 2. Description of change

Just modify the corresponding part in the template file.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento Open Source 2.2.6.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.32.

**✏️ Details:**

Write a translation in the i18n file and confirm that translation works.
The place to check is the heading of the field to select a credit card when a credit card is stored.

#### 4. Impact of the change

Translation will work.

#### 5. Priority of change

High for non-English speaking developers.

#### 6. Additional Notes

N/A