### PR TITLE
Display info on checkout if plugin is in Sandbox mode

### DIFF
--- a/Model/Ui/PluginConfigProvider.php
+++ b/Model/Ui/PluginConfigProvider.php
@@ -20,7 +20,7 @@ class PluginConfigProvider implements ConfigProviderInterface
     public function getConfig()
     {
         return [
-            'isOmiseSandboxEnabled' => $this->config->isSandboxEnabled()
+            'isOmiseSandboxOn' => $this->config->isSandboxEnabled()
         ];
     }
 }

--- a/Model/Ui/PluginConfigProvider.php
+++ b/Model/Ui/PluginConfigProvider.php
@@ -1,0 +1,26 @@
+<?php
+namespace Omise\Payment\Model\Ui;
+
+use Magento\Checkout\Model\ConfigProviderInterface;
+use Omise\Payment\Model\Config\Config;
+
+class PluginConfigProvider implements ConfigProviderInterface
+{
+    private $config;
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Retrieve assoc array of checkout configuration
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        return [
+            'isOmiseSandboxEnabled' => $this->config->isSandboxEnabled()
+        ];
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -5,6 +5,7 @@
         <arguments>
             <argument name="configProviders" xsi:type="array">
                 <item name="omise_cc_config_provider" xsi:type="object">Omise\Payment\Model\Ui\CcConfigProvider</item>
+                <item name="omise_plugin_config_provider" xsi:type="object">Omise\Payment\Model\Ui\PluginConfigProvider</item>
                 <item name="omise_capabilities_config_provider" xsi:type="object">Omise\Payment\Model\Ui\CapabilitiesConfigProvider</item>
             </argument>
         </arguments>

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -8,5 +8,5 @@
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Manage your cards", "จัดการบัตร"
-"more info", "โ้อมูลเพิ่มเติม"
+"more info", "ข้อมูลเพิ่มเติม"
 "Test mode", "โหมดทดสอบ"

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -9,4 +9,4 @@
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Manage your cards", "จัดการบัตร"
 "more info", "โ้อมูลเพิ่มเติม"
-"Test mode", "โหมดทดลอง"
+"Test mode", "โหมดทดสอบ"

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -8,3 +8,5 @@
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
 "Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
 "Manage your cards", "จัดการบัตร"
+"more info", "โ้อมูลเพิ่มเติม"
+"Test mode", "โหมดทดลอง"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -101,6 +101,15 @@ define(
             },
 
             /**
+             * Checks if sandbox is turned on
+             *
+             * @return {string}
+             */
+            isSandboxOn: function () {
+                return window.checkoutConfig.isOmiseSandboxOn;
+            },
+
+            /**
              * Is 3-D Secure config enabled
              *
              * @return {boolean}

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -103,7 +103,7 @@ define(
             /**
              * Checks if sandbox is turned on
              *
-             * @return {string}
+             * @return {boolean}
              */
             isSandboxOn: function () {
                 return window.checkoutConfig.isOmiseSandboxOn;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
@@ -45,7 +45,7 @@ define(
             /**
              * Checks if sandbox is turned on
              *
-             * @return {string}
+             * @return {boolean}
              */
             isSandboxOn: function () {
                 return window.checkoutConfig.isOmiseSandboxOn;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offline-tesco-method.js
@@ -43,6 +43,15 @@ define(
             },
 
             /**
+             * Checks if sandbox is turned on
+             *
+             * @return {string}
+             */
+            isSandboxOn: function () {
+                return window.checkoutConfig.isOmiseSandboxOn;
+            },
+
+            /**
              * Get order currency
              *
              * @return {string}

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipay-method.js
@@ -69,7 +69,7 @@ define(
             /**
              * Checks if sandbox is turned on
              *
-             * @return {string}
+             * @return {boolean}
              */
             isSandboxOn: function () {
                 return window.checkoutConfig.isOmiseSandboxOn;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipay-method.js
@@ -67,6 +67,15 @@ define(
             },
 
             /**
+             * Checks if sandbox is turned on
+             *
+             * @return {string}
+             */
+            isSandboxOn: function () {
+                return window.checkoutConfig.isOmiseSandboxOn;
+            },
+
+            /**
              * Hook the placeOrder function.
              * Original source: placeOrder(data, event); @ module-checkout/view/frontend/web/js/view/payment/default.js
              *

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -101,6 +101,15 @@ define(
             },
 
             /**
+             * Checks if sandbox is turned on
+             *
+             * @return {string}
+             */
+            isSandboxOn: function () {
+                return window.checkoutConfig.isOmiseSandboxOn;
+            },
+
+            /**
              * Returns Installment Terms
              *
              * @return {array}

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -103,7 +103,7 @@ define(
             /**
              * Checks if sandbox is turned on
              *
-             * @return {string}
+             * @return {boolean}
              */
             isSandboxOn: function () {
                 return window.checkoutConfig.isOmiseSandboxOn;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
@@ -97,7 +97,7 @@ define(
             /**
              * Checks if sandbox is turned on
              *
-             * @return {string}
+             * @return {boolean}
              */
             isSandboxOn: function () {
                 return window.checkoutConfig.isOmiseSandboxOn;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-internetbanking-method.js
@@ -95,6 +95,15 @@ define(
             },
 
             /**
+             * Checks if sandbox is turned on
+             *
+             * @return {string}
+             */
+            isSandboxOn: function () {
+                return window.checkoutConfig.isOmiseSandboxOn;
+            },
+
+            /**
              * Hook the placeOrder function.
              * Original source: placeOrder(data, event); @ module-checkout/view/frontend/web/js/view/payment/default.js
              *

--- a/view/frontend/web/template/payment/offline-tesco-form.html
+++ b/view/frontend/web/template/payment/offline-tesco-form.html
@@ -12,7 +12,17 @@
                enable: isActive()"/>
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
+            <!-- ko if: isSandboxOn() -->
+            <span data-bind="i18n: ''"></span>
+            <!-- /ko -->
         </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                </div>
+            </div>
+        </div>
         <div data-bind="visible: !isActive()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">

--- a/view/frontend/web/template/payment/offline-tesco-form.html
+++ b/view/frontend/web/template/payment/offline-tesco-form.html
@@ -12,9 +12,6 @@
                enable: isActive()"/>
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
-            <!-- ko if: isSandboxOn() -->
-            <span data-bind="i18n: ''"></span>
-            <!-- /ko -->
         </label>
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">

--- a/view/frontend/web/template/payment/offline-tesco-form.html
+++ b/view/frontend/web/template/payment/offline-tesco-form.html
@@ -16,7 +16,7 @@
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
                 </div>
             </div>
         </div>

--- a/view/frontend/web/template/payment/offsite-alipay-form.html
+++ b/view/frontend/web/template/payment/offsite-alipay-form.html
@@ -13,6 +13,13 @@
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                </div>
+            </div>
+        </div>
         <div data-bind="visible: !isActive()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">

--- a/view/frontend/web/template/payment/offsite-alipay-form.html
+++ b/view/frontend/web/template/payment/offsite-alipay-form.html
@@ -16,7 +16,7 @@
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
                 </div>
             </div>
         </div>

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -14,7 +14,7 @@
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
                 </div>
             </div>
         </div>

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -11,6 +11,13 @@
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                </div>
+            </div>
+        </div>
         <div data-bind="visible: !isActive()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">

--- a/view/frontend/web/template/payment/offsite-internetbanking-form.html
+++ b/view/frontend/web/template/payment/offsite-internetbanking-form.html
@@ -17,7 +17,7 @@
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
                 </div>
             </div>
         </div>

--- a/view/frontend/web/template/payment/offsite-internetbanking-form.html
+++ b/view/frontend/web/template/payment/offsite-internetbanking-form.html
@@ -14,6 +14,13 @@
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                </div>
+            </div>
+        </div>
         <div data-bind="visible: !isActive()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -13,6 +13,13 @@
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="payment-method-content">
         <!-- ko foreach: getRegion('messages') -->

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -16,7 +16,7 @@
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Sandbox mode'"></div>
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
                 </div>
             </div>
         </div>


### PR DESCRIPTION
#### 1. Objective

This PR adds information on the checkout page if the omise plugin is in sandbox mode. 

#### 2. Description of change

Added new config file that sends information to javascript renderers if the omise plugin is in sandbox mode.

![image](https://user-images.githubusercontent.com/10651523/58319741-7d6c2680-7e1a-11e9-9ed4-f1a4db8e195b.png)



#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3.
- **Omise plugin version**: Omise-Magento 2.7.
- **PHP version**: 7.0.16.

**✏️ Details:**

To manually test this PR:
1. Enable omise plugin sandbox mode in Admin panel.
Check if the warning about the plugin being in sandbox mode is displayed for each of omise payment methods.

2. Disable omise plugin sandbox mode in Admin panel.
Check if none sandbox warning is displayed.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A