### PR TITLE
Fix: Display correctly barcode from tesco lotus on checkout success page.

### DIFF
--- a/Block/Checkout/Onepage/Success/TescoAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/TescoAdditionalInformation.php
@@ -36,7 +36,7 @@ class TescoAdditionalInformation extends \Magento\Framework\View\Element\Templat
         $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
 
         $this->addData([
-            'tesco_code_image' => $paymentData['additional_information']['barcode'],
+            'tesco_barcode_svg' => $paymentData['additional_information']['barcode'],
             'order_amount' => number_format($paymentData['amount_ordered'], 2) .' '.$orderCurrency
         ]);
         

--- a/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
@@ -1,5 +1,5 @@
 
 <p><?= __('To finish payment, print the code below and bring it to make payment in any Tesco Lotus Store. Code is valid for the next <b>24 hours only</b>. After that time your order will be canceled.'); ?></p>
-<p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay'))?>: <strong><?= $block->getOrderAmount();?></b></strong>
-<div><?= $block->getTescoCodeImage() ?></div>
+<p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay')) ?>: <strong><?= $block->getOrderAmount() ?></b></strong>
+<div><?= $block->getTescoBarcodeSvg() ?></div>
 <p><button class="action secondary" onclick="window.print ? window.print() : alert('Print not available')"><?= __('Print')?></button></p>

--- a/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/tesco_additional_info.phtml
@@ -1,5 +1,5 @@
 
 <p><?= __('To finish payment, print the code below and bring it to make payment in any Tesco Lotus Store. Code is valid for the next <b>24 hours only</b>. After that time your order will be canceled.'); ?></p>
 <p style="margin:.5rem 0"><?= $block->escapeHtml(__('Amount to pay'))?>: <strong><?= $block->getOrderAmount();?></b></strong>
-<p><img src="<?= $block->escapeUrl($block->getTescoCodeUrl()) ?>" /></p>
+<div><?= $block->getTescoCodeImage() ?></div>
 <p><button class="action secondary" onclick="window.print ? window.print() : alert('Print not available')"><?= __('Print')?></button></p>


### PR DESCRIPTION
#### 1. Objective

Display barcode fix. 
There is error that barcode is not displayed on tesco lotus page.
This PR deliver fix for that functionality.

#### 2. Description of change

Just renamed function to get proper array value.

array value we are pointing in:
`TescoAdditionalInformation.php:39` is named `tesco_code_image`,
but we try to get by calling `getTescoCodeUrl`:
`tesco_code_url`

We removed `img` tag, because we display Tesco barcode using SVG code.
In that PR also was changed array key represents Tesco image displayed in checkout success page.
`tesco_code_image` => `tesco_barcode_svg`.

and getter function was renamed to `getTescoBarcodeSvg`.


#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.6.
- **PHP version**: 7.0.29.

**✏️ Details:**

Make Tesco Payment,
See if barcode is displayed properly.

#### 4. Impact of the change

Solve issue

#### 5. Priority of change

High,

#### 6. Additional Notes

None