### PR TITLE
Error when change Omise Account - Fix

### DIFF
--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -172,12 +172,15 @@ class Customer
      */
     protected function initializeObject()
     {
-        if ($this->getId()) {
-            $customerAPI = $this->customerAPI->find($this->getId());
+        $customerId = $this->getId();
+
+        if ($customerId) {
+            $customerAPI = $this->customerAPI->find($customerId);
 
             if ($customerAPI instanceof \Omise\Payment\Model\Api\Error) {
                 // instance of Error if merchants Omise account and key has been changed
                 $this->create();
+                //after re-creating customer, it's ID has beenchanged, so we need to find API using new customer ID, so get it again.
                 $customerAPI = $this->customerAPI->find($this->getId());
             }
 

--- a/Model/Customer.php
+++ b/Model/Customer.php
@@ -97,9 +97,12 @@ class Customer
      *
      * @return self
      */
-    public function create(array $params)
+    public function create()
     {
-        $this->customerAPI = $this->customerAPI->create($params);
+        $this->customerAPI = $this->customerAPI->create([
+            'email'       => $this->magentoCustomer->getEmail(),
+            'description' => trim($this->magentoCustomer->getFirstname() . ' ' . $this->magentoCustomer->getLastname())
+        ]);
 
         $this->magentoCustomer->setData(self::OMISE_CUSTOMER_ID_FIELD, $this->customerAPI->id);
         $this->magentoCustomerResource->saveAttribute($this->magentoCustomer, self::OMISE_CUSTOMER_ID_FIELD);
@@ -117,10 +120,7 @@ class Customer
     public function addCard($cardToken)
     {
         if (! $this->getId()) {
-            $this->create([
-                'email'       => $this->magentoCustomer->getEmail(),
-                'description' => trim($this->magentoCustomer->getFirstname() . ' ' . $this->magentoCustomer->getLastname())
-            ]);
+            $this->create();
         }
 
         $this->customerAPI = $this->customerAPI->update(['card' => $cardToken]);
@@ -163,7 +163,6 @@ class Customer
     public function getLatestCard()
     {
         $cards = $this->cards(['order' => 'reverse_chronological']);
-
         return $cards['total'] > 0 ? $cards['data'][0] : null;
     }
 
@@ -174,7 +173,15 @@ class Customer
     protected function initializeObject()
     {
         if ($this->getId()) {
-            $this->customerAPI = $this->customerAPI->find($this->getId());
+            $customerAPI = $this->customerAPI->find($this->getId());
+
+            if ($customerAPI instanceof \Omise\Payment\Model\Api\Error) {
+                // instance of Error if merchants Omise account and key has been changed
+                $this->create();
+                $customerAPI = $this->customerAPI->find($this->getId());
+            }
+
+            $this->customerAPI = $customerAPI;
         }
     }
 }


### PR DESCRIPTION
This PR adds fix.

An error occurred when a user changed Omise account.

#### 1. Objective

An error occurred because Magento was using on checkout customer ID that was created using old account's data (Private Key).
When Merchant's Private Key has been changed and used from different Omise Account, then customer id did not match new merchant's data.
Customer Object was an instance of the error. All operations on this object were throwing exceptions.

#### 2. Description of change

This PR adds a mechanism that checks if an instance of the `customer API object` is Error, if yes, then it refreshes omise customer data. This PR assumes that 

*Note:*
In case of changing omise account, all saved customer's credit card information becomes unavailable.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.5.
- **Omise plugin version**: Omise-Magento 2.8.
- **PHP version**: 7.0.16.

**✏️ Details:**

1. Create a Magento customer's account/profile or use an existing one.
2. Make payment (make sure you DO NOT check the box to save credit card)
3. Payment should be successful.

4. Make payment (make sure you check the box to save credit card)
5. Payment should be successful, the card's data should be stored.

6. Make payment with saved credit card
7. Payment should be successful, card should be still stored.

**Change Omise Keys to different Omise Account.**

8. Login to Magento account used in Point 1.
9. Make payment (make sure you DO NOT check the box to save credit card)
10. Payment should be successful.

11. Make payment (make sure you check the box to save credit card)
12. Payment should be successful, the card's data should be stored.

13. Make payment with saved credit card
14. Payment should be successful, card should be still stored.


#### 4. Impact of the change

This PR change Customer ID generated using different omise account.
Stored credit cards from all customers (saved using previous omise account) will be unavailable in case of changing omise account.
These cards are not deleted, they will be available again if previous omise account keys are again used.

#### 5. Priority of change

Immediate.

#### 6. Additional Notes

N/A