### PR TITLE
Make plugin compatible with PHP 7.2

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -100,7 +100,7 @@ class Offsite extends Action
         try {
             $charge = $this->charge->find($charge_id);
 
-            if (! $charge instanceof \Omise\Payment\Model\Api\Object) {
+            if (! $charge instanceof \Omise\Payment\Model\Api\BaseObject) {
                 throw new Exception('Couldn\'t retrieve charge transaction. Please contact administrator.');
             }
 

--- a/Gateway/Validator/CommandResponseValidator.php
+++ b/Gateway/Validator/CommandResponseValidator.php
@@ -20,7 +20,7 @@ class CommandResponseValidator extends AbstractValidator
     {
         $charge = $validationSubject['response']['charge'];
 
-        if (! $charge instanceof \Omise\Payment\Model\Api\Object) {
+        if (! $charge instanceof \Omise\Payment\Model\Api\BaseObject) {
             return $this->createResult(false, [ (new ErrorResponseInvalid)->getMessage() ]);
         }
 

--- a/Model/Api/BaseObject.php
+++ b/Model/Api/BaseObject.php
@@ -4,7 +4,7 @@ namespace Omise\Payment\Model\Api;
 
 use Exception;
 
-class Object
+class BaseObject
 {
     /**
      * @var mixed
@@ -12,7 +12,7 @@ class Object
     protected $object;
 
     /**
-     * @param  mixed $object  of \Omise\Payment\Model\Api\Object.
+     * @param  mixed $object  of \Omise\Payment\Model\Api\BaseObject.
      *
      * @return self
      */

--- a/Model/Api/Charge.php
+++ b/Model/Api/Charge.php
@@ -30,7 +30,7 @@ use OmiseCharge;
  *
  * @see      https://www.omise.co/charges-api
  */
-class Charge extends Object
+class Charge extends BaseObject
 {
     /**
      * @param  string $id

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -5,7 +5,7 @@ namespace Omise\Payment\Model\Api;
 use Exception;
 use OmiseCustomer;
 
-class Customer extends Object
+class Customer extends BaseObject
 {
     /**
      * @param  string $id

--- a/Model/Api/Error.php
+++ b/Model/Api/Error.php
@@ -2,7 +2,7 @@
 
 namespace Omise\Payment\Model\Api;
 
-class Error extends Object
+class Error extends BaseObject
 {
     /**
      * @var string

--- a/Model/Api/Event.php
+++ b/Model/Api/Event.php
@@ -15,7 +15,7 @@ use OmiseEvent;
  * @property Object $data
  * @see      https://www.omise.co/events-api
  */
-class Event extends Object
+class Event extends BaseObject
 {
     /**
      * @param  string $id

--- a/Test/Unit/Model/Api/ObjectTest.php
+++ b/Test/Unit/Model/Api/ObjectTest.php
@@ -3,7 +3,7 @@
 namespace Omise\Payment\Test\Unit\Model\Api;
 
 use PHPUnit\Framework\TestCase;
-use Omise\Payment\Model\Api\Object;
+use Omise\Payment\Model\Api\BaseObject;
 
 class ObjectTest extends TestCase
 {


### PR DESCRIPTION
#### 1. Objective

Make plugin compatible with PHP 7.2

**Related information**:
#167 

#### 2. Description of change

Changed class name from `Object` to `BaseObject` - can't use general `Object` name in php 7.2

#### 3. Quality assurance

**🔧 Environments:**
- **Platform version**: Magento CE 2.3.
- **Omise plugin version**: Omise-Magento 2.3.
- **PHP version**: 7.2.

**✏️ Details:**
Use PHP 7.2 to install fresh plugin in Magento 2.3
Note that Magento below `2.3` is not compatible with `PHP 7.2`

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A