### PR TITLE
Better format of installment minimum amount message (Merge after #196)

### DIFF
--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -6,7 +6,7 @@
 "Option available only for orders in THB","สามารถเลือกชำระผ่านอาลีเพย์ได้ในรายการที่เป็นสกุลเงินบาทเท่านั้น"
 "Print", "พิมพ์"
 "Choose your installment terms","เลือกระยะเวลาการผ่อนชำระ"
-"Miminum order value is 3000 THB", "ยอดสั่งซื้อขั้นต่ำ 3000 บาท"
+"Minimum order value is %amount", "ยอดสั่งซื้อขั้นต่ำ %amount"
 "Choose number of monthly payments", "เลือกระยะเวลาผ่อนชำระ"
 "%terms months (%amount / month)", "%terms เดือน (%amount / เดือน)"
 "Manage your cards", "จัดการบัตร"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -22,6 +22,7 @@ define(
         priceUtils,
     ) {
         'use strict';
+        const installmentMinimumPurchaseAmount = 3000;
 
         return Component.extend({
             defaults: {
@@ -76,7 +77,7 @@ define(
              * @return {string}
              */
             getMinimumOrderText: function () {
-                return $.mage.__('Minimum order value is %amount').replace('%amount', this.getFormattedAmount(3000));
+                return $.mage.__('Minimum order value is %amount').replace('%amount', this.getFormattedAmount(installmentMinimumPurchaseAmount));
             },
 
             /**
@@ -261,7 +262,7 @@ define(
              * @return {boolean}
              */
             orderValueTooLow: function () {
-                return this.getTotal() < 3000;
+                return this.getTotal() < installmentMinimumPurchaseAmount;
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -70,13 +70,13 @@ define(
 
             /**
              * Get formatted message about installment value limitation
-             * 
+             *
+             * NOTE: this value should be taken directly from capability object when it is fully implemented.
+             *
              * @return {string}
              */
             getMinimumOrderText: function () {
-                const formattedAmount = this.getFormattedAmount(3000);
-
-                return 'Minimum order value is %amount'.replace('%amount', formattedAmount);
+                return $.mage.__('Minimum order value is %amount').replace('%amount', this.getFormattedAmount(3000));
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -69,6 +69,17 @@ define(
             },
 
             /**
+             * Get formatted message about installment value limitation
+             * 
+             * @return {string}
+             */
+            getMinimumOrderText: function () {
+                const formattedAmount = this.getFormattedAmount(3000);
+
+                return 'Minimum order value is %amount'.replace('%amount', formattedAmount);
+            },
+
+            /**
              * Get Installment minimum
              * this function respects info from: https://www.omise.co/installment-payment
              *

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -21,7 +21,7 @@
         <div data-bind="visible: orderValueTooLow()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
-                    <div data-bind="i18n: 'Minimum order value is 3000 THB'"></div>
+                    <div data-bind="text: getMinimumOrderText()"></div>
                 </div>
             </div>
         </div>

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -18,7 +18,7 @@
                 </div>
             </div>
         </div>
-        <div data-bind="visible: orderValueTooLow()" class="page messages">
+        <div data-bind="visible: orderValueTooLow() && isActive()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
                     <div data-bind="text: getMinimumOrderText()"></div>

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -18,7 +18,7 @@
                 </div>
             </div>
         </div>
-        <div data-bind="visible: orderValueTooLow() && isActive()" class="page messages">
+        <div data-bind="visible: isActive() && orderValueTooLow()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
                     <div data-bind="text: getMinimumOrderText()"></div>


### PR DESCRIPTION
#### 1. Objective
This PR adds formatting of currency displayed on the minimum installment amount requirement message.

![image](https://user-images.githubusercontent.com/10651523/59056299-280f2b00-8898-11e9-9d55-782aead42426.png)

Formatting is done according to the merchant's Magento store setup.

This PR also change condition when this message is displayed.
It also adds a condition to this message also when installment payment is active at all.

#### 2. Description of change

Added simple message formatting function.
Added extra condition when the installment warning message is displayed.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

Please do the following tests:
1. check if a properly formatted message is displayed when you have set up the store's currency as THB and order value is below 3000 THB.
2. check if the message is not displayed when 3000 THB is not met, but store's currency is set as non-THB

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A