### PR TITLE
Show instalment amounts, interest rates, and enforce monthly and overall minimum payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-### [v1.16 _(Apr 5, 2018)_](https://github.com/omise/omise-magento/releases/tag/v1.16)
+### [v1.16 _(Apr 5, 2019)_](https://github.com/omise/omise-magento/releases/tag/v1.16)
 
 #### 🚀 Enhancements
 

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
@@ -31,6 +31,31 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
     }
 
     /**
+     * Has the merchant selected interest free installmnet payments for merchants?
+     *
+     * @return boolean
+     */
+    public function isInterestFree()
+    {
+        return Mage::getModel('omise_gateway/api_capabilities')->isZeroInterestInstallments();
+    }
+
+    /**
+     * Calculate monthly payment amount for installment backend, given number of months
+     *
+     * @return boolean
+     */
+    public function getMonthlyPaymentAmount($saleAmount, $monthCount, $interestRatePC)
+    {
+        $interestRate = $this->isInterestFree() ? 0 : $interestRatePC/100;
+        var_dump($interestRate);
+        $VAT = 0.07; // Should this be in config, and also country dependent??
+        $interestAmount = $interestRate * $monthCount * $saleAmount * (1+$VAT);
+        $totalAmount = $saleAmount + $interestAmount;
+        return $totalAmount/$monthCount;
+    }
+
+    /**
      * Gets an array of available installment backends (with some conveniences added for building HTML)
      *
      * @return [backends]
@@ -42,6 +67,7 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
         foreach ($backends as &$backend) {
             $backend->_bankcode = str_replace('installment_', '', $backend->_id);
             $backend->_bankname = Mage::helper('omise_gateway')->installmentProviderName($backend->_id);
+            $backend->_interest_rate = Mage::helper('omise_gateway')->installmentProviderInterestRate($backend->_id);
         }
         return $backends;
     }

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
@@ -68,6 +68,7 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
             $backend->_bankcode = str_replace('installment_', '', $backend->_id);
             $backend->_bankname = Mage::helper('omise_gateway')->installmentProviderName($backend->_id);
             $backend->_interest_rate = Mage::helper('omise_gateway')->installmentProviderInterestRate($backend->_id);
+            $backend->_monthly_minimum_thb = Mage::helper('omise_gateway')->installmentProviderMonthlyMinimum($backend->_id);
         }
         return $backends;
     }

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
@@ -49,7 +49,7 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
     {
         $interestRate = $this->isInterestFree() ? 0 : $interestRatePC/100;
         $VAT = 0.07; // Should this be in config, and also country dependent??
-        $interestAmount = $interestRate * $monthCount * $saleAmount * (1+$VAT);
+        $interestAmount = $interestRate * $monthCount * $saleAmount * (1 + $VAT);
         $totalAmount = $saleAmount + $interestAmount;
         return $totalAmount/$monthCount;
     }

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
@@ -48,7 +48,6 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
     public function getMonthlyPaymentAmount($saleAmount, $monthCount, $interestRatePC)
     {
         $interestRate = $this->isInterestFree() ? 0 : $interestRatePC/100;
-        var_dump($interestRate);
         $VAT = 0.07; // Should this be in config, and also country dependent??
         $interestAmount = $interestRate * $monthCount * $saleAmount * (1+$VAT);
         $totalAmount = $saleAmount + $interestAmount;
@@ -68,7 +67,7 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
             $backend->_bankcode = str_replace('installment_', '', $backend->_id);
             $backend->_bankname = Mage::helper('omise_gateway')->installmentProviderName($backend->_id);
             $backend->_interest_rate = Mage::helper('omise_gateway')->installmentProviderInterestRate($backend->_id);
-            $backend->_monthly_minimum_thb = Mage::helper('omise_gateway')->installmentProviderMonthlyMinimum($backend->_id);
+            $backend->_monthly_minimum_subunits_thb = Mage::helper('omise_gateway')->installmentProviderMonthlyMinimum($backend->_id);
         }
         return $backends;
     }

--- a/src/app/code/community/Omise/Gateway/Helper/Data.php
+++ b/src/app/code/community/Omise/Gateway/Helper/Data.php
@@ -36,6 +36,12 @@ class Omise_Gateway_Helper_Data extends Mage_Core_Helper_Abstract
     public function installmentProviderName($code)
     {
         $providers = Mage::getSingleton('omise_gateway/config')->getInstallmentProviders();
-        return $this->__(array_key_exists($code, $providers) ? $providers[$code] : "New provider ($code)");
+        return $this->__(array_key_exists($code, $providers) ? $providers[$code]['name'] : "New provider ($code)");
+    }
+
+    public function installmentProviderInterestRate($code)
+    {
+        $providers = Mage::getSingleton('omise_gateway/config')->getInstallmentProviders();
+        return (double)($providers[$code]['interest_rate']);
     }
 }

--- a/src/app/code/community/Omise/Gateway/Helper/Data.php
+++ b/src/app/code/community/Omise/Gateway/Helper/Data.php
@@ -44,4 +44,12 @@ class Omise_Gateway_Helper_Data extends Mage_Core_Helper_Abstract
         $providers = Mage::getSingleton('omise_gateway/config')->getInstallmentProviders();
         return (double)($providers[$code]['interest_rate']);
     }
+
+    public function installmentProviderMonthlyMinimum($code, $currencyCode='thb')
+    {
+        $providers = Mage::getSingleton('omise_gateway/config')->getInstallmentProviders();
+        return (int)($providers[$code]['monthly_minimum_subunits_'.$currencyCode]);
+    }
+
+
 }

--- a/src/app/code/community/Omise/Gateway/Model/Api/Capabilities.php
+++ b/src/app/code/community/Omise/Gateway/Model/Api/Capabilities.php
@@ -36,6 +36,16 @@ class Omise_Gateway_Model_Api_Capabilities extends Omise_Gateway_Model_Api_Objec
     }
 
     /**
+     * Retrieves zero_interest_installments setting
+     *
+     * @return string
+     */
+    public static function isZeroInterestInstallments()
+    {
+        return self::$_capabilities['zero_interest_installments'];
+    }
+
+    /**
      * Retrieves capabilities object
      *
      * @return string

--- a/src/app/code/community/Omise/Gateway/Model/Config.php
+++ b/src/app/code/community/Omise/Gateway/Model/Config.php
@@ -43,6 +43,9 @@ class Omise_Gateway_Model_Config extends Mage_Core_Model_Abstract
             if (!array_key_exists('interest_rate', $data)) {
                 $types[$code]['interest_rate'] = Mage::getConfig()->getNode('default/payment/omise_offsite_installment/default_interest_rate');
             }
+            if (!array_key_exists('monthly_minimum_subunits_thb', $data)) {
+                $types[$code]['monthly_minimum_subunits_thb'] = Mage::getConfig()->getNode('default/payment/omise_offsite_installment/default_monthly_minimum_subunits_thb');
+            }
         }
         return $types;
     }

--- a/src/app/code/community/Omise/Gateway/Model/Config.php
+++ b/src/app/code/community/Omise/Gateway/Model/Config.php
@@ -39,7 +39,10 @@ class Omise_Gateway_Model_Config extends Mage_Core_Model_Abstract
         $_types = Mage::getConfig()->getNode('global/payment/omise/installment')->asArray();
         $types = [];
         foreach ($_types as $code => $data) {
-            $types[$code] = $data['name'];
+            $types[$code] = $data;
+            if (!array_key_exists('interest_rate', $data)) {
+                $types[$code]['interest_rate'] = Mage::getConfig()->getNode('default/payment/omise_offsite_installment/default_interest_rate');
+            }
         }
         return $types;
     }

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -96,6 +96,7 @@
                 <installment>
                     <installment_bay>
                         <name>Krungsri</name>
+                        <monthly_minimum_subunits_thb>50000</monthly_minimum_subunits_thb>
                     </installment_bay>
                     <installment_first_choice>
                         <name>First Choice</name>
@@ -106,6 +107,7 @@
                     </installment_kbank>
                     <installment_bbl>
                         <name>Bangkok Bank</name>
+                        <monthly_minimum_subunits_thb>50000</monthly_minimum_subunits_thb>
                     </installment_bbl>
                     <installment_ktc>
                         <name>KTC</name>
@@ -191,6 +193,7 @@
                 <model>omise_gateway/payment_offsiteinstallment</model>
                 <title>Installment payments</title>
                 <default_interest_rate>0.8</default_interest_rate>
+                <default_monthly_minimum_subunits_thb>30000</default_monthly_minimum_subunits_thb>
             </omise_offsite_installment>
 
         </payment>

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -99,6 +99,7 @@
                     </installment_bay>
                     <installment_first_choice>
                         <name>First Choice</name>
+                        <interest_rate>1.3</interest_rate>
                     </installment_first_choice>
                     <installment_kbank>
                         <name>KBank</name>
@@ -189,6 +190,7 @@
                 <payment_action>authorize_capture</payment_action>
                 <model>omise_gateway/payment_offsiteinstallment</model>
                 <title>Installment payments</title>
+                <default_interest_rate>0.8</default_interest_rate>
             </omise_offsite_installment>
 
         </payment>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -154,7 +154,7 @@
                             </fields>
                         </omise_offsite_alipay>
 
-                        <!-- <omise_offsite_installment type="group">
+                        <omise_offsite_installment type="group">
                             <label>Installment Payments</label>
                             <comment>Enables customers to pay in installments.</comment>
                             <sort_order>720</sort_order>
@@ -173,7 +173,7 @@
                                     <show_in_store>0</show_in_store>
                                 </active>
                             </fields>
-                        </omise_offsite_installment> -->
+                        </omise_offsite_installment>
                     </fields>
                 </omise_payment>
             </groups>

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
@@ -1,4 +1,5 @@
 <?php
+
 $code = $this->getMethodCode();
 $backends = $this->getInstallmentBackends();
 $isInterestFree = $this->isInterestFree();
@@ -32,7 +33,7 @@ $currencyHelper = Mage::app()->getLocale()->currency($quote->getBaseCurrencyCode
                             $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month'); ?>
 
                             <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>
-                            
+
                         <?php } 
                     }?>
                     

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
@@ -30,7 +30,9 @@ $currencyHelper = Mage::app()->getLocale()->currency($quote->getBaseCurrencyCode
                         // This will need to change if we introduce instalment payments for currencies with different subunit settings
                         if ($monthlyPaymentAmount >= ($backend->_monthly_minimum_subunits_thb/100)) {
                             $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month'); ?>
+
                             <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>
+                            
                         <?php } 
                     }?>
                     

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
@@ -27,6 +27,7 @@ $currencyHelper = Mage::app()->getLocale()->currency($quote->getBaseCurrencyCode
 
                     <?php foreach ($backend->allowed_installment_terms as $termMonths) {
                         $monthlyPaymentAmount = $this->getMonthlyPaymentAmount($saleAmount, $termMonths, $backend->_interest_rate);
+                        // TODO - need to check here if monthly amount is >= ($backend->_monthly_minimum_subunits_thb/100)
                         $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month');
                     ?>
                         <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
@@ -27,11 +27,12 @@ $currencyHelper = Mage::app()->getLocale()->currency($quote->getBaseCurrencyCode
 
                     <?php foreach ($backend->allowed_installment_terms as $termMonths) {
                         $monthlyPaymentAmount = $this->getMonthlyPaymentAmount($saleAmount, $termMonths, $backend->_interest_rate);
-                        // TODO - need to check here if monthly amount is >= ($backend->_monthly_minimum_subunits_thb/100)
-                        $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month');
-                    ?>
-                        <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>
-                    <?php } ?>
+                        // This will need to change if we introduce instalment payments for currencies with different subunit settings
+                        if ($monthlyPaymentAmount >= ($backend->_monthly_minimum_subunits_thb/100)) {
+                            $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month'); ?>
+                            <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>
+                        <?php } 
+                    }?>
                     
                 </select>
             </div>

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsiteinstallment.phtml
@@ -1,11 +1,19 @@
 <?php
 $code = $this->getMethodCode();
 $backends = $this->getInstallmentBackends();
+$isInterestFree = $this->isInterestFree();
+
+$quote = Mage::helper('checkout')->getQuote();
+$saleAmount = $quote->getBaseGrandTotal();
+$currencyHelper = Mage::app()->getLocale()->currency($quote->getBaseCurrencyCode());
+
 ?>
 
 <ul id="payment_form_<?php echo $code; ?>" class="banks-list form-list" style="display:none;">
 
-    <?php if (count($backends)) { foreach ($backends as $backend) { ?>
+    <?php if (count($backends)) { foreach ($backends as $backend) {
+        $installmentText = $backend->_bankname . ($isInterestFree ? '' : ' ('.$backend->_interest_rate.'%)');
+    ?>
         
     <li class="item">
         <input class="validate-one-required-by-name" id="<?=$backend->_id;?>" type="radio" name="payment[type]" value="<?=$backend->_id;?>" />
@@ -14,11 +22,16 @@ $backends = $this->getInstallmentBackends();
                 <div class="logo-<?=$backend->_bankcode;?>"></div>
             </div>
             <div class="omise-banking-text-wrapper">
-                <span class="title"><?=$backend->_bankname;?></span><br/>
+                <span class="title"><?=$installmentText;?></span><br/>
                 <select name="payment[terms_<?=$backend->_id;?>]" id="payment_term_<?=$backend->_id;?>">
-                    <?php foreach ($backend->allowed_installment_terms as $termMonths) { ?>
-                        <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?></option>
+
+                    <?php foreach ($backend->allowed_installment_terms as $termMonths) {
+                        $monthlyPaymentAmount = $this->getMonthlyPaymentAmount($saleAmount, $termMonths, $backend->_interest_rate);
+                        $monthlyPaymentText = $currencyHelper->toCurrency($monthlyPaymentAmount) . ' ' .$this->__('/ month');
+                    ?>
+                        <option value="<?=$termMonths;?>"><?=$termMonths;?> <?=$this->__('months');?> - <?=$monthlyPaymentText;?></option>
                     <?php } ?>
+                    
                 </select>
             </div>
         </label>
@@ -29,5 +42,10 @@ $backends = $this->getInstallmentBackends();
         <?=$this->__('There are no installment plans available for this purchase amount.');?>
     </li>
     <?php } ?>
+
+    <?php $interestInfo = $isInterestFree ? 'All installment payments are interest free' : 'Monthly payment rates shown may be inaccurate as interest rates are subject to change.'; ?>
+    <li>
+        <span class="rate secondary-text"><?=$this->__($interestInfo);?></span>
+    </li>
 
 </ul>


### PR DESCRIPTION
#### 1. Objective

This PR essentially adds everything we can for now to ensure that should a customer go to the instalment provider's page, the payment options they have selected will be valid and the chances are they will proceed with the payment (hopefully drastically minimising the chances of the cancellation issue).

#### 2. Description of change

Hardcoded(!) interest rates and monthly minimum payments have been added on a per-provider basis. The instalment options presented to the customer at the checkout page have been modified to include monthly payment amounts and information/disclaimers about the interest rates. Payment options resulting in monthly payments below the defined minimums are automatically removed from those available for selection

<img width="581" alt="Screenshot 2019-05-08 at 11 26 34" src="https://user-images.githubusercontent.com/1510194/57349442-50661580-7184-11e9-950d-50c70868f862.png">
<img width="577" alt="Screenshot 2019-05-08 at 11 25 57" src="https://user-images.githubusercontent.com/1510194/57349443-50661580-7184-11e9-88ad-c870df32f3f8.png">

#### 3. Quality assurance

Install on Magento 1, activate, check that all is working as it should. Monthly minimum amounts for each providers can be found [here](https://www.omise.co/installment-payment). To test the interest absorption setting, you can change it in the Omise Dashboard

<img width="1153" alt="Screenshot 2019-05-08 at 11 17 08" src="https://user-images.githubusercontent.com/1510194/57349089-02044700-7183-11e9-8184-bce615e07c3c.png">


#### 4. Impact of the change

The customer now has as much information as we can give them about the instalment payment before they actually go to the provider's site. Also, any options selected for the instalment payment should now automatically be valid for the provider (respects minimums)

#### 5. Priority of change

High

#### 6. Additional Notes

🎉🎉🎉🎉