### PR TITLE
Removes temporarily the switch for instalment payments

### DIFF
--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -154,7 +154,7 @@
                             </fields>
                         </omise_offsite_alipay>
 
-                        <omise_offsite_installment type="group">
+                        <!-- <omise_offsite_installment type="group">
                             <label>Installment Payments</label>
                             <comment>Enables customers to pay in installments.</comment>
                             <sort_order>720</sort_order>
@@ -173,7 +173,7 @@
                                     <show_in_store>0</show_in_store>
                                 </active>
                             </fields>
-                        </omise_offsite_installment>
+                        </omise_offsite_installment> -->
                     </fields>
                 </omise_payment>
             </groups>


### PR DESCRIPTION
#### 1. Objective

Temporarily removes switch for turning instalment payments on. Necessary so we can do a release with all other enhancements/fixes

#### 2. Description of change

Commented out the XML config defining the switch in the admin area

#### 3. Quality assurance

Check to see the switch is gone in admin area

#### 4. Impact of the change

All recent fixes/enhancements for Magento 1 will now be in the next release, but instalment payments will be switched off (hidden)

#### 5. Priority of change

Normal

#### 6. Additional Notes

🍌