### PR TITLE
Model\Ui\CapabilitiesConfigProvider: returns an empty array instaed o…

### DIFF
--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -42,6 +42,6 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
                 ];
             }
         }
-        return null;
+        return [];
     }
 }


### PR DESCRIPTION
#### 1. Objective
According to an error from _Magento/Checkout/Model/CompositeConfigProvider.php_ line 39. 
```php
35: public function getConfig()
36: {
37:     $config = [];
38:     foreach ($this->configProviders as $configProvider) {
39:         $config = array_merge_recursive($config, $configProvider->getConfig());
40:     }
41:     return $config;
42: }
```
Magento merges all of configurations from all registered-config-providers into one array.

The problem occurs when we disabled Installment patment method, our _CapabilitiesConfigProvider_ returns `null` instead of an empty array, and that caused to _Magento/Checkout/Model/CompositeConfigProvider.php_ trying to merge `null` value with array_merge_recursive().

**Related information**:
Related issue(s): #173 

Thanks @BrainTurner for the report.

#### 2. Description of change

**Model\Ui\CapabilitiesConfigProvider** : returns an empty array instaed of null when Installment payment method is disabled.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento Open Source v2.2.4
- **PHP version**: 7.0.16.

**✏️ Details:**

1. Install a fresh-new Magento website, then install Omise-Magento. Then try to check out on both case "Installment payment method enabled" and "Installment payment method disabled"

#### 4. Impact of the change

No

#### 5. Priority of change

High.

#### 6. Additional Notes

No