### PR TITLE
Enable 'Order' button only if installment terms are chosen

### DIFF
--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -193,7 +193,7 @@
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
                         css: {disabled: !isPlaceOrderActionAllowed()},
-                        enable: (getCode() == isChecked())">
+                        enable: (getCode() == isChecked()) && omiseOffsite() && installmentTerms()">
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>


### PR DESCRIPTION
#### 1. Objective

In the current version, a user can click order even if installment terms are not set yet. It causes Backend error and displays a general error message on the screen.

We should not make any backend requests if a user did not choose terms that are required to construct a proper request.

#### 2. Description of change

In HTML layout file of installments added extra conditions to enable button

#### 3. Quality assurance

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

To manually test that PR you should go to installment payment, and:
1. See if the order button is enabled only if you choose an installment bank with detailed terms.
2. If a button is disabled you should not be able to make any order.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A