### PR TITLE
Manual Capture Functionality

### DIFF
--- a/Gateway/Http/Client/APMPayment.php
+++ b/Gateway/Http/Client/APMPayment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Omise\Payment\Gateway\Http\Client;
+
+class APMPayment extends AbstractPayment
+{
+    /**
+     * @param  \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     *
+     * @return \Omise\Payment\Model\Api\Charge|\Omise\Payment\Model\Api\Error
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $this->setupOmiseLib();
+
+        $transferObjectBody = $transferObject->getBody();
+
+        return [self::CHARGE => $this->apiCharge->create($transferObjectBody)];
+    }
+}

--- a/Gateway/Http/Client/APMPayment.php
+++ b/Gateway/Http/Client/APMPayment.php
@@ -11,8 +11,6 @@ class APMPayment extends AbstractPayment
      */
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
-        $this->setupOmiseLib();
-
         $transferObjectBody = $transferObject->getBody();
 
         return [self::CHARGE => $this->apiCharge->create($transferObjectBody)];

--- a/Gateway/Http/Client/AbstractPayment.php
+++ b/Gateway/Http/Client/AbstractPayment.php
@@ -7,7 +7,7 @@ use Magento\Payment\Gateway\Http\TransferInterface;
 use Omise\Payment\Model\Api\Charge as ApiCharge;
 use Omise\Payment\Model\Omise;
 
-class Payment implements ClientInterface
+abstract class AbstractPayment implements ClientInterface
 {
     /**
      * Client request status represented to successful request step.
@@ -49,8 +49,15 @@ class Payment implements ClientInterface
         ApiCharge $apiCharge,
         Omise     $omise
     ) {
-        $this->omise     = $omise;
+        $this->omise = $omise;
         $this->apiCharge = $apiCharge;
+    }
+
+    protected function setupOmiseLib()
+    {
+        $this->omise->defineUserAgent();
+        $this->omise->defineApiVersion();
+        $this->omise->defineApiKeys();
     }
 
     /**
@@ -58,21 +65,5 @@ class Payment implements ClientInterface
      *
      * @return \Omise\Payment\Model\Api\Charge|\Omise\Payment\Model\Api\Error
      */
-    public function placeRequest(TransferInterface $transferObject)
-    {
-
-        $this->omise->defineUserAgent();
-        $this->omise->defineApiVersion();
-        $this->omise->defineApiKeys();
-        
-        $transferObjectBody = $transferObject->getBody();
-
-        // if charge_id already exists than action is 'manual capture'
-        if (isset($transferObjectBody[self::CHARGE_ID])) {
-            $charge = $this->apiCharge->find($transferObjectBody[self::CHARGE_ID]);
-            return [self::CHARGE => $charge->capture()];
-        }
-
-        return [self::CHARGE => $this->apiCharge->create($transferObjectBody)];
-    }
+    abstract public function placeRequest(TransferInterface $transferObject);
 }

--- a/Gateway/Http/Client/AbstractPayment.php
+++ b/Gateway/Http/Client/AbstractPayment.php
@@ -45,19 +45,19 @@ abstract class AbstractPayment implements ClientInterface
      */
     protected $apiCharge;
 
+    /**
+     * @param \Omise\Payment\Model\Api\Charge $apiCharge
+     * @param \Omise\Payment\Model\Omise $omise;
+     */
     public function __construct(
         ApiCharge $apiCharge,
         Omise     $omise
     ) {
-        $this->omise = $omise;
-        $this->apiCharge = $apiCharge;
-    }
+        $omise->defineUserAgent();
+        $omise->defineApiVersion();
+        $omise->defineApiKeys();
 
-    protected function setupOmiseLib()
-    {
-        $this->omise->defineUserAgent();
-        $this->omise->defineApiVersion();
-        $this->omise->defineApiKeys();
+        $this->apiCharge = $apiCharge;
     }
 
     /**

--- a/Gateway/Http/Client/CCPayment.php
+++ b/Gateway/Http/Client/CCPayment.php
@@ -11,8 +11,6 @@ class CCPayment extends AbstractPayment
      */
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
-        $this->setupOmiseLib();
-
         $transferObjectBody = $transferObject->getBody();
 
         // if charge_id already exists than action is 'manual capture'

--- a/Gateway/Http/Client/CCPayment.php
+++ b/Gateway/Http/Client/CCPayment.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Omise\Payment\Gateway\Http\Client;
+
+class CCPayment extends AbstractPayment
+{
+    /**
+     * @param  \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     *
+     * @return \Omise\Payment\Model\Api\Charge|\Omise\Payment\Model\Api\Error
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $this->setupOmiseLib();
+
+        $transferObjectBody = $transferObject->getBody();
+
+        // if charge_id already exists than action is 'manual capture'
+        if (isset($transferObjectBody[self::CHARGE_ID])) {
+            $charge = $this->apiCharge->find($transferObjectBody[self::CHARGE_ID]);
+            return [self::CHARGE => $charge->capture()];
+        }
+
+        return [self::CHARGE => $this->apiCharge->create($transferObjectBody)];
+    }
+}

--- a/Gateway/Http/Client/Payment.php
+++ b/Gateway/Http/Client/Payment.php
@@ -24,6 +24,18 @@ class Payment implements ClientInterface
     const PROCESS_STATUS_FAILED = 'failed';
 
     /**
+     *
+     * @var string
+     */
+    const CHARGE_ID = 'charge_id';
+
+    /**
+     *
+     * @var string
+     */
+    const CHARGE = 'charge';
+
+    /**
      * @var Omise\Payment\Model\Omise
      */
     protected $omise;
@@ -56,11 +68,11 @@ class Payment implements ClientInterface
         $transferObjectBody = $transferObject->getBody();
 
         // if charge_id already exists than action is 'manual capture'
-        if (isset($transferObjectBody['charge_id'])) {
-            $charge = $this->apiCharge->find($transferObjectBody['charge_id']);
-            return ['charge' => $charge->capture()];
+        if (isset($transferObjectBody[self::CHARGE_ID])) {
+            $charge = $this->apiCharge->find($transferObjectBody[self::CHARGE_ID]);
+            return [self::CHARGE => $charge->capture()];
         }
 
-        return ['charge' => $this->apiCharge->create($transferObjectBody)];
+        return [self::CHARGE => $this->apiCharge->create($transferObjectBody)];
     }
 }

--- a/Gateway/Http/Client/Payment.php
+++ b/Gateway/Http/Client/Payment.php
@@ -35,9 +35,9 @@ class Payment implements ClientInterface
 
     public function __construct(
         ApiCharge $apiCharge,
-        Omise $omise
+        Omise     $omise
     ) {
-        $this->omise = $omise;
+        $this->omise     = $omise;
         $this->apiCharge = $apiCharge;
     }
 
@@ -56,8 +56,8 @@ class Payment implements ClientInterface
         $transferObjectBody = $transferObject->getBody();
 
         // if charge_id already exists than action is 'manual capture'
-        if ($chargeID = $transferObjectBody['charge_id']) {
-            $charge = $this->apiCharge->find($chargeID);
+        if (isset($transferObjectBody['charge_id'])) {
+            $charge = $this->apiCharge->find($transferObjectBody['charge_id']);
             return ['charge' => $charge->capture()];
         }
 

--- a/Gateway/Request/CreditCardBuilder.php
+++ b/Gateway/Request/CreditCardBuilder.php
@@ -22,24 +22,24 @@ class CreditCardBuilder implements BuilderInterface
     public function build(array $buildSubject)
     {
         $payment = SubjectReader::readPayment($buildSubject);
-        $method = $payment->getPayment();
-
-        $paymentData = null;
-
-        if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
-            $paymentData = [
-                self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER),
-                self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::CARD),
-            ];
-        } else {
-            $paymentData = [
-                self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN)
+        $method  = $payment->getPayment();
+    
+        // if charge ID already exists than it is 'manual capture' request, so no other data is necessary to build request
+        if ($charge_id = $method->getAdditionalInformation(CreditCardDataObserver::CHARGE_ID)) {
+            return [
+                self::CHARGE_ID => $charge_id
             ];
         }
 
-        //add information about charge_id, if charge id exists than it is 'manual capture' request.
-        $paymentData[self::CHARGE_ID] = $method->getAdditionalInformation(CreditCardDataObserver::CHARGE_ID);
+        if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
+            return [
+                self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER),
+                self::CARD     => $method->getAdditionalInformation(CreditCardDataObserver::CARD)
+            ];
+        }
 
-        return $paymentData;
+        return [ 
+            self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN)
+        ];
     }
 }

--- a/Gateway/Request/CreditCardBuilder.php
+++ b/Gateway/Request/CreditCardBuilder.php
@@ -10,8 +10,9 @@ class CreditCardBuilder implements BuilderInterface
     /**
      * @var string
      */
-    const CARD     = 'card';
-    const CUSTOMER = 'customer';
+    const CARD      = 'card';
+    const CUSTOMER  = 'customer';
+    const CHARGE_ID = 'charge_id';
 
     /**
      * @param  array $buildSubject
@@ -21,15 +22,24 @@ class CreditCardBuilder implements BuilderInterface
     public function build(array $buildSubject)
     {
         $payment = SubjectReader::readPayment($buildSubject);
-        $method  = $payment->getPayment();
+        $method = $payment->getPayment();
+
+        $paymentData = null;
 
         if ($method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER)) {
-            return [
+            $paymentData = [
                 self::CUSTOMER => $method->getAdditionalInformation(CreditCardDataObserver::CUSTOMER),
-                self::CARD     => $method->getAdditionalInformation(CreditCardDataObserver::CARD)
+                self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::CARD),
+            ];
+        } else {
+            $paymentData = [
+                self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN)
             ];
         }
 
-        return [ self::CARD => $method->getAdditionalInformation(CreditCardDataObserver::TOKEN) ];
+        //add information about charge_id, if charge id exists than it is 'manual capture' request.
+        $paymentData[self::CHARGE_ID] = $method->getAdditionalInformation(CreditCardDataObserver::CHARGE_ID);
+
+        return $paymentData;
     }
 }

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -16,7 +16,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     const CARD          = 'omise_card';
     const REMEMBER_CARD = 'omise_save_card';
     const CUSTOMER      = 'customer';
-
+    const CHARGE_ID     = 'charge_id';
     /**
      * @var array
      */
@@ -24,7 +24,8 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
         self::TOKEN,
         self::CARD,
         self::REMEMBER_CARD,
-        self::CUSTOMER
+        self::CUSTOMER,
+        self::CHARGE_ID
     ];
 
     /**

--- a/Observer/CreditCardDataObserver.php
+++ b/Observer/CreditCardDataObserver.php
@@ -17,6 +17,7 @@ class CreditCardDataObserver extends AbstractDataAssignObserver
     const REMEMBER_CARD = 'omise_save_card';
     const CUSTOMER      = 'customer';
     const CHARGE_ID     = 'charge_id';
+
     /**
      * @var array
      */

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -149,7 +149,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseAPMRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="client" xsi:type="object">OmiseAPMCharge</argument>
             <argument name="handler" xsi:type="object">OmiseAPMResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAPMInitializeCommandResponseValidator</argument>
         </arguments>
@@ -235,7 +235,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseAPMAuthorizeResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
@@ -258,7 +258,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureThreeDSecureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseAPMResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\ThreeDSecureCommandResponseValidator</argument>
         </arguments>
@@ -310,7 +310,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseAuthorizeRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator</argument>
         </arguments>
@@ -332,7 +332,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">OmiseCaptureRequest</argument>
             <argument name="transferFactory" xsi:type="object">Omise\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">OmiseCharge</argument>
+            <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator</argument>
         </arguments>
@@ -349,7 +349,9 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="OmiseCharge" type="Omise\Payment\Gateway\Http\Client\Payment"></virtualType>
+    <virtualType name="OmiseAPMCharge" type="Omise\Payment\Gateway\Http\Client\APMPayment"></virtualType>
+
+    <virtualType name="OmiseCCCharge" type="Omise\Payment\Gateway\Http\Client\CCPayment"></virtualType>
 
     <virtualType name="OmiseAdapter" type="OmiseCcAdapter">
         <arguments>


### PR DESCRIPTION
#### 1. Objective

Allow Merchant to use Manual Capture functionality from Magento 2 Admin Panel

#### 2. Description of change

When a user pays by Credit Card using `authorize_only` method than Merchant has to go to `Omise.co` Dashboard to manually capture payment.

This Pull Request allow to manual capture payment during creating an invoice directly from Magento 2 Admin Panel.

There has been added information about existing `charge_id` when there is created request body of Credit Card Payment.
If `charge_id` already exists then all request is to Manual Capture payment.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

To manually test that Pull Request:

-  Make sure you have set up in Admin Panel -> Store -> Configuration -> Sales -> Payment Methods -> Omise -> Credit Card Solution -> Payment Action as *Authorize Only*
- Make order with CC Payment.
- Go to Omise Dashboard and make sure that last payment you did is _authorized only_
- Go to Admin Panel, in Orders select last order and create an invoice using _Submit Invoice_ button, make sure you have selected _Capture Online_ option.
![image](https://user-images.githubusercontent.com/10651523/55452871-aedb2980-5603-11e9-9cf8-d97094bad220.png)

- After creating invoice go to Omise Dashboard and check if Payment is successfully _captured_.

#### 4. Impact of the change

N/A

#### 5. Additional Notes

N/A