### PR TITLE
Adds support for new currencies and tidies up some currency related code

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Form/Cc.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Cc.php
@@ -45,10 +45,7 @@ class Omise_Gateway_Block_Form_Cc extends Mage_Payment_Block_Form
      */
     protected function _isStoreCurrencySupported()
     {
-        return in_array(
-            Mage::app()->getStore()->getBaseCurrencyCode(),
-            array('JPY', 'THB', 'SGD', 'USD', 'EUR', 'GBP')
-        );
+        return Mage::helper('omise_gateway')->isCurrencySupported(Mage::app()->getStore()->getBaseCurrencyCode());
     }
 
     /**

--- a/src/app/code/community/Omise/Gateway/Helper/Data.php
+++ b/src/app/code/community/Omise/Gateway/Helper/Data.php
@@ -1,30 +1,107 @@
 <?php
 class Omise_Gateway_Helper_Data extends Mage_Core_Helper_Abstract
 {
-    public function formatPrice($currency, $amount)
+
+    private static
+        $currencyDecimals = [
+            "BIF" => 0,
+            "CLP" => 0,
+            "DJF" => 0,
+            "GNF" => 0,
+            "ISK" => 0,
+            "JPY" => 0,
+            "KMF" => 0,
+            "KRW" => 0,
+            "PYG" => 0,
+            "RWF" => 0,
+            "UGX" => 0,
+            "UYI" => 0,
+            "VND" => 0,
+            "VUV" => 0,
+            "XAF" => 0,
+            "XOF" => 0,
+            "XPF" => 0,
+            "BHD" => 3,
+            "IQD" => 3,
+            "JOD" => 3,
+            "KWD" => 3,
+            "LYD" => 3,
+            "OMR" => 3,
+            "TND" => 3,
+        ],
+        $defaultCurrencyDecimals = 2,
+        $supportedCurrencies = [
+            'AUD',
+            'CAD',
+            'CHF',
+            'CNY',
+            'DKK',
+            'EUR',
+            'GBP',
+            'HKD',
+            'JPY',
+            'MYR',
+            'THB',
+            'SGD',
+            'USD'
+        ]
+    ;
+
+
+    /**
+     * Return number of subunits the passed currency has
+     *
+     * @param string $currency
+     * @return integer
+     */
+    public static function subUnitsFor($curr) {
+        $c = strtoupper($curr);
+        $decimals = isset(self::$currencyDecimals[$c]) ? self::$currencyDecimals[$c] : self::$defaultCurrencyDecimals;
+        return pow(10, $decimals);
+    }        
+
+    /**
+     *
+     * @param string $currency
+     * @param numeric $amount
+     * @return string
+     */
+    public function amountToSubunits($currency, $amount)
     {
+        return $amount * self::subUnitsFor($currency);
+    }
 
-        switch (strtoupper($currency)) {
-            case 'THB':
-                $amount = "฿" . number_format(($amount / 100), 2);
-                if (preg_match('/\.00$/', $amount)) {
-                    $amount = substr($amount, 0, -3);
-                }
-                break;
+    /**
+     *
+     * @param string $currency
+     * @param numeric $amount
+     * @return string
+     */
+    public function subunitsToAmount($currency, $subunits)
+    {
+        return $subunits / self::subUnitsFor($currency);
+    }
 
-            case 'SGD':
-                $amount = "S$" . number_format(($amount / 100), 2);
-                if (preg_match('/\.00$/', $amount)) {
-                    $amount = substr($amount, 0, -3);
-                }
-                break;
 
-            case 'JPY':
-                $amount = number_format($amount) . "円";
-                break;
-        }
+    /**
+     * Check whether the current currency is supported by the Omise API.
+     * (This could/should probably come from Capbilities API in the future)
+     *
+     * Now, Omise API has no interface to check the supported currencies.
+     * So, the supported currencies have been fixed in this function.
+     *
+     * @param string $currency
+     * @return bool
+     */
+    public function isCurrencySupported($currency)
+    {
+        return in_array(strtoupper($currency), self::$supportedCurrencies);
+    }
 
-        return $amount;
+
+    public function formatPrice($currency, $subunitAmount)
+    {
+        return Mage::app()->getLocale()->currency(strtoupper($currency))->toCurrency($this->subunitsToAmount($currency, $subunitAmount));
     }
 
     public function internetBankingName($code)

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -6,19 +6,6 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     protected $_omise;
 
-    // /**
-    //  * @var array
-    //  */
-    // private $_currency_subunits = array(
-    //     ////// move to subunits function in omise_gateway helper
-    //     'JPY' => 1,
-    //     'THB' => 100,
-    //     'SGD' => 100,
-    //     'USD' => 100,
-    //     'EUR' => 100,
-    //     'GBP' => 100
-    // );
-
     /**
      * Load necessary file and setup Omise keys
      *
@@ -38,29 +25,16 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
     protected function _isCurrencySupport($currency)
     {
         return Mage::helper('omise_gateway')->isCurrencySupported($currency);
-
-        // if (isset($this->_currency_subunits[strtoupper($currency)])) {
-        //     return true;
-        // }
-
-        // return false;
     }
 
     /**
-     * @param  numeric  $amount
+     * @param  numeric $amount
      * @param  string $currency
      *
      * @return int
      */
     public function getAmountInSubunits($amount, $currency)
     {
-        // ////// move to omise_gateway helper
-        // if ($this->_isCurrencySupport($currency)) {
-        //     return $this->_currency_subunits[$currency] * $amount;
-        // }
-
-        // return $amount;
-
         return Mage::helper('omise_gateway')->amountToSubunits($currency, $amount);
     }
 

--- a/src/app/code/community/Omise/Gateway/Model/Payment.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment.php
@@ -6,17 +6,18 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     protected $_omise;
 
-    /**
-     * @var array
-     */
-    private $_currency_subunits = array(
-        'JPY' => 1,
-        'THB' => 100,
-        'SGD' => 100,
-        'USD' => 100,
-        'EUR' => 100,
-        'GBP' => 100
-    );
+    // /**
+    //  * @var array
+    //  */
+    // private $_currency_subunits = array(
+    //     ////// move to subunits function in omise_gateway helper
+    //     'JPY' => 1,
+    //     'THB' => 100,
+    //     'SGD' => 100,
+    //     'USD' => 100,
+    //     'EUR' => 100,
+    //     'GBP' => 100
+    // );
 
     /**
      * Load necessary file and setup Omise keys
@@ -36,26 +37,31 @@ abstract class Omise_Gateway_Model_Payment extends Mage_Payment_Model_Method_Abs
      */
     protected function _isCurrencySupport($currency)
     {
-        if (isset($this->_currency_subunits[strtoupper($currency)])) {
-            return true;
-        }
+        return Mage::helper('omise_gateway')->isCurrencySupported($currency);
 
-        return false;
+        // if (isset($this->_currency_subunits[strtoupper($currency)])) {
+        //     return true;
+        // }
+
+        // return false;
     }
 
     /**
-     * @param  int    $amount
+     * @param  numeric  $amount
      * @param  string $currency
      *
      * @return int
      */
     public function getAmountInSubunits($amount, $currency)
     {
-        if ($this->_isCurrencySupport($currency)) {
-            return $this->_currency_subunits[$currency] * $amount;
-        }
+        // ////// move to omise_gateway helper
+        // if ($this->_isCurrencySupport($currency)) {
+        //     return $this->_currency_subunits[$currency] * $amount;
+        // }
 
-        return $amount;
+        // return $amount;
+
+        return Mage::helper('omise_gateway')->amountToSubunits($currency, $amount);
     }
 
     /**


### PR DESCRIPTION
#### 1. Objective

Adds support for new currencies recently added on the backend:

```
TH:

Australian Dollar (AUD)
Swiss Franc (CHF)
Chinese Yuan (CNY)
Danish Krone (DKK)
Euro (EUR)
British Pound (GBP)
Hongkong Dollar (HKD)
Japanese Yen (JPY)
Singapore Dollar (SGD)
US Dollar (USD)

SG:

Australian Dollar (AUD)
Canadian Dollar (CAD)
Swiss Franc (CHF)
China Yuan (CNY)
Euro (EUR)
British Pound (GBP)
Hongkong Dollar (HKD)
Japanese Yen (JPY)
Malaysian Ringgit (MYR)
Thai Baht (THB)
US Dollar (USD)
```

#### 2. Description of change

Reworked code relating to currencies + fixed some code that was unnecessarily formatting prices so that it uses Magento's built in formatting functions instead

#### 3. Quality assurance

Tested on Magento 1.9 - made sure all payments in supported currencies working and that amount formatting on the 'Omise dashboard' admin page is working correctly

#### 4. Impact of the change

New currencies can now be used

#### 5. Priority of change

Normal

#### 6. Additional Notes

**🎶**