### PR TITLE
Fix for missing "Terms and Conditions" in Alipay and Tesco payment method

### DIFF
--- a/view/frontend/web/template/payment/offline-tesco-form.html
+++ b/view/frontend/web/template/payment/offline-tesco-form.html
@@ -24,6 +24,11 @@
             <!-- /ko -->
             <!--/ko-->
         </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
         <div class="actions-toolbar">
             <div class="primary">
                 <button class="action primary checkout" type="submit"

--- a/view/frontend/web/template/payment/offsite-alipay-form.html
+++ b/view/frontend/web/template/payment/offsite-alipay-form.html
@@ -32,6 +32,11 @@
             <!-- /ko -->
             <!--/ko-->
         </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
         <div class="actions-toolbar">
             <div class="primary">
                 <button class="action primary checkout" type="submit"


### PR DESCRIPTION
#### 1. Objective

When Store admin turn on displaying information about Terms And Conditions than it should be visible on checkout page, when user is selecting payment method.
That option is not visible currently for Alipay and Tesco Bill Payment.
 
This PR is fix for above error.
#### 2. Description of change

Added html block that display terms and conditions if it that option is activated in admin panel.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.5.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.29.

**✏️ Details:**

Turn on terms and conditions option.
https://docs.magento.com/m2/ce/user_guide/sales/terms-and-conditions.html

Check if terms are displayed on checkout page on `Internet Banking`, `Alipay`, `CC`, `Tesco` payment options.

Example:
![screenshot 2018-11-02 at 14 32 01](https://user-images.githubusercontent.com/10651523/47899462-2e759880-deac-11e8-96db-318e7ce6911f.png)

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A