### PR TITLE
Display Installment terms

### DIFF
--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -30,7 +30,7 @@ class Capabilities extends BaseObject
      *
      * @return bool
      */
-    public function isZeroInterests() {
+    public function isZeroInterest() {
         return $this->capabilities['zero_interest_installments'];
     }
 }

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -15,7 +15,7 @@ class Capabilities extends BaseObject
 
     /**
      * Get Installment capabilities array from Omise-PHP
-     * 
+     *
      * @return array
      */
     public function getInstallmentBackends()
@@ -23,5 +23,14 @@ class Capabilities extends BaseObject
         return $this->capabilities->getBackends(
             $this->capabilities->makeBackendFilterType('installment')
         );    
+    }
+
+    /**
+     * Get information about zero interest installments
+     *
+     * @return bool
+     */
+    public function isZeroInterests() {
+        return $this->capabilities['zero_interest_installments'];
     }
 }

--- a/Model/Capabilities.php
+++ b/Model/Capabilities.php
@@ -40,8 +40,8 @@ class Capabilities
     /**
      * @return bool
      */
-    public function isZeroInterests()
+    public function isZeroInterest()
     {
-        return $this->capabilitiesAPI->isZeroInterests();
+        return $this->capabilitiesAPI->isZeroInterest();
     }
 }

--- a/Model/Capabilities.php
+++ b/Model/Capabilities.php
@@ -36,4 +36,12 @@ class Capabilities
     {
         return $this->capabilitiesAPI->getInstallmentBackends();
     }
+
+    /**
+     * @return bool
+     */
+    public function isZeroInterests()
+    {
+        return $this->capabilitiesAPI->isZeroInterests();
+    }
 }

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -38,7 +38,8 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
         foreach ($listOfActivePaymentMethods as $method) {
             if ($method->getCode() === OmiseInstallmentConfig::CODE) {
                 return [ 
-                    'installment_backends' => $this->capabilities->retrieveInstallmentBackends()
+                    'installment_backends' => $this->capabilities->retrieveInstallmentBackends(),
+                    'is_zero_interest' => $this->capabilities->isZeroInterests()
                 ];
             }
         }

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -39,7 +39,7 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
             if ($method->getCode() === OmiseInstallmentConfig::CODE) {
                 return [ 
                     'installment_backends' => $this->capabilities->retrieveInstallmentBackends(),
-                    'is_zero_interest' => $this->capabilities->isZeroInterests()
+                    'is_zero_interest' => $this->capabilities->isZeroInterest()
                 ];
             }
         }

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -7,3 +7,5 @@
 "Print", "พิมพ์"
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
+"Choose number of monthly payments", "เลือกระยะเวลาผ่อนชำระ"
+"%terms months (%amount THB / month)", "%terms เดือน (%amount บาท/เดือน)"

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -8,4 +8,4 @@
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Choose number of monthly payments", "เลือกระยะเวลาผ่อนชำระ"
-"%terms months (%amount THB / month)", "%terms เดือน (%amount/เดือน)"
+"%terms months (%amount / month)", "%terms เดือน (%amount / เดือน)"

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -9,3 +9,4 @@
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Choose number of monthly payments", "เลือกระยะเวลาผ่อนชำระ"
 "%terms months (%amount / month)", "%terms เดือน (%amount / เดือน)"
+"Manage your cards", "จัดการบัตร"

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -8,4 +8,4 @@
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Choose number of monthly payments", "เลือกระยะเวลาผ่อนชำระ"
-"%terms months (%amount THB / month)", "%terms เดือน (%amount บาท/เดือน)"
+"%terms months (%amount THB / month)", "%terms เดือน (%amount/เดือน)"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -57,6 +57,37 @@ define(
             },
 
             /**
+             * Get Installment minimum
+             * this function respects info from: https://www.omise.co/installment-payment
+             *
+             * NOTE: in the future this function should return data from capabilities object.
+             *
+             * @return {integer}
+             */
+            getInstallmentMinimum(id) {
+                switch (id) {
+                    case 'kbank': return 500;
+                    case 'bbl': return 500;
+                    case 'bay': return 300;
+                    case 'first_choice': return 300;
+                    case 'ktc': return 300;
+                    default: return NaN;
+                }
+            },
+
+            /**
+             * Checks if minimum amount is respected
+             * 
+             * @return {boolean}
+             */
+            isMinimumAmount(id, terms) {
+                const min = this.getInstallmentMinimum(id);
+                const total = checkoutConfig.quoteData.grand_total;
+
+                return total / terms >= min;
+            },
+
+            /**
              * Get installment terms
              * 
              * @return {string|null}
@@ -122,10 +153,12 @@ define(
 
                         var dispTerms = [];
                         for (let i = 0; i < terms.length; i++) {
-                            dispTerms.push({ 
-                                label: templateLabel.replace('%terms', terms[i]).replace('%amount', (total / terms[i]).toFixed(0)),
-                                key: terms[i] 
-                            });
+                            if (this.isMinimumAmount(id, terms[i])) {
+                                dispTerms.push({
+                                    label: templateLabel.replace('%terms', terms[i]).replace('%amount', (total / terms[i]).toFixed(0)),
+                                    key: terms[i]
+                                });
+                            }
                         }
 
                         return ko.observableArray(

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -67,6 +67,8 @@ define(
                 };
             },
 
+
+
             /**
              * Is method available to display
              *
@@ -105,6 +107,15 @@ define(
              */
             getOrderCurrency: function () {
                 return window.checkoutConfig.quoteData.quote_currency_code;
+            },
+
+            /**
+             * Get zero interests setting
+             *
+             * @return {string}
+             */
+            isZeroInterests: function () {
+                return window.checkoutConfig.is_zero_interest;
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -71,7 +71,6 @@ define(
                     case 'bay':          return 300;
                     case 'first_choice': return 300;
                     case 'ktc':          return 300;
-                    default:             return NaN;
                 }
             },
 
@@ -89,7 +88,6 @@ define(
                     case 'bay':          return 0.008;
                     case 'first_choice': return 0.013;
                     case 'ktc':          return 0.008;
-                    default:             return NaN;
                 }
             },
 
@@ -127,7 +125,7 @@ define(
                     return (total / terms).toFixed(0)
                 }
 
-                // get yearly interests setting
+                // get monthly interests setting
                 const rate = this.getinstallmentInterestRate(id);
                 const interests = ((1 + tax) * rate * terms * total);
 

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -121,10 +121,12 @@ define(
                         const terms = installmentBackends[key].allowed_installment_terms;
                         var dispTerms = [];
                         for (let i = 0; i < terms.length; i++) {
-                            dispTerms.push(`${terms[i]} months (${(total / terms[i]).toFixed(0)} THB / month)`);
+                            dispTerms.push({ label: `${terms[i]} months (${(total / terms[i]).toFixed(0)} THB / month)`, key: terms[i]});
                         }
 
-                        return dispTerms;
+                        return ko.observableArray(
+                            dispTerms
+                        )
                     }
                 }
             },

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -7,7 +7,8 @@ define(
         'Magento_Checkout/js/model/full-screen-loader',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/model/url-builder',
-        'Magento_Checkout/js/model/error-processor'
+        'Magento_Checkout/js/model/error-processor',
+        'Magento_Catalog/js/price-utils',
     ],
     function (
         $,
@@ -17,7 +18,8 @@ define(
         fullScreenLoader,
         quote,
         urlBuilder,
-        errorProcessor
+        errorProcessor,
+        priceUtils,
     ) {
         'use strict';
 
@@ -54,6 +56,15 @@ define(
                     ]);
 
                 return this;
+            },
+
+            /**
+             * Format Price
+             *
+             * @return {string}
+             */
+            getFormattedPrice: function (price) {
+                return priceUtils.formatPrice(price, quote.getPriceFormat());
             },
 
             /**
@@ -204,7 +215,7 @@ define(
              */
             getInstallmentTerms(id) {
                 const installmentBackends = checkoutConfig.installment_backends;
-                const templateLabel = $.mage.__('%terms months (%amount THB / month)');
+                const templateLabel = $.mage.__('%terms months (%amount / month)');
 
                 for (const key in installmentBackends) {
                     if (installmentBackends[key]._id === 'installment_' + id) {
@@ -213,7 +224,7 @@ define(
                         var dispTerms = [];
                         for (let i = 0; i < terms.length; i++) {
                             if (this.isMinimumAmount(id, terms[i])) {
-                                const amount = this.calculateSingleInstallmentAmount(id, terms[i]);
+                                const amount = this.getFormattedPrice(this.calculateSingleInstallmentAmount(id, terms[i]));
 
                                 dispTerms.push({
                                     label: templateLabel.replace('%terms', terms[i]).replace('%amount', amount),

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -172,12 +172,6 @@ define(
                 };
             },
 
-            getFormattedInstallmentTerms: function () {
-                var termsStr = getTerms();
-                console.log(termsStr);
-                return termsStr.substring(0, termsStr.indexOf('months') - 1);
-            },
-
             /**
              * Is method available to display
              *

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -106,17 +106,6 @@ define(
             },
 
             /**
-             * Get VAT tax rate
-             *
-             * NOTE: in the future this function should return data from capabilities object.
-             *
-             * @return {float}
-             */
-            getVatRate: function () {
-                return 0.07;
-            },
-
-            /**
              * Get zero interest setting
              *
              * @return {boolean}
@@ -134,7 +123,6 @@ define(
              */
             calculateSingleInstallmentAmount: function (id, terms) {
                 const total = this.getTotal();
-                const tax = this.getVatRate();
 
                 if (this.isZeroInterest()) {
                     //merchant pays interest
@@ -145,7 +133,7 @@ define(
                 const rate = this.getInstallmentInterestRate(id);
 
                 //calculate interests
-                const interest = ((1 + tax) * rate * terms * total);
+                const interest = rate * terms * total;
 
                 return + (((total + interest) / terms).toFixed(2));
             },

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -129,10 +129,7 @@ define(
                     return (total / terms).toFixed(2)
                 }
 
-                // get monthly interest setting
                 const rate = this.getInstallmentInterestRate(id);
-
-                //calculate interests
                 const interest = rate * terms * total;
 
                 return + (((total + interest) / terms).toFixed(2));

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -31,7 +31,7 @@ define(
             /**
              * Get payment method code
              *
-             * @return {string|null}
+             * @return {string}
              */
             getCode: function () {
                 return 'omise_offsite_installment';
@@ -76,7 +76,7 @@ define(
             },
 
             /**
-             * Get Installment yearly interest rate
+             * Get Installment monthly interest rate
              *
              * NOTE: in the future this function should return data from capabilities object.
              *

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -62,7 +62,7 @@ define(
              * @return {string|null}
              */
             getTerms() {
-                 return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();
+                return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();
             },
 
             /**
@@ -112,16 +112,20 @@ define(
              * @return {array}
              */
             getInstallmentTerms(id) {
-                //console.log(checkoutConfig);
                 const installmentBackends = checkoutConfig.installment_backends;
                 const total = checkoutConfig.quoteData.grand_total;
+                const templateLabel = $.mage.__('%terms months (%amount THB / month)');
 
                 for (const key in installmentBackends) {
                     if (installmentBackends[key]._id === 'installment_' + id) {
                         const terms = installmentBackends[key].allowed_installment_terms;
+
                         var dispTerms = [];
                         for (let i = 0; i < terms.length; i++) {
-                            dispTerms.push({ label: `${terms[i]} months (${(total / terms[i]).toFixed(0)} THB / month)`, key: terms[i]});
+                            dispTerms.push({ 
+                                label: templateLabel.replace('%terms', terms[i]).replace('%amount', (total / terms[i]).toFixed(0)),
+                                key: terms[i] 
+                            });
                         }
 
                         return ko.observableArray(

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -67,7 +67,11 @@ define(
                 };
             },
 
-
+            getInstallmentTerms: function () {
+                var termsStr = installmentTerms();
+                console.log(termsStr);
+                return termsStr.substring(0, termsStr.indexOf('months') - 1);
+            },
 
             /**
              * Is method available to display
@@ -84,6 +88,7 @@ define(
              * @return {array}
              */
             getInstallmentTerms(id) {
+                //console.log(checkoutConfig);
                 const installmentBackends = checkoutConfig.installment_backends;
                 const total = checkoutConfig.quoteData.grand_total;
 

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -138,7 +138,7 @@ define(
 
                 if (this.isZeroInterest()) {
                     //merchant pays interest
-                    return (total / terms).toFixed(0)
+                    return (total / terms).toFixed(2)
                 }
 
                 // get monthly interest setting
@@ -147,7 +147,7 @@ define(
                 //calculate interests
                 const interest = ((1 + tax) * rate * terms * total);
 
-                return + (((total + interest) / terms).toFixed(0));
+                return + (((total + interest) / terms).toFixed(2));
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -46,7 +46,7 @@ define(
                 this._super()
                     .observe([
                         'omiseOffsite',
-                        'installmentTerms'
+                        'installmentTerms',
                     ]);
 
                 return this;
@@ -83,9 +83,18 @@ define(
              */
             getInstallmentTerms(id) {
                 const installmentBackends = checkoutConfig.installment_backends;
+                const total = checkoutConfig.quoteData.grand_total;
+
                 for (const key in installmentBackends) {
-                    if (installmentBackends[key]._id === 'installment_' + id)
-                        return ko.observableArray(installmentBackends[key].allowed_installment_terms);
+                    if (installmentBackends[key]._id === 'installment_' + id) {
+                        const terms = installmentBackends[key].allowed_installment_terms;
+                        var dispTerms = [];
+                        for (let i = 0; i < terms.length; i++) {
+                            dispTerms.push(`${terms[i]} months (${(total / terms[i]).toFixed(0)} THB / month)`);
+                        }
+
+                        return dispTerms;
+                    }
                 }
             },
 
@@ -99,7 +108,7 @@ define(
             },
 
             /**
-             * Get store currency
+             * Get store currency 
              *
              * @return {string}
              */

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -103,11 +103,11 @@ define(
             },
 
             /**
-             * Get zero interests setting
+             * Get zero interest setting
              *
              * @return {string}
              */
-            isZeroInterests() {
+            isZeroInterest() {
                 return window.checkoutConfig.is_zero_interest;
             },
 
@@ -120,16 +120,16 @@ define(
                 const total = this.getTotal();
                 const tax = this.getVatRate();
 
-                if (this.isZeroInterests()) {
-                    //merchant pays interests
+                if (this.isZeroInterest) {
+                    //merchant pays interest
                     return (total / terms).toFixed(0)
                 }
 
-                // get monthly interests setting
+                // get monthly interest setting
                 const rate = this.getinstallmentInterestRate(id);
-                const interests = ((1 + tax) * rate * terms * total);
+                const interest = ((1 + tax) * rate * terms * total);
 
-                return + ( ( (total + interests ) / terms ).toFixed( 0 ) );
+                return + ( ( (total + interest ) / terms ).toFixed( 0 ) );
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -94,6 +94,17 @@ define(
             },
 
             /**
+             * Get VAT tax rate
+             *
+             * NOTE: in the future this function should return data from capabilities object.
+             *
+             * @return {float}
+             */
+            getVatRate() {
+                return 0.07;
+            },
+
+            /**
              * Get zero interests setting
              *
              * @return {string}
@@ -109,7 +120,7 @@ define(
              */
             calculateSingleInstallmentAmount(id, terms) {
                 const total = this.getTotal();
-                const tax = 0.07;
+                const tax = this.getVatRate();
 
                 if (this.isZeroInterests()) {
                     //merchant pays interests
@@ -135,6 +146,11 @@ define(
                 return singleInstallment >= min;
             },
 
+            /**
+             * Get total amount of an order
+             *
+             * @return {integer}
+             */
             getTotal() {
                 return +window.checkoutConfig.totalsData.grand_total;
             },

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -120,7 +120,7 @@ define(
                 const total = this.getTotal();
                 const tax = this.getVatRate();
 
-                if (this.isZeroInterest) {
+                if (this.isZeroInterest()) {
                     //merchant pays interest
                     return (total / terms).toFixed(0)
                 }

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -31,7 +31,7 @@ define(
             /**
              * Get payment method code
              *
-             * @return {string}
+             * @return {string|null}
              */
             getCode: function () {
                 return 'omise_offsite_installment';
@@ -46,10 +46,33 @@ define(
                 this._super()
                     .observe([
                         'omiseOffsite',
-                        'installmentTerms',
+                        'installmentTermsFC',
+                        'installmentTermsKTC',
+                        'installmentTermsKBank',
+                        'installmentTermsBBL',
+                        'installmentTermsBAY',
                     ]);
 
                 return this;
+            },
+
+            /**
+             * Get installment terms
+             * @return {string}
+             */
+            getTerms() {
+                 return this.installmentTermsBBL() || this.installmentTermsKBank() || this.installmentTermsFC() || this.installmentTermsKTC() || this.installmentTermsBAY();
+            },
+
+            /**
+             * Reset selected terms
+             */
+            resetTerms() {
+                this.installmentTermsBBL(null);
+                this.installmentTermsKBank(null);
+                this.installmentTermsFC(null);
+                this.installmentTermsKTC(null);
+                this.installmentTermsBAY(null);
             },
 
             /**
@@ -62,13 +85,13 @@ define(
                     'method': this.item.method,
                     'additional_data': {
                         'offsite': this.omiseOffsite(),
-                        'terms': this.installmentTerms()
+                        'terms': this.getTerms()
                     }
                 };
             },
 
-            getInstallmentTerms: function () {
-                var termsStr = installmentTerms();
+            getFormattedInstallmentTerms: function () {
+                var termsStr = getTerms();
                 console.log(termsStr);
                 return termsStr.substring(0, termsStr.indexOf('months') - 1);
             },

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -64,7 +64,12 @@
                             </div>
                         </label>
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('ktc'),
-                                        optionsText: item,
+                                        optionsText: function (item) {
+                                            return item.label
+                                        },
+                                        optionsValue: function (item) {
+                                            return item.key
+                                        },
                                         valueAllowUnset: true,
                                         value: installmentTermsKTC,
                                         visible: omiseOffsite() === 'installment_ktc',
@@ -91,7 +96,12 @@
                             </div>
                         </label>
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('first_choice'),
-                                        optionsText: item;
+                                        optionsText: function (item) {
+                                            return item.label
+                                        },
+                                        optionsValue: function (item) {
+                                            return item.key
+                                        },
                                         valueAllowUnset: true,
                                         value: installmentTermsFC,
                                         visible: omiseOffsite() === 'installment_first_choice',
@@ -118,7 +128,12 @@
                             </div>
                         </label>
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('kbank'),
-                                        optionsText: item,
+                                        optionsText: function (item) {
+                                            return item.label
+                                        },
+                                        optionsValue: function (item) {
+                                            return item.key
+                                        },
                                         valueAllowUnset: true,
                                         value: installmentTermsKBank,
                                         visible: omiseOffsite() === 'installment_kbank',
@@ -146,7 +161,12 @@
                             </div>
                         </label>
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bbl'),
-                                        optionsText: item,
+                                        optionsText: function (item) {
+                                            return item.label
+                                        },
+                                        optionsValue: function (item) {
+                                            return item.key
+                                        },
                                         valueAllowUnset:true,
                                         value: installmentTermsBBL,
                                         visible: omiseOffsite() === 'installment_bbl',
@@ -172,7 +192,12 @@
                             </div>
                         </label>
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bay'),
-                                        optionsText: item,
+                                        optionsText: function (item) {
+                                            return item.label
+                                        },
+                                        optionsValue: function (item) {
+                                            return item.key
+                                        },
                                         valueAllowUnset:true,
                                         value: installmentTermsBAY,
                                         visible: omiseOffsite() === 'installment_bay',

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -52,9 +52,9 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                    installmentTerms(null); 
-                                    return true; 
-                                }" />
+                                resetTerms();
+                                return true;
+                            }" />
                         <label for="omise_offsite_installment_ktc">
                             <div class="omise-logo-wrapper ktc">
                                 <img class="ktc" />
@@ -66,7 +66,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('ktc'),
                                         optionsText: item,
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsKTC,
                                         visible: omiseOffsite() === 'installment_ktc',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -79,8 +79,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_first_choice">
                             <div class="omise-logo-wrapper fc">
@@ -93,7 +93,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('first_choice'),
                                         optionsText: item;
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsFC,
                                         visible: omiseOffsite() === 'installment_first_choice',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -106,8 +106,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_kbank">
                             <div class="omise-logo-wrapper kbank">
@@ -120,7 +120,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('kbank'),
                                         optionsText: item,
                                         valueAllowUnset: true,
-                                        value: installmentTerms,
+                                        value: installmentTermsKBank,
                                         visible: omiseOffsite() === 'installment_kbank',
                                         optionsCaption: 'Choose number of montly payments'"></select>
 
@@ -134,8 +134,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_bbl">
                             <div class="omise-logo-wrapper bbl">
@@ -148,7 +148,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bbl'),
                                         optionsText: item,
                                         valueAllowUnset:true,
-                                        value: installmentTerms,
+                                        value: installmentTermsBBL,
                                         visible: omiseOffsite() === 'installment_bbl',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -160,8 +160,8 @@
                             },
                             checked: omiseOffsite,
                             click: function(data, event) { 
-                                installmentTerms(null); 
-                                return true; 
+                                resetTerms();
+                                return true;
                             };" />
                         <label for="omise_offsite_installment_bay">
                             <div class="omise-logo-wrapper bay">
@@ -174,7 +174,7 @@
                         <select style="margin-top:10px" data-bind="options: getInstallmentTerms('bay'),
                                         optionsText: item,
                                         valueAllowUnset:true,
-                                        value: installmentTerms,
+                                        value: installmentTermsBAY,
                                         visible: omiseOffsite() === 'installment_bay',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
@@ -193,7 +193,7 @@
                         click: placeOrder,
                         attr: {title: $t('Place Order')},
                         css: {disabled: !isPlaceOrderActionAllowed()},
-                        enable: (getCode() == isChecked()) && omiseOffsite() && installmentTerms()">
+                        enable: (getCode() == isChecked()) && omiseOffsite() && getTerms() ">
                     <span data-bind="i18n: 'Place Order'"></span>
                 </button>
             </div>


### PR DESCRIPTION
#### 1. Objective

This PR added functionality to display installment terms.

#### 2. Description of change

Hardcoded interest rates and monthly minimum payments have been added on a per-provider basis. The installment options presented to the customer at the checkout page have been modified to include monthly payment amounts and information/disclaimers about the interest rates. Payment options resulting in monthly payments below the defined minimums are automatically removed from those available for selection

![image](https://user-images.githubusercontent.com/10651523/58417347-cfb08000-8084-11e9-852c-bb83345e0ea1.png)

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.7.
- **PHP version**: 7.0.16.

**✏️ Details:**

To test this PR make payment with installment, observe if there are amounts properly displayed.
Check if minimum amounts are respected.

ie. If you choose order value for 3k THB than 12 months option should not be displayed, due to the minimum installment amount is not met in any provider.
More info about minimum installment amounts [here](https://www.omise.co/installment-payment)

Check both options for absorbing rates by Merchant and Customer.

Check if TH translated texts regarding this functionality are displayed.

#### 4. Impact of the change

 N/A

#### 5. Priority of change

High

#### 6. Additional Notes

N/A