### PR TITLE
Restrict Tesco Bill Payment to THB transactions only

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
@@ -39,7 +39,25 @@ define(
              * @return {boolean}
              */
             isActive: function() {
-                return true;
+                return this.getOrderCurrency().toLowerCase() === 'thb' && this.getStoreCurrency().toLowerCase() === 'thb';
+            },
+
+            /**
+             * Get order currency
+             *
+             * @return {string}
+             */
+            getOrderCurrency: function () {
+                return window.checkoutConfig.quoteData.quote_currency_code;
+            },
+
+            /**
+             * Get store currency
+             *
+             * @return {string}
+             */
+            getStoreCurrency: function () {
+                return window.checkoutConfig.quoteData.store_currency_code;
             },
 
             /**

--- a/view/frontend/web/template/payment/offline-tesco-form.html
+++ b/view/frontend/web/template/payment/offline-tesco-form.html
@@ -8,10 +8,18 @@
                value: getCode(),
                checked: isChecked,
                click: selectPaymentMethod,
-               visible: isRadioButtonVisible()" />
+               visible: isRadioButtonVisible(),
+               enable: isActive()"/>
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: !isActive()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Option available only for orders in THB'"></div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="payment-method-content">
         <!-- ko foreach: getRegion('messages') -->


### PR DESCRIPTION
#### 1. Objective

Tesco Bill Payment option is available only for Thai Baht orders.
The purpose of this PR is to disable possibility of make Tesco Bill Payments for orders in other currencies.

#### 2. Description of change

Changed in JavaScript rendering files and HTML Tesco Bill Payment Checkou view.

To resolve issue there is checking if order is done in THB (Thai Baht) if yes, than payment method is displayed normally, otherwise option is _readonly_ and it is displayed message 
_Option available only for Thai Baht currency orders_

<img width="829" alt="screenshot 2018-11-08 at 14 42 45" src="https://user-images.githubusercontent.com/10651523/48184517-da176080-e364-11e8-944c-80a1a5456d2d.png">

#### 3. Quality assurance
**🔧 Environments:**

- **Platform version**: Magento CE 2.5.
- **Omise plugin version**: Omise-Magento 2.5-dev.
- **PHP version**: 7.0.29.

**✏️ Details:**

Step 1. Open magento admin, make sure that Thai Baht is main store currency.
Make order, and do payment with Tesco Bill Payment.
Step 2. Open magento admin, change Thai Baht store currency to other currency,
Try to make payment with Internet Banking. Payment should not be available.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A