### PR TITLE
Fix for unable to select some installment terms

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -57,7 +57,9 @@ define(
             },
 
             /**
-             * Check if terms are selected
+             * Get installment terms
+             * 
+             * @return {string|null}
              */
             getTerms() {
                  return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -56,10 +56,16 @@ define(
                 return this;
             },
 
-            areTermsSelected() {
+            /**
+             * Check if terms are selected
+             */
+            getTerms() {
                  return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();
             },
 
+            /**
+             * Reset selected terms
+             */
             resetTerms() {
                 this.installmentTermsBBL(null);
                 this.installmentTermsKBank(null);
@@ -78,7 +84,7 @@ define(
                     'method': this.item.method,
                     'additional_data': {
                         'offsite': this.omiseOffsite(),
-                        'terms': this.installmentTermsFC() || this.installmentTermsKTC() ||  this.installmentTermsKBank() || this.installmentTermsBBL() || this.installmentTermsBAY()
+                        'terms': this.getTerms()
                     }
                 };
             },

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -46,10 +46,26 @@ define(
                 this._super()
                     .observe([
                         'omiseOffsite',
-                        'installmentTerms'
+                        'installmentTermsFC',
+                        'installmentTermsKTC',
+                        'installmentTermsKBank',
+                        'installmentTermsBBL',
+                        'installmentTermsBAY',
                     ]);
 
                 return this;
+            },
+
+            areTermsSelected() {
+                 return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();
+            },
+
+            resetTerms() {
+                this.installmentTermsBBL(null);
+                this.installmentTermsKBank(null);
+                this.installmentTermsFC(null);
+                this.installmentTermsKTC(null);
+                this.installmentTermsBAY(null);
             },
 
             /**
@@ -62,7 +78,7 @@ define(
                     'method': this.item.method,
                     'additional_data': {
                         'offsite': this.omiseOffsite(),
-                        'terms': this.installmentTerms()
+                        'terms': this.installmentTermsFC() || this.installmentTermsKTC() ||  this.installmentTermsKBank() || this.installmentTermsBBL() || this.installmentTermsBAY()
                     }
                 };
             },

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -52,9 +52,9 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                    installmentTerms(null); 
-                                    return true; 
-                                }" />
+                                resetTerms();
+                                return true;
+                            }" />
                         <label for="omise_offsite_installment_ktc">
                             <div class="omise-logo-wrapper ktc">
                                 <img class="ktc" />
@@ -66,7 +66,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('ktc'),
                                         optionsText: item,
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsKTC,
                                         visible: omiseOffsite() === 'installment_ktc',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -79,8 +79,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_first_choice">
                             <div class="omise-logo-wrapper fc">
@@ -93,7 +93,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('first_choice'),
                                         optionsText: item;
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsFC,
                                         visible: omiseOffsite() === 'installment_first_choice',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -106,8 +106,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_kbank">
                             <div class="omise-logo-wrapper kbank">
@@ -120,7 +120,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('kbank'),
                                         optionsText: item,
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsKBank,
                                         visible: omiseOffsite() === 'installment_kbank',
                                         optionsCaption: 'Choose number of montly payments'"></select>
 
@@ -134,8 +134,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_bbl">
                             <div class="omise-logo-wrapper bbl">
@@ -148,7 +148,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bbl'),
                                         optionsText: item,
                                         valueAllowUnset:true,
-                                        value: installmentTerms,
+                                        value: installmentTermsBBL,
                                         visible: omiseOffsite() === 'installment_bbl',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -160,8 +160,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_bay">
                             <div class="omise-logo-wrapper bay">
@@ -174,7 +174,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bay'),
                                         optionsText: item,
                                         valueAllowUnset:true,
-                                        value: installmentTerms,
+                                        value: installmentTermsBAY,
                                         visible: omiseOffsite() === 'installment_bay',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -193,7 +193,7 @@
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
                         css: {disabled: !isPlaceOrderActionAllowed()},
-                        enable: (getCode() == isChecked()) && omiseOffsite() && installmentTerms()">
+                        enable: (getCode() == isChecked()) && omiseOffsite() && areTermsSelected() ">
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -193,7 +193,7 @@
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
                         css: {disabled: !isPlaceOrderActionAllowed()},
-                        enable: (getCode() == isChecked()) && omiseOffsite() && areTermsSelected() ">
+                        enable: (getCode() == isChecked()) && omiseOffsite() && getTerms() ">
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>


### PR DESCRIPTION
#### 1. Objective

This PR fix issue that the user cannot select some terms.

Currently selectable is the only number of installments (terms) that exists in each of Installment options.
For instance, 5 installments are available only _Krungthai Card_ option so they are not selectable.
10 installments are available in each option so they are selectable for a user.

#### 2. Description of change

This PR separates observables for terms of each installment option.
Each installment brand has own terms observable.
It used to be single observable for all brand's terms.

#### 3. Quality assurance

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.8-dev.
- **PHP version**: 7.0.19.

**✏️ Details:**

To manually test that PR you need to make payment with installment number that is not available in all options (ie. 5 installments using KTC) and make payment using terms available in all options (ie. 10 installments in BAY)

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
