### PR TITLE
Hide installment companies using Admin Panel

### DIFF
--- a/Model/Config/Installment.php
+++ b/Model/Config/Installment.php
@@ -11,8 +11,8 @@ class Installment extends Config
     const CODE = 'omise_offsite_installment';
 
     const KBANK       = 'omise_offsite_installment_kbank';
-    const KRUNGTHAI   = 'omise_offsite_installment_krungthai';
-    const FIRSTCHOICE = 'omise_offsite_installment_fc';
+    const KRUNGTHAI   = 'omise_offsite_installment_ktc';
+    const FIRSTCHOICE = 'omise_offsite_installment_first_choice';
     const BBL         = 'omise_offsite_installment_bbl';
-    const KRUNGSRI    = 'omise_offsite_installment_krungsri';
+    const KRUNGSRI    = 'omise_offsite_installment_bay';
 }

--- a/Model/Config/Installment.php
+++ b/Model/Config/Installment.php
@@ -9,4 +9,10 @@ class Installment extends Config
      * @var string
      */
     const CODE = 'omise_offsite_installment';
+
+    const KBANK       = 'omise_offsite_installment_kbank';
+    const KRUNGTHAI   = 'omise_offsite_installment_krungthai';
+    const FIRSTCHOICE = 'omise_offsite_installment_fc';
+    const BBL         = 'omise_offsite_installment_bbl';
+    const KRUNGSRI    = 'omise_offsite_installment_krungsri';
 }

--- a/Model/Config/Installment.php
+++ b/Model/Config/Installment.php
@@ -13,25 +13,25 @@ class Installment extends Config
     /**
      * @var string
      */
-    const KBANK = 'omise_offsite_installment_kbank';
+    const KBANK = CODE + '_kbank';
 
     /**
      * @var string
      */
-    const KRUNGTHAI = 'omise_offsite_installment_ktc';
+    const KRUNGTHAI = CODE + '_ktc';
 
     /**
      * @var string
      */
-    const FIRSTCHOICE = 'omise_offsite_installment_first_choice';
+    const FIRSTCHOICE = CODE + '_first_choice';
 
     /**
      * @var string
      */
-    const BBL = 'omise_offsite_installment_bbl';
+    const BBL = CODE + '_bbl';
 
     /**
      * @var string
      */
-    const KRUNGSRI = 'omise_offsite_installment_bay';
+    const KRUNGSRI = CODE + '_bay';
 }

--- a/Model/Config/Installment.php
+++ b/Model/Config/Installment.php
@@ -10,9 +10,28 @@ class Installment extends Config
      */
     const CODE = 'omise_offsite_installment';
 
-    const KBANK       = 'omise_offsite_installment_kbank';
-    const KRUNGTHAI   = 'omise_offsite_installment_ktc';
+    /**
+     * @var string
+     */
+    const KBANK = 'omise_offsite_installment_kbank';
+
+    /**
+     * @var string
+     */
+    const KRUNGTHAI = 'omise_offsite_installment_ktc';
+
+    /**
+     * @var string
+     */
     const FIRSTCHOICE = 'omise_offsite_installment_first_choice';
-    const BBL         = 'omise_offsite_installment_bbl';
-    const KRUNGSRI    = 'omise_offsite_installment_bay';
+
+    /**
+     * @var string
+     */
+    const BBL = 'omise_offsite_installment_bbl';
+
+    /**
+     * @var string
+     */
+    const KRUNGSRI = 'omise_offsite_installment_bay';
 }

--- a/Model/Ui/InstallmentConfigProvider.php
+++ b/Model/Ui/InstallmentConfigProvider.php
@@ -5,6 +5,7 @@ use Magento\Checkout\Model\ConfigProviderInterface;
 use Omise\Payment\Model\Config\Installment as OmiseInstallmentConfig;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Payment\Api\PaymentMethodListInterface;
 
 class InstallmentConfigProvider implements ConfigProviderInterface
 {
@@ -38,7 +39,11 @@ class InstallmentConfigProvider implements ConfigProviderInterface
             if ($method->getCode() === OmiseInstallmentConfig::CODE) {
                 return [
                     'installment_config' => [
-                        OmiseInstallmentConfig::KBANK => $this->scopeConfig->getValue('payment/' . OmiseInstallmentConfig::KBANK . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+                        OmiseInstallmentConfig::KBANK => $this->_scopeConfig->getValue('installment_config/' . OmiseInstallmentConfig::KBANK . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE),
+                        OmiseInstallmentConfig::BBL => $this->_scopeConfig->getValue('installment_config/' . OmiseInstallmentConfig::BBL . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE),
+                        OmiseInstallmentConfig::KRUNGTHAI => $this->_scopeConfig->getValue('installment_config/' . OmiseInstallmentConfig::KRUNGTHAI . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE),
+                        OmiseInstallmentConfig::FIRSTCHOICE => $this->_scopeConfig->getValue('installment_config/' . OmiseInstallmentConfig::FIRSTCHOICE . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE),
+                        OmiseInstallmentConfig::KRUNGSRI => $this->_scopeConfig->getValue('installment_config/' . OmiseInstallmentConfig::KRUNGSRI . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
                     ]
                 ];
             }

--- a/Model/Ui/InstallmentConfigProvider.php
+++ b/Model/Ui/InstallmentConfigProvider.php
@@ -3,6 +3,7 @@ namespace Omise\Payment\Model\Ui;
 
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Omise\Payment\Model\Config\Installment as OmiseInstallmentConfig;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class InstallmentConfigProvider implements ConfigProviderInterface
 {
@@ -10,12 +11,15 @@ class InstallmentConfigProvider implements ConfigProviderInterface
      * @var Magento\Payment\Api\PaymentMethodListInterface;
      */
     private $_paymentLists;
+    private $_scopeConfig;
 
     public function __construct(
-        PaymentMethodListInterface $paymentLists
+        PaymentMethodListInterface $paymentLists,
+        ScopeConfigInterface $scopeConfig
     )
     {
-        $this->_paymentLists   = $paymentLists;
+        $this->_paymentLists = $paymentLists;
+        $this->_scopeConfig  = $scopeConfig;
     }
 
     /**
@@ -28,7 +32,10 @@ class InstallmentConfigProvider implements ConfigProviderInterface
         $listOfActivePaymentMethods = $this->_paymentLists->getActiveList($this->_storeManager->getStore()->getId());
         foreach ($listOfActivePaymentMethods as $method) {
             if ($method->getCode() === OmiseInstallmentConfig::CODE) {
-                return [ 
+                return [
+                    'installment_config' => [
+                        OmiseInstallmentConfig::KBANK => $this->scopeConfig->getValue('payment/' . OmiseInstallmentConfig::KBANK . '/active', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+                    ]
                 ];
             }
         }

--- a/Model/Ui/InstallmentConfigProvider.php
+++ b/Model/Ui/InstallmentConfigProvider.php
@@ -1,0 +1,37 @@
+<?php
+namespace Omise\Payment\Model\Ui;
+
+use Magento\Checkout\Model\ConfigProviderInterface;
+use Omise\Payment\Model\Config\Installment as OmiseInstallmentConfig;
+
+class InstallmentConfigProvider implements ConfigProviderInterface
+{
+    /**
+     * @var Magento\Payment\Api\PaymentMethodListInterface;
+     */
+    private $_paymentLists;
+
+    public function __construct(
+        PaymentMethodListInterface $paymentLists
+    )
+    {
+        $this->_paymentLists   = $paymentLists;
+    }
+
+    /**
+     * Retrieve assoc array of checkout configuration
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        $listOfActivePaymentMethods = $this->_paymentLists->getActiveList($this->_storeManager->getStore()->getId());
+        foreach ($listOfActivePaymentMethods as $method) {
+            if ($method->getCode() === OmiseInstallmentConfig::CODE) {
+                return [ 
+                ];
+            }
+        }
+        return [];
+    }
+}

--- a/Model/Ui/InstallmentConfigProvider.php
+++ b/Model/Ui/InstallmentConfigProvider.php
@@ -10,10 +10,18 @@ use Magento\Payment\Api\PaymentMethodListInterface;
 class InstallmentConfigProvider implements ConfigProviderInterface
 {
     /**
-     * @var Magento\Payment\Api\PaymentMethodListInterface;
+     * @var Magento\Payment\Api\PaymentMethodListInterface
      */
     private $_paymentLists;
+
+    /**
+     * @var Magento\Framework\App\Config\ScopeConfigInterface
+     */
     private $_scopeConfig;
+
+    /**
+     * @var Magento\Store\Model\StoreManagerInterface
+     */
     private $_storeManager;
 
     public function __construct(

--- a/Model/Ui/InstallmentConfigProvider.php
+++ b/Model/Ui/InstallmentConfigProvider.php
@@ -4,6 +4,7 @@ namespace Omise\Payment\Model\Ui;
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Omise\Payment\Model\Config\Installment as OmiseInstallmentConfig;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class InstallmentConfigProvider implements ConfigProviderInterface
 {
@@ -12,14 +13,17 @@ class InstallmentConfigProvider implements ConfigProviderInterface
      */
     private $_paymentLists;
     private $_scopeConfig;
+    private $_storeManager;
 
     public function __construct(
         PaymentMethodListInterface $paymentLists,
-        ScopeConfigInterface $scopeConfig
+        ScopeConfigInterface       $scopeConfig,
+        StoreManagerInterface      $storeManager
     )
     {
         $this->_paymentLists = $paymentLists;
         $this->_scopeConfig  = $scopeConfig;
+        $this->_storeManager = $storeManager;
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -131,27 +131,27 @@
                         <field id="active_kasikorn" translate="label comment" type="select" sortOrder="251" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Kasikorn</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/omise_offsite_installment_kbank/active</config_path>
+                            <config_path>installment_config/omise_offsite_installment_kbank/active</config_path>
                         </field>
                         <field id="active_krungthai" translate="label comment" type="select" sortOrder="252" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Krungthai</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/omise_offsite_installment_krungthai/active</config_path>
+                            <config_path>installment_config/omise_offsite_installment_ktc/active</config_path>
                         </field>
                         <field id="active_bbl" translate="label comment" type="select" sortOrder="253" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Bangkok Bank</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/omise_offsite_installment_bbl/active</config_path>
+                            <config_path>installment_config/omise_offsite_installment_bbl/active</config_path>
                         </field>
                         <field id="active_krungsri" translate="label comment" type="select" sortOrder="254" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Krungsri</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/omise_offsite_installment_krungsri/active</config_path>
+                            <config_path>installment_config/omise_offsite_installment_bay/active</config_path>
                         </field>
                         <field id="active_fc" translate="label comment" type="select" sortOrder="255" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable First Choice</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/omise_offsite_installment_fc/active</config_path>
+                            <config_path>installment_config/omise_offsite_installment_first_choice/active</config_path>
                         </field>
                     </group>
                 </group>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+<config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="payment">
             <group id="omise" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -34,10 +35,11 @@
                 </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Webhook endpoint</label>
-                    <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>
+                    <comment>
+                        <![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a><em>(HTTPS only)</em>.]]>
+                    </comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook</frontend_model>
                 </field>
-
                 <group id="omise_cc" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Credit Card Solution</label>
                     <comment>Powerful payment features that allows you to easily and securely accept credit/debit card payments on your store.</comment>
@@ -64,7 +66,6 @@
                         <config_path>payment/omise_cc/3ds</config_path>
                     </field>
                 </group>
-
                 <group id="omise_offsite_internetbanking" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Internet Banking Solution</label>
                     <comment>Enables customers of a bank to easily conduct financial transactions through a bank-operated website (only available in Thailand).</comment>
@@ -124,6 +125,34 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_installment/title</config_path>
                     </field>
+                    <group id="omise_offsite_installment_advanced" translate="label" sortOrder="241" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Advanced</label>
+                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Enable Kasikorn</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/omise_offsite_installment_kbank/active</config_path>
+                        </field>
+                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Enable Krungthai</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/omise_offsite_installment_krungthai/active</config_path>
+                        </field>
+                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Enable Bangkok Bank</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/omise_offsite_installment_bbl/active</config_path>
+                        </field>
+                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Enable Krungsri</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/omise_offsite_installment_krungsri/active</config_path>
+                        </field>
+                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Enable First Choice</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/omise_offsite_installment_fc/active</config_path>
+                        </field>
+                    </group>
                 </group>
                 <group id="omise_offsite_truemoney" translate="label" sortOrder="260" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable True Money Solution</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -125,29 +125,30 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_installment/title</config_path>
                     </field>
-                    <group id="omise_offsite_installment_advanced" translate="label" sortOrder="241" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <group id="omise_offsite_installment_advanced" translate="label" sortOrder="250" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Advanced</label>
-                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <fieldset_css>payments-other-header</fieldset_css>
+                        <field id="active_kasikorn" translate="label comment" type="select" sortOrder="251" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Kasikorn</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/omise_offsite_installment_kbank/active</config_path>
                         </field>
-                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="active_krungthai" translate="label comment" type="select" sortOrder="252" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Krungthai</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/omise_offsite_installment_krungthai/active</config_path>
                         </field>
-                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="active_bbl" translate="label comment" type="select" sortOrder="253" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Bangkok Bank</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/omise_offsite_installment_bbl/active</config_path>
                         </field>
-                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="active_krungsri" translate="label comment" type="select" sortOrder="254" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable Krungsri</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/omise_offsite_installment_krungsri/active</config_path>
                         </field>
-                        <field id="active" translate="label comment" type="select" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <field id="active_fc" translate="label comment" type="select" sortOrder="255" showInDefault="1" showInWebsite="1" showInStore="1">
                             <label>Enable First Choice</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/omise_offsite_installment_fc/active</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <tesco>
@@ -7,49 +8,7 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <send_email>send_email_email_template</send_email>
             </email>
         </tesco>
-        <payment>
-
-            <omise>
-                <sandbox_status>0</sandbox_status>
-                <model>OmiseAdapter</model>
-            </omise>
-
-            <omise_cc>
-                <active>0</active>
-                <title>Credit / Debit Card</title>
-                <model>OmiseCcAdapter</model>
-                <is_gateway>1</is_gateway>
-                <can_initialize>1</can_initialize>
-                <can_use_checkout>1</can_use_checkout>
-                <can_authorize>1</can_authorize>
-                <can_capture>1</can_capture>
-                <payment_action>authorize</payment_action>
-            </omise_cc>
-
-            <omise_offsite_internetbanking>
-                <active>0</active>
-                <title>Internet Banking</title>
-                <model>OmiseInternetbankingAdapter</model>
-                <is_gateway>1</is_gateway>
-                <can_initialize>1</can_initialize>
-                <can_use_checkout>1</can_use_checkout>
-                <can_capture>1</can_capture>
-                <can_review_payment>1</can_review_payment>
-                <payment_action>authorize_capture</payment_action>
-            </omise_offsite_internetbanking>
-            
-            <omise_offsite_alipay>
-                <active>0</active>
-                <title>Alipay</title>
-                <model>OmiseAlipayAdapter</model>
-                <is_gateway>1</is_gateway>
-                <can_initialize>1</can_initialize>
-                <can_use_checkout>1</can_use_checkout>
-                <can_capture>1</can_capture>
-                <can_review_payment>1</can_review_payment>
-                <payment_action>authorize_capture</payment_action>
-            </omise_offsite_alipay>
-
+        <installment_option>
             <omise_offsite_installment_fc>
                 <active>1</active>
             </omise_offsite_installment_fc>
@@ -65,7 +24,45 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
             <omise_offsite_installment_kbank>
                 <active>1</active>
             </omise_offsite_installment_kbank>
-
+        </installment_option>
+        <payment>
+            <omise>
+                <sandbox_status>0</sandbox_status>
+                <model>OmiseAdapter</model>
+            </omise>
+            <omise_cc>
+                <active>0</active>
+                <title>Credit / Debit Card</title>
+                <model>OmiseCcAdapter</model>
+                <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
+                <can_use_checkout>1</can_use_checkout>
+                <can_authorize>1</can_authorize>
+                <can_capture>1</can_capture>
+                <payment_action>authorize</payment_action>
+            </omise_cc>
+            <omise_offsite_internetbanking>
+                <active>0</active>
+                <title>Internet Banking</title>
+                <model>OmiseInternetbankingAdapter</model>
+                <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
+                <can_use_checkout>1</can_use_checkout>
+                <can_capture>1</can_capture>
+                <can_review_payment>1</can_review_payment>
+                <payment_action>authorize_capture</payment_action>
+            </omise_offsite_internetbanking>
+            <omise_offsite_alipay>
+                <active>0</active>
+                <title>Alipay</title>
+                <model>OmiseAlipayAdapter</model>
+                <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
+                <can_use_checkout>1</can_use_checkout>
+                <can_capture>1</can_capture>
+                <can_review_payment>1</can_review_payment>
+                <payment_action>authorize_capture</payment_action>
+            </omise_offsite_alipay>
             <omise_offsite_installment>
                 <active>0</active>
                 <title>Installment</title>
@@ -77,7 +74,6 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_installment>
-
             <omise_offsite_truemoney>
                 <active>0</active>
                 <title>True Money</title>
@@ -89,7 +85,6 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_truemoney>
-
             <omise_offline_tesco>
                 <active>0</active>
                 <title>Tesco Bill Payment</title>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,23 +8,23 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <send_email>send_email_email_template</send_email>
             </email>
         </tesco>
-        <installment_option>
-            <omise_offsite_installment_fc>
+        <installment_config>
+            <omise_offsite_installment_first_choice>
                 <active>1</active>
-            </omise_offsite_installment_fc>
-            <omise_offsite_installment_krungthai>
+            </omise_offsite_installment_first_choice>
+            <omise_offsite_installment_ktc>
                 <active>1</active>
-            </omise_offsite_installment_krungthai>
+            </omise_offsite_installment_ktc>
             <omise_offsite_installment_bbl>
                 <active>1</active>
             </omise_offsite_installment_bbl>
-            <omise_offsite_installment_krungsri>
+            <omise_offsite_installment_bay>
                 <active>1</active>
-            </omise_offsite_installment_krungsri>
+            </omise_offsite_installment_bay>
             <omise_offsite_installment_kbank>
                 <active>1</active>
             </omise_offsite_installment_kbank>
-        </installment_option>
+        </installment_config>
         <payment>
             <omise>
                 <sandbox_status>0</sandbox_status>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,6 +50,22 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_alipay>
 
+            <omise_offsite_installment_fc>
+                <active>1</active>
+            </omise_offsite_installment_fc>
+            <omise_offsite_installment_krungthai>
+                <active>1</active>
+            </omise_offsite_installment_krungthai>
+            <omise_offsite_installment_bbl>
+                <active>1</active>
+            </omise_offsite_installment_bbl>
+            <omise_offsite_installment_krungsri>
+                <active>1</active>
+            </omise_offsite_installment_krungsri>
+            <omise_offsite_installment_kbank>
+                <active>1</active>
+            </omise_offsite_installment_kbank>
+
             <omise_offsite_installment>
                 <active>0</active>
                 <title>Installment</title>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -7,6 +7,7 @@
                 <item name="omise_cc_config_provider" xsi:type="object">Omise\Payment\Model\Ui\CcConfigProvider</item>
                 <item name="omise_plugin_config_provider" xsi:type="object">Omise\Payment\Model\Ui\PluginConfigProvider</item>
                 <item name="omise_capabilities_config_provider" xsi:type="object">Omise\Payment\Model\Ui\CapabilitiesConfigProvider</item>
+                <item name="omise_installment_config_provider" xsi:type="object">Omise\Payment\Model\Ui\InstallmentConfigProvider</item>
             </argument>
         </arguments>
     </type>

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -21,3 +21,4 @@
 "Payment rejected by card issuer.", "รายการถูกปฏิเสธโดยธนาคารผู้ออกบัตร"
 "Card stolen or lost.", "บัตรหายหรือถูกขโมย"
 "Payer did not take action before charge expiration.", "ผู้ซื้อไม่ทำรายการภายในเวลาที่กำหนด"
+"There are no any installment options available", "ไม่มีตัวเลือกในการผ่อนชำระ"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -70,6 +70,29 @@ define(
             },
 
             /**
+             * Format Price
+             * 
+             * @param {string} option Name of option to be verified
+             * @return {boolean}
+             */
+            isInstallmentOptionActive: function (option) {
+                return parseInt(window.checkoutConfig.installment_config[option]);
+            },
+
+            /**
+             * Format Price
+             * 
+             * @param {string} option Name of option to be verified
+             * @return {boolean}
+             */
+            isAnyInstallmentOptionActive: function () {
+                return parseInt(window.checkoutConfig.installment_config['omise_offsite_installment_kbank'])
+                    || parseInt(window.checkoutConfig.installment_config['omise_offsite_installment_ktc'])
+                    || parseInt(window.checkoutConfig.installment_config['omise_offsite_installment_first_choice'])
+                    || parseInt(window.checkoutConfig.installment_config['omise_offsite_installment_bbl'])
+                    || parseInt(window.checkoutConfig.installment_config['omise_offsite_installment_bay']);
+            },
+            /**
              * Get formatted message about installment value limitation
              *
              * NOTE: this value should be taken directly from capability object when it is fully implemented.

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -196,7 +196,7 @@
                     </li>
                     <!-- BAY -->
                     <li class="items"  data-bind="
-                        visible: isInstallmentOptionActive(getCode() + '_bbl')
+                        visible: isInstallmentOptionActive(getCode() + '_bay')
                     ">
                         <input type="radio" name="offsite" value="installment_bay" data-bind="
                             attr: {

--- a/view/frontend/web/template/payment/offsite-installment-form.html
+++ b/view/frontend/web/template/payment/offsite-installment-form.html
@@ -7,7 +7,7 @@
                checked: isChecked,
                click: selectPaymentMethod,
                visible: isRadioButtonVisible(),
-               enable: isActive() && !orderValueTooLow()" />
+               enable: isActive() && !orderValueTooLow() && isAnyInstallmentOptionActive()" />
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
@@ -25,7 +25,14 @@
                 </div>
             </div>
         </div>
-        <div data-bind="visible: isActive() && orderValueTooLow()" class="page messages">
+        <div data-bind="visible: !isAnyInstallmentOptionActive()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <div data-bind="i18n: 'There are no any installment options available'"></div>
+                </div>
+            </div>
+        </div>
+        <div data-bind="visible: isAnyInstallmentOptionActive() && isActive() && orderValueTooLow()" class="page messages">
             <div role="alert" class="messages">
                 <div class="message-warning warning message">
                     <div data-bind="text: getMinimumOrderText()"></div>
@@ -52,7 +59,9 @@
             <fieldset data-bind="attr: {class: 'fieldset payment items ' + getCode(), id: 'payment_form_' + getCode()}">
                 <ul class="form-list">
                     <!-- KTC -->
-                    <li class="items">
+                    <li class="items" data-bind="
+                        visible: isInstallmentOptionActive(getCode() + '_ktc')
+                    ">
                         <input type="radio" name="offsite" value="installment_ktc" data-bind="
                             attr: {
                                 id: getCode() + '_ktc'
@@ -84,7 +93,9 @@
                     </li>
 
                     <!-- First Choice -->
-                    <li class="items">
+                    <li class="items" data-bind="
+                        visible: isInstallmentOptionActive(getCode() + '_first_choice')
+                    ">
                         <input type="radio" name="offsite" value="installment_first_choice" data-bind="
                             attr: {
                                 id: getCode() + '_first_choice'
@@ -116,7 +127,9 @@
                     </li>
 
                     <!-- KBank -->
-                    <li class="items">
+                    <li class="items" data-bind="
+                        visible: isInstallmentOptionActive(getCode() + '_kbank')
+                    ">
                         <input type="radio" name="offsite" value="installment_kbank" data-bind="
                             attr: {
                                 id: getCode() + '_kbank'
@@ -149,7 +162,9 @@
                     </li>
 
                     <!-- BBL -->
-                    <li class="items">
+                    <li class="items" data-bind="
+                        visible: isInstallmentOptionActive(getCode() + '_bbl')
+                    ">
                         <input type="radio" name="offsite" value="installment_bbl" data-bind="
                             attr: {
                                 id: getCode() + '_bbl'
@@ -179,8 +194,10 @@
                                         visible: omiseOffsite() === 'installment_bbl',
                                         optionsCaption: 'Choose number of montly payments'"></select>
                     </li>
-                     <!-- BAY -->
-                     <li class="items">
+                    <!-- BAY -->
+                    <li class="items"  data-bind="
+                        visible: isInstallmentOptionActive(getCode() + '_bbl')
+                    ">
                         <input type="radio" name="offsite" value="installment_bay" data-bind="
                             attr: {
                                 id: getCode() + '_bay'


### PR DESCRIPTION
#### 1. Objective

This PR enables the possibility of hiding installment companies by the merchant in the admin panel.

#### 2. Description of change

Added new Magento config entries representing each of installment providing company.
Added in admin panel UI list of options to enable/disable Installment option.
Added in JS/HTML on checkout page functionality to hide installment options depends on admin panel settings.

#### 3. Quality assurance

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

To manually test this feature enable/disable installment options in the admin panel.
Check if disabled options disappear from the checkout page. 
Make a successful payment with enabled options.

#### 4. Impact of the change

This PR adds a new section under the Installment Payment Option on the Admin Panel.
The section is named _Advanced_ and is used by a merchant can disable unwanted installment providers.
By default, all companies are enabled.

![image](https://user-images.githubusercontent.com/10651523/64511118-d39f9f80-d30d-11e9-8960-5f12adf51119.png)

If a merchant enables Installment Payment in Admin panel, but turn off all installment companies, _There are no installment options available_ text will be displayed on the checkout page. Also selecting Installment on the checkout page will be disabled.

![image](https://user-images.githubusercontent.com/10651523/64512241-25492980-d310-11e9-8e87-8f737d7323f3.png)


#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A