### PR TITLE
Installment calculation - remove VAT

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsiteinstallment.php
@@ -48,8 +48,7 @@ class Omise_Gateway_Block_Form_Offsiteinstallment extends Mage_Payment_Block_For
     public function getMonthlyPaymentAmount($saleAmount, $monthCount, $interestRatePC)
     {
         $interestRate = $this->isInterestFree() ? 0 : $interestRatePC/100;
-        $VAT = 0.07; // Should this be in config, and also country dependent??
-        $interestAmount = $interestRate * $monthCount * $saleAmount * (1 + $VAT);
+        $interestAmount = $interestRate * $monthCount * $saleAmount;
         $totalAmount = $saleAmount + $interestAmount;
         return $totalAmount/$monthCount;
     }


### PR DESCRIPTION
#### 1. Objective

Removed VAT from calculations, the customer does not pay VAT when he absorbs interests.

#### 2. Description of change

This PR removes VAT declaration and calculations when Installment value is calculated to be displayed for customer on the checkout page.

#### 3. Quality assurance

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

Try to make an installment payment, observe if interests calculated on the checkout page are the same as interests displayed in the bank you have chosen.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A