### PR TITLE
Add a very visible 'Omise test mode' reminder on the checkout page 

### DIFF
--- a/src/app/code/community/Omise/Gateway/Helper/Data.php
+++ b/src/app/code/community/Omise/Gateway/Helper/Data.php
@@ -51,5 +51,10 @@ class Omise_Gateway_Helper_Data extends Mage_Core_Helper_Abstract
         return (int)($providers[$code]['monthly_minimum_subunits_'.$currencyCode]);
     }
 
+    public function getTestModeJS()
+    {
+        $isTestMode = Mage::getModel('omise_gateway/config')->load(1)->test_mode;
+        return $isTestMode ? 'omise/gateway/js/testmode.js' : '';
+    }
 
 }

--- a/src/app/design/frontend/base/default/layout/omise/gateway.xml
+++ b/src/app/design/frontend/base/default/layout/omise/gateway.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0"?>
 <layout version="0.1.0">
-     <checkout_onepage_index translate="label">
-         <reference name="head">
-             <action method="addItem">
-                 <type>skin_css</type>
-                 <name>omise/gateway/css/style.css</name>
-             </action>
-         </reference>
-     </checkout_onepage_index>
+    <checkout_onepage_index translate="label">
+        <reference name="head">
+            <action method="addItem">
+                <type>skin_css</type>
+                <name>omise/gateway/css/style.css</name>
+            </action>
+            <action method="addItem">
+                <type>skin_js</type>
+                <name helper="omise_gateway/getTestModeJS" />
+            </action>
+        </reference>
+    </checkout_onepage_index>
 </layout>

--- a/src/skin/frontend/base/default/omise/gateway/css/style.css
+++ b/src/skin/frontend/base/default/omise/gateway/css/style.css
@@ -97,3 +97,19 @@
 .banks-list .omise-logo-wrapper > div.logo-ktc {
     background: url('../images/ktc.svg') #ffffff;
 }
+
+.omise-test-warning {
+    background: #ffcc00;
+    color: #000;
+    font-weight: bold;
+    width: 80%;
+    position: fixed;
+    top: 0;
+    left: 10%;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 5px;
+    border-radius: 0 0 10px 10px;
+    border-top: none;
+    opacity: 0.75;
+}

--- a/src/skin/frontend/base/default/omise/gateway/css/style.css
+++ b/src/skin/frontend/base/default/omise/gateway/css/style.css
@@ -106,10 +106,13 @@
     position: fixed;
     top: 0;
     left: 10%;
-    text-transform: uppercase;
     text-align: center;
     padding: 5px;
     border-radius: 0 0 10px 10px;
     border-top: none;
     opacity: 0.75;
+}
+
+.omise-test-warning a, .omise-test-warning a:hover {
+    color: #007;
 }

--- a/src/skin/frontend/base/default/omise/gateway/js/testmode.js
+++ b/src/skin/frontend/base/default/omise/gateway/js/testmode.js
@@ -1,4 +1,3 @@
-
 window.addEventListener('load', function() {
 	var warning = document.createElement('div'); 
 	warning.innerHTML = Translator.translate('OMISE TEST MODE') + ' - \

--- a/src/skin/frontend/base/default/omise/gateway/js/testmode.js
+++ b/src/skin/frontend/base/default/omise/gateway/js/testmode.js
@@ -1,7 +1,7 @@
 
 window.addEventListener('load', function() {
 	var warning = document.createElement('div');
-	warning.innerHTML = 'Omise Test Mode';
+	warning.innerHTML = 'OMISE TEST MODE - <a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys">[more info here]</a>';
 	warning.className = 'omise-test-warning';
 	document.body.appendChild(warning);
 });

--- a/src/skin/frontend/base/default/omise/gateway/js/testmode.js
+++ b/src/skin/frontend/base/default/omise/gateway/js/testmode.js
@@ -1,7 +1,9 @@
 
 window.addEventListener('load', function() {
-	var warning = document.createElement('div');
-	warning.innerHTML = 'OMISE TEST MODE - <a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys">[more info here]</a>';
+	var warning = document.createElement('div'); 
+	warning.innerHTML = Translator.translate('OMISE TEST MODE') + ' - \
+		<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys">\
+		[ ' + Translator.translate('more info') +' ]</a>';
 	warning.className = 'omise-test-warning';
 	document.body.appendChild(warning);
 });

--- a/src/skin/frontend/base/default/omise/gateway/js/testmode.js
+++ b/src/skin/frontend/base/default/omise/gateway/js/testmode.js
@@ -1,0 +1,7 @@
+
+window.addEventListener('load', function() {
+	var warning = document.createElement('div');
+	warning.innerHTML = 'Omise Test Mode';
+	warning.className = 'omise-test-warning';
+	document.body.appendChild(warning);
+});


### PR DESCRIPTION
#### 1. Objective

Merchants have requested that there be some visual indication on the checkout page if the Omise payment plugin is set to test mode. This will avoid the situation where they may accidentally leave their store in this test payments state

#### 2. Description of change

A small JS file is injected into the checkout page if the config setting for 'test mode' is switched on. This JS adds some HTML to the page to show a warning overlaid at the top of the page. The plugin CSS has also been altered to include styling for the warning.

![image](https://user-images.githubusercontent.com/1510194/58398001-81e44980-807d-11e9-8271-3232614acf1f.png)


#### 3. Quality assurance

Switch test mode on/off via the plugin settings, make sure the warning on the checkout page appears/disappears as expected.

#### 4. Impact of the change

Merchants way less likely to accidentally leave Omise payments in test mode on their sites

#### 5. Priority of change

Normal

#### 6. Additional Notes

None