### PR TITLE
Change to display an error message using ErrorMessageMapper

### DIFF
--- a/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseAuthorizeCommandResponseValidator.php
@@ -15,7 +15,7 @@ class OmiseAuthorizeCommandResponseValidator extends CommandResponseValidator
     protected function validateResponse(Charge $charge)
     {
         if ($charge->isFailed()) {
-            return new ErrorInvalid('Payment failed. ' . ucfirst($charge->failure_message) . ', please contact our support if you have any questions.');
+            return new ErrorInvalid($charge->failure_code);
         }
 
         return $charge->isAwaitCapture() ? true : (new ErrorInvalid('Payment failed, invalid payment status, please contact our support if you have any questions'));

--- a/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
+++ b/Gateway/Validator/OmiseCaptureCommandResponseValidator.php
@@ -15,7 +15,7 @@ class OmiseCaptureCommandResponseValidator extends CommandResponseValidator
     protected function validateResponse(Charge $charge)
     {
         if ($charge->isFailed()) {
-            return new ErrorInvalid('Payment failed. ' . ucfirst($charge->failure_message) . ', please contact our support if you have any questions.');
+            return new ErrorInvalid($charge->failure_code);
         }
 
         return $charge->isSuccessful() ? true : (new ErrorInvalid('Payment failed, invalid payment status, please contact our support if you have any questions'));

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -305,6 +305,24 @@
         </arguments>
     </virtualType>
 
+
+    <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualConfigReader" type="Magento\Payment\Gateway\ErrorMapper\VirtualConfigReader">
+        <arguments>
+            <argument name="fileName" xsi:type="string">omise_error_mapping.xml</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualMappingData" type="Magento\Payment\Gateway\ErrorMapper\MappingData">
+        <arguments>
+            <argument name="reader" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualConfigReader</argument>
+            <argument name="cacheId" xsi:type="string">omise_error_mapper</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualErrorMessageMapper" type="Magento\Payment\Gateway\ErrorMapper\ErrorMessageMapper">
+        <arguments>
+            <argument name="messageMapping" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualMappingData</argument>
+        </arguments>
+    </virtualType>
+
     <!-- OmiseAuthorize Command -->
     <virtualType name="OmiseAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
@@ -313,6 +331,7 @@
             <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseAuthorizeCommandResponseValidator</argument>
+            <argument name="errorMessageMapper" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualErrorMessageMapper</argument>
         </arguments>
     </virtualType>
 
@@ -335,6 +354,7 @@
             <argument name="client" xsi:type="object">OmiseCCCharge</argument>
             <argument name="handler" xsi:type="object">OmiseResponseHandler</argument>
             <argument name="validator" xsi:type="object">Omise\Payment\Gateway\Validator\OmiseCaptureCommandResponseValidator</argument>
+            <argument name="errorMessageMapper" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualErrorMessageMapper</argument>
         </arguments>
     </virtualType>
 

--- a/etc/omise_error_mapping.xml
+++ b/etc/omise_error_mapping.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/error_mapping.xsd">
+    <message_list>
+        <message code="failed_fraud_check" translate="true">Card was marked as fraudulent.</message>
+        <message code="failed_processing" translate="true">General payment processing failure.</message>
+        <message code="insufficient_balance" translate="true">Insufficient funds in the account or the card has reached the credit limit.</message>
+        <message code="insufficient_fund" translate="true">Insufficient funds in the account or the card has reached the credit limit.</message>
+        <message code="invalid_account_number" translate="true">Valid account for payment method not found.</message>
+        <message code="invalid_account" translate="true">Valid account for payment method not found.</message>
+        <message code="invalid_security_code" translate="true">Security code invalid or card did not pass preauthorization.</message>
+        <message code="payment_cancelled" translate="true">Payment cancelled by payer.</message>
+        <message code="payment_rejected" translate="true">Payment rejected by issuer.</message>
+        <message code="stolen_or_lost_card" translate="true">Card stolen or lost.</message>
+        <message code="timeout" translate="true">Payer did not take action before charge expiration.</message>
+    </message_list>
+</mapping>


### PR DESCRIPTION
#### 1. Objective

Currently, credit card payment error messages are not displayed correctly.
It should be changed to display an error message according to the error code.

#### 2. Description of change

Change to use ErrorMessageMapper to display an error message.
As of the present, if you do not use ErrorMessageMapper, the function of \Magento\Payment\Gateway\Command\GatewayCommand::processErrors will display only the following messages.
'Transaction has been declined. Please try again later.'
Also, it is not desirable to manipulate the contents of the error message before passing it to the ErrorMessageMapper.
We should pass the error code as is.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.8.
- **Omise plugin version**: Omise-Magento 2.7.
- **PHP version**:  7.1.30.

**✏️ Details:**

In the One-Page Checkout payment step, enter and confirm incorrect credit card information.

#### 4. Impact of the change

The error message for credit card payments is changed.

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A