### PR TITLE
Tesco Bill Payment added PRINT button

### DIFF
--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -4,3 +4,4 @@
 "Krungthai Bank", "ธนาคารกรุงไทย"
 "Krungsri Bank","ธนาคารกรุงศรี"
 "Option available only for orders in THB","สามารถเลือกชำระผ่านอาลีเพย์ได้ในรายการที่เป็นสกุลเงินบาทเท่านั้น"
+"Print", "พิมพ์"

--- a/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
@@ -2,4 +2,4 @@
 <p><?= __('To finish payment, print the code below and bring it to make payment in any Tesco Lotus Store. Code is valid for the next <b>24 hours only</b>. After that time your order will be canceled.'); ?></p>
 <p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay'))?>: <strong><?= $block->getOrderAmount();?></b></strong>
 <p><img src="<?= $block->escapeUrl($block->getTescoCodeUrl()) ?>" /></p>
-<p><button class="action secondary" onclick="window.print()"><?= __('Print Barcode')?></button></p>
+<p><button class="action secondary" onclick="window.print()"><?= __('Print')?></button></p>

--- a/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
@@ -2,3 +2,4 @@
 <p><?= __('To finish payment, print the code below and bring it to make payment in any Tesco Lotus Store. Code is valid for the next <b>24 hours only</b>. After that time your order will be canceled.'); ?></p>
 <p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay'))?>: <strong><?= $block->getOrderAmount();?></b></strong>
 <p><img src="<?= $block->escapeUrl($block->getTescoCodeUrl()) ?>" /></p>
+<p><button class="action secondary" onclick="window.print()"><?= __('Print Barcode')?></button></p>

--- a/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
@@ -2,4 +2,4 @@
 <p><?= __('To finish payment, print the code below and bring it to make payment in any Tesco Lotus Store. Code is valid for the next <b>24 hours only</b>. After that time your order will be canceled.'); ?></p>
 <p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay'))?>: <strong><?= $block->getOrderAmount();?></b></strong>
 <p><img src="<?= $block->escapeUrl($block->getTescoCodeUrl()) ?>" /></p>
-<p><button class="action secondary" onclick="window.print()"><?= __('Print')?></button></p>
+<p><button class="action secondary" onclick="window.print ? window.print() : alert('Print not available')"><?= __('Print')?></button></p>


### PR DESCRIPTION
#### 1. Objective

Added print button on checkout success page, when using Tesco Lotus Payment so user can have easy access to print option.

#### 2. Description of change

Simple change of html layout file.
Also added TH translation.

#### 3. Quality assurance

- **Platform version**: Magento CE 2.2.5.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.16.

**✏️ Details:**

Do payment using Tesco Method, check if print button is available when payment is completed.
Check if print button is not available in other methods.

#### 4. Impact of the change

Checkout success page will have extra button `Print`, when paying using Tesco Method.

<img width="628" alt="screenshot 2018-11-07 at 15 12 54" src="https://user-images.githubusercontent.com/10651523/48122237-a9262580-e2a9-11e8-97d5-99697c1aa2a1.png">

#### 5. Priority of change

Normal

#### 6. Additional Notes

None

