### PR TITLE
Handle exception when getting capabilities with invalid Omise Keys

### DIFF
--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -8,7 +8,7 @@ class Capabilities extends BaseObject
 {
     private $capabilities;
 
-    public function __construct(\PSR\Log\LoggerInterface $log)
+    public function __construct()
     {
         try {
             $this->capabilities = OmiseCapabilities::retrieve();

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -8,9 +8,13 @@ class Capabilities extends BaseObject
 {
     private $capabilities;
 
-    public function __construct()
+    public function __construct(\PSR\Log\LoggerInterface $log)
     {
-        $this->capabilities = OmiseCapabilities::retrieve();
+        try {
+            $this->capabilities = OmiseCapabilities::retrieve();
+        } catch (\Exception $e) {
+            // do nothing
+        }
     }
 
     /**
@@ -20,9 +24,10 @@ class Capabilities extends BaseObject
      */
     public function getInstallmentBackends()
     {
-        return $this->capabilities->getBackends(
+        return $this->capabilities ? $this->capabilities->getBackends(
             $this->capabilities->makeBackendFilterType('installment')
-        );    
+        )
+        : null;
     }
 
     /**
@@ -31,6 +36,6 @@ class Capabilities extends BaseObject
      * @return bool
      */
     public function isZeroInterest() {
-        return $this->capabilities['zero_interest_installments'];
+        return $this->capabilities ? $this->capabilities['zero_interest_installments'] : false;
     }
 }


### PR DESCRIPTION
#### 1. Objective

This fixes unhandled exception when omise keys are wrong or not set in the admin panel.

**Related information**:
Related issue(s): #189 

#### 2. Description of change

Added `try/catch` when getting capabilities.
Return particular capabilities only if the capabilities API object is not null. 

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

Remove omise keys, make sure application does not crash when going to the checkout page.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A