### PR TITLE
Change minimum order from 5000 to 3000 THB

### DIFF
--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -6,4 +6,4 @@
 "Option available only for orders in THB","สามารถเลือกชำระผ่านอาลีเพย์ได้ในรายการที่เป็นสกุลเงินบาทเท่านั้น"
 "Print", "พิมพ์"
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
-"Miminum order value is 5000 THB", "ยอดสั่งซื้อขั้นต่ำ 5000 บาท"
+"Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -113,7 +113,7 @@ define(
              * @return {boolean}
              */
             orderValueTooLow: function () {
-                return window.checkoutConfig.totalsData.base_grand_total < 5000;
+                return window.checkoutConfig.totalsData.base_grand_total < 3000;
             },
 
             /**

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -21,7 +21,7 @@
         <div data-bind="visible: orderValueTooLow()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Minimum order value is 5000 THB'"></div>
+                    <div data-bind="i18n: 'Minimum order value is 3000 THB'"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### 1. Objective

Installment payment is now available for orders higher than 3000 THB. Before it was 5000 THB.
This PR corrects amount in the plugin.

#### 2. Description of change

Just changed the number in all display strings from 5000 to 3000.
Also, it changes a value in javascript amount validation. 

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.8-dev.
- **PHP version**: 7.1.16.

**✏️ Details:**

Try to use an installment payment option when having items that value is not greater than 3000 THB.
Installment payment option should be disabled, other payment options should be available.
Make a successful payment using an installment when the order value is greater than 3000 THB.

