### PR TITLE
Restrict internet banking payment method to THB orders only

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
@@ -40,6 +40,24 @@ define(
             },
 
             /**
+             * Get order currency
+             *
+             * @return {string}
+             */
+            getOrderCurrency: function () {
+                return window.checkoutConfig.quoteData.quote_currency_code;
+            },
+
+             /**
+             * Get store currency
+             *
+             * @return {string}
+             */
+            getStoreCurrency: function () {
+                return window.checkoutConfig.quoteData.store_currency_code;
+            },
+
+            /**
              * Initiate observable fields
              *
              * @return this
@@ -73,7 +91,7 @@ define(
              * @return {boolean}
              */
             isActive: function() {
-                return true;
+                return this.getOrderCurrency().toLowerCase() === 'thb' && this.getStoreCurrency().toLowerCase() === 'thb';
             },
 
             /**

--- a/view/frontend/web/template/payment/offsite-internetbanking-form.html
+++ b/view/frontend/web/template/payment/offsite-internetbanking-form.html
@@ -9,10 +9,18 @@
                value: getCode(),
                checked: isChecked,
                click: selectPaymentMethod,
-               visible: isRadioButtonVisible()"/>
+               visible: isRadioButtonVisible(),
+               enable: isActive()"/>
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: !isActive()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Option available only for orders in THB'"></div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="payment-method-content">
         <!-- ko foreach: getRegion('messages') -->


### PR DESCRIPTION
#### 1. Objective

Internet Banking payment option is available only for Thai Baht orders.
The purpose of this PR is to disable possibility of make Internet Banking payments for orders in other currencies.

#### 2. Description of change

Changed in JavaScript rendering files and HTML Internet Banking Checkout payment view.

To resolve issue there is checking if order is done in THB (Thai Baht) if yes, than payment method is displayed normally, otherwise option is _readonly_ and it is displayed message 
_Option available only for Thai Baht currency orders_

<img width="1240" alt="screenshot 2018-10-31 at 12 34 31" src="https://user-images.githubusercontent.com/10651523/47768251-cedf8780-dd09-11e8-9ce2-aaa1de73a31a.png">

#### 3. Quality assurance
**🔧 Environments:**

- **Platform version**: Magento CE 2.5.
- **Omise plugin version**: Omise-Magento 2.5-dev.
- **PHP version**: 7.0.29.

**✏️ Details:**

Step 1. Open magento admin, make sure that Thai Baht is main store currency.
Make order, and do payment with Alipay.
Step 2. Open magento admin, change Thai Baht store currency to other currency,
Try to make payment with Internet Banking. Payment should not be available.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A