### PR TITLE
Enable Place Order button on Internet Banking checkout option only if bank is selected.

### DIFF
--- a/view/frontend/web/template/payment/offsite-internetbanking-form.html
+++ b/view/frontend/web/template/payment/offsite-internetbanking-form.html
@@ -143,7 +143,7 @@
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
                         css: {disabled: !isPlaceOrderActionAllowed()},
-                        enable: (getCode() == isChecked())">
+                        enable: (getCode() == isChecked() && omiseOffsite())">
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>


### PR DESCRIPTION
#### 1. Objective

This PR introduce functionality to enable internet banking place order only when internet banking is enabled.
<img width="838" alt="screenshot 2018-11-08 at 15 55 02" src="https://user-images.githubusercontent.com/10651523/48188232-d89f6580-e36f-11e8-84d6-2a05fdb03fee.png">

#### 2. Description of change

Java Script renderer, there was added option to check if bank option is selected.

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.4.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.0.16.

**✏️ Details:**

To test it, please you need to clear static content using `rm -rf static/*`

Go to checkout page and test if you can place order after choosing internet banking option, but not choosing bank.

Button `Place Order` will be disabled until user chose bank.

#### 4. Impact of the change

None

#### 5. Priority of change

Normal

#### 6. Additional Notes

None