### PR TITLE
Fix: Order can't be completed when choosing other payment methods than Omise

### DIFF
--- a/Observer/TescoPaymentObserver.php
+++ b/Observer/TescoPaymentObserver.php
@@ -39,19 +39,15 @@ class TescoPaymentObserver implements ObserverInterface
     {
         $order   = $observer->getEvent()->getOrder();
         $payment = $order->getPayment();
-        
-        if (!$payment) {
+
+        if ($payment->getAdditionalData('payment_type') !== 'bill_payment_tesco_lotus') {
             return $this;
         }
 
-        $paymentData = $payment->getData();
-
-        if ($paymentData['additional_information']['payment_type'] !== 'bill_payment_tesco_lotus') {
-            return $this;
-        }
+        $paymentData   = $payment->getData();
 
         $amount        = number_format($paymentData['amount_ordered'], 2) . ' ' . $order->getOrderCurrency()->getCurrencyCode();
-        $barcodeHtml   = $this->_helper->convertTescoSVGCodeToHTML($paymentData['additional_information']['barcode']);
+        $barcodeHtml   = $this->_helper->convertTescoSVGCodeToHTML($payment->getAdditionalData('barcode'));
         $storeName     = $this->_scopeConfig->getValue('trans_email/ident_sales/name', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         $storeEmail    = $this->_scopeConfig->getValue('trans_email/ident_sales/email', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         $customerEmail = $order->getCustomerEmail();


### PR DESCRIPTION
#### 1. Objective

There is error when choosing Cash on delivery payment method.

Reason is that our extension does not get required additional data when choosing different than `omise` payment methods. 

Issue has been described in different report: 

This is fix for that issue. [#173](https://github.com/omise/omise-magento/issues/173)

#### 2. Description of change

We need to check if there is `additional_information` passed in payment data array in displaying payment success page.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.5.
- **PHP version**: 7.0.16.

**✏️ Details:**

Make payment with Cash On Delivery as payment option.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A