### PR TITLE
Changed in composer omise-php requirement to version 2.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "magento/module-payment": ">=100.1",
         "magento/module-checkout": ">=100.1",
         "magento/module-sales": ">=100.1",
-        "omise/omise-php": "2.11.0"
+        "omise/omise-php": "2.11.1"
     },
     "autoload": {
         "files": ["registration.php"],


### PR DESCRIPTION
#### 1. Objective

Use newer `omise-php` version in `omise-magento` composer file.

#### 2. Description of change

`omise-php` library has been updated, and this PR adds to composer information about new library requirement.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.5.
- **PHP version**: 7.0.16.

**✏️ Details:**

Install or update `omise-magento` plugin for Magento 2 framework using `composer` and check if new version of library (`2.11.1`) has been installed or updated.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A