### PR TITLE
Adding citipoints method for payment

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsitecitipoints.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsitecitipoints.php
@@ -1,0 +1,5 @@
+<?php
+class Omise_Gateway_Block_Form_Offsitecitipoints extends Mage_Payment_Block_Form
+{
+    // Note that we need to have this class (even it's empty) as a reference for html block in checkout page.
+}

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
@@ -1,0 +1,143 @@
+<?php
+
+
+class Omise_Gateway_Model_Payment_Offsitecitipoints extends Omise_Gateway_Model_Payment {
+    /**
+     * @var string
+     */
+    protected $_code = 'omise_offsite_citipoints';
+
+    /**
+     * @var string
+     */
+    protected $_formBlockType = 'omise_gateway/form_offsitecitipoints';
+
+    /**
+     * @var string
+     */
+    protected $_infoBlockType = 'payment/info';
+
+    /**
+     * Payment Method features
+     *
+     * @var bool
+     */
+    protected $_isGateway          = true;
+    protected $_canReviewPayment   = true;
+    protected $_isInitializeNeeded = true;
+
+    /**
+     * Check method for processing with base currency
+     * Note that Citipoints can only be used with Omise Thailand account and 'THB' currency
+     *
+     * @param  string $currencyCode
+     *
+     * @return boolean
+     */
+    public function canUseForCurrency($currencyCode)
+    {
+        return (strtoupper($currencyCode) === 'THB' && strtoupper(Mage::app()->getStore()->getCurrentCurrencyCode()) === 'THB');
+    }
+
+    /**
+     * Instantiate state and set it to state object
+     *
+     * @param string        $payment_action
+     * @param Varien_Object $state_object
+     */
+    public function initialize($payment_action, $state_object)
+    {
+        $payment = $this->getInfoInstance();
+        $order   = $payment->getOrder();
+
+        $invoice = $order->prepareInvoice();
+        $invoice->setIsPaid(false)->register();
+
+        $charge = $this->process($payment, $invoice->getBaseGrandTotal());
+
+        $payment->setCreatedInvoice($invoice)
+            ->setIsTransactionClosed(false)
+            ->setIsTransactionPending(true)
+            ->addTransaction(
+                Mage_Sales_Model_Order_Payment_Transaction::TYPE_ORDER,
+                $invoice,
+                false,
+                Mage::helper('omise_gateway')->__('Processing an amount of %s via Omise Citipoints payment.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
+            );
+
+        $order->addRelatedObject($invoice);
+
+        if ($charge->isAwaitPayment()) {
+            $state_object->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+            $state_object->setStatus($order->getConfig()->getStateDefaultStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT));
+            $state_object->setIsNotified(false);
+
+            return;
+        }
+
+        $this->_suspectToBeFailed($payment);
+    }
+
+    /**
+     * @param  Varien_Object $payment
+     * @param  float         $amount
+     *
+     * @return Omise_Gateway_Model_Api_Charge
+     */
+    public function process(Varien_Object $payment, $amount)
+    {
+        $order = $payment->getOrder();
+
+        return parent::_process(
+            $payment,
+            array(
+                'amount'       => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
+                'currency'     => $order->getBaseCurrencyCode(),
+                'description'  => 'Processing payment with Citipoints. Magento order ID: ' . $order->getIncrementId(),
+                'offsite'      => 'points_citi',
+                'return_uri'   => $this->getCallbackUri(),
+                'metadata'     => array(
+                    'order_id' => $order->getIncrementId()
+                )
+            )
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Payment/Model/Method/Abstract.php
+     */
+    public function assignData($data)
+    {
+        parent::assignData($data);
+
+        $this->getInfoInstance()->setAdditionalInformation('offsite', $data->getData('offsite'));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Sales/Model/Quote/Payment.php
+     */
+    public function getOrderPlaceRedirectUrl()
+    {
+        return Mage::getSingleton('checkout/session')->getOmiseAuthorizeUri();
+    }
+
+    /**
+     * @param  array $params
+     *
+     * @return string
+     */
+    public function getCallbackUri($params = array())
+    {
+        return Mage::getUrl(
+            'omise/callback_validateoffsitecitipoints',
+            array(
+                '_secure' => Mage::app()->getStore()->isCurrentlySecure(),
+                '_query'  => $params
+            )
+        );
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
@@ -28,7 +28,7 @@ class Omise_Gateway_Model_Payment_Offsitecitipoints extends Omise_Gateway_Model_
 
     /**
      * Check method for processing with base currency
-     * Note that Citipoints can only be used with Omise Thailand account and 'THB' currency
+     * Note that Citi Reward Points can only be used with Omise Thailand account and 'THB' currency
      *
      * @param  string $currencyCode
      *
@@ -62,7 +62,7 @@ class Omise_Gateway_Model_Payment_Offsitecitipoints extends Omise_Gateway_Model_
                 Mage_Sales_Model_Order_Payment_Transaction::TYPE_ORDER,
                 $invoice,
                 false,
-                Mage::helper('omise_gateway')->__('Processing an amount of %s via Omise Citipoints payment.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
+                Mage::helper('omise_gateway')->__('Processing an amount of %s via Omise Citi Reward Points payment.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
             );
 
         $order->addRelatedObject($invoice);
@@ -93,7 +93,7 @@ class Omise_Gateway_Model_Payment_Offsitecitipoints extends Omise_Gateway_Model_
             array(
                 'amount'       => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
                 'currency'     => $order->getBaseCurrencyCode(),
-                'description'  => 'Processing payment with Citipoints. Magento order ID: ' . $order->getIncrementId(),
+                'description'  => 'Processing payment with Citi Reward Points. Magento order ID: ' . $order->getIncrementId(),
                 'source[type]' => 'points_citi',
                 'return_uri'   => $this->getCallbackUri(),
                 'metadata'     => array(

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitecitipoints.php
@@ -94,7 +94,7 @@ class Omise_Gateway_Model_Payment_Offsitecitipoints extends Omise_Gateway_Model_
                 'amount'       => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
                 'currency'     => $order->getBaseCurrencyCode(),
                 'description'  => 'Processing payment with Citipoints. Magento order ID: ' . $order->getIncrementId(),
-                'offsite'      => 'points_citi',
+                'source[type]' => 'points_citi',
                 'return_uri'   => $this->getCallbackUri(),
                 'metadata'     => array(
                     'order_id' => $order->getIncrementId()

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitecitipointsController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitecitipointsController.php
@@ -8,7 +8,7 @@ class Omise_Gateway_Callback_ValidateoffsitecitipointsController extends Omise_G
 
         if (! $payment = $order->getPayment()) {
             Mage::getSingleton('core/session')->addError(
-                $this->__('Citipoints validation failed, we cannot retrieve your payment information. Please contact our support team to confirm the payment.')
+                $this->__('Citi Reward Points validation failed, we cannot retrieve your payment information. Please contact our support team to confirm the payment.')
             );
 
             $this->_redirect('checkout/cart');
@@ -29,7 +29,7 @@ class Omise_Gateway_Callback_ValidateoffsitecitipointsController extends Omise_G
             $order->markAsAwaitPayment(
                 $payment->getLastTransId(),
                 Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
-                Mage::helper('omise_gateway')->__('The payment is in progress.<br/>Due to the way Citipoints works, this might take a few seconds or up to an hour. Please click "Accept" or "Deny" to complete the payment manually once the result has been updated (you can check at Omise Dashboard).')
+                Mage::helper('omise_gateway')->__('The payment is in progress.<br/>Due to the way Citi Reward Point works, this might take a few seconds or up to an hour. Please click "Accept" or "Deny" to complete the payment manually once the result has been updated (you can check at Omise Dashboard).')
             );
             Mage::getSingleton('checkout/session')->addNotice(Mage::helper('omise_gateway')->__('Please note - the payment process is still ongoing. Once it is complete, you will receive the order confirmation.'));
             return $this->_redirect('checkout/onepage/success');

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitecitipointsController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitecitipointsController.php
@@ -1,0 +1,59 @@
+<?php
+class Omise_Gateway_Callback_ValidateoffsitecitipointsController extends Omise_Gateway_Controller_Base
+{
+    public function indexAction()
+    {
+        // Callback validation.
+        $order = $this->_getOrder();
+
+        if (! $payment = $order->getPayment()) {
+            Mage::getSingleton('core/session')->addError(
+                $this->__('Citipoints validation failed, we cannot retrieve your payment information. Please contact our support team to confirm the payment.')
+            );
+
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        $charge = Mage::getModel('omise_gateway/api_charge')->find(
+            $payment->getMethodInstance()->getInfoInstance()->getAdditionalInformation('omise_charge_id')
+        );
+
+        if ($charge instanceof Omise_Gateway_Model_Api_Error) {
+            Mage::getSingleton('core/session')->addError($charge->getMessage());
+
+            return $this->_redirect('checkout/cart');
+        }
+
+        if ($charge->isAwaitPayment()) {
+            $order->markAsAwaitPayment(
+                $payment->getLastTransId(),
+                Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW,
+                Mage::helper('omise_gateway')->__('The payment is in progress.<br/>Due to the way Citipoints works, this might take a few seconds or up to an hour. Please click "Accept" or "Deny" to complete the payment manually once the result has been updated (you can check at Omise Dashboard).')
+            );
+            Mage::getSingleton('checkout/session')->addNotice(Mage::helper('omise_gateway')->__('Please note - the payment process is still ongoing. Once it is complete, you will receive the order confirmation.'));
+            return $this->_redirect('checkout/onepage/success');
+        }
+
+        if ($charge->isSuccessful()) {
+            $invoice = $order->getInvoice($payment->getLastTransId());
+            $transId = $payment->getLastTransId();
+
+            // Make sure to avoid marking invoice paid more than once
+            if (!$order->isInvoicePaid($transId)) $order->markAsPaid(
+                $transId,
+                Mage_Sales_Model_Order::STATE_PROCESSING,
+                Mage::helper('omise_gateway')->__('An amount of %s has been paid online.', $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal()))
+            );
+
+            return $this->_redirect('checkout/onepage/success');
+        }
+
+        $order->markAsFailed(
+            $payment->getLastTransId(),
+            $this->__('The payment was invalid, %s (%s)', $charge->failure_message, $charge->failure_code)
+        );
+
+        return $this->_redirect('checkout/cart');
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -184,7 +184,7 @@
                 <active>0</active>
                 <payment_action>order</payment_action>
                 <model>omise_gateway/payment_offsitecitipoints</model>
-                <title>City Pay with Points</title>
+                <title>Citi Pay with Points</title>
             </omise_offsite_citipoints>
 
             <omise_offsite_alipay>

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -180,6 +180,13 @@
                 <title>Internet banking</title>
             </omise_offsite_internet_banking>
 
+            <omise_offsite_citipoints>
+                <active>0</active>
+                <payment_action>order</payment_action>
+                <model>omise_gateway/payment_offsitecitipoints</model>
+                <title>Pay with Citipoints</title>
+            </omise_offsite_citipoints>
+
             <omise_offsite_alipay>
                 <active>0</active>
                 <payment_action>order</payment_action>

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -184,7 +184,7 @@
                 <active>0</active>
                 <payment_action>order</payment_action>
                 <model>omise_gateway/payment_offsitecitipoints</model>
-                <title>Pay with Citipoints</title>
+                <title>City Pay with Points</title>
             </omise_offsite_citipoints>
 
             <omise_offsite_alipay>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -134,8 +134,8 @@
                         </omise_offsite_internet_banking>
 
                         <omise_offsite_citipoints type="group">
-                            <label>Pay With Citipoints</label>
-                            <comment>Accepting payments through citipoints.</comment>
+                            <label>City Pay with Points</label>
+                            <comment>Accepting payments through Citi Reward Points.</comment>
                             <sort_order>709</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -133,6 +133,27 @@
                             </fields>
                         </omise_offsite_internet_banking>
 
+                        <omise_offsite_citipoints type="group">
+                            <label>Citipoints</label>
+                            <comment>Accepting payments through citipoints.</comment>
+                            <sort_order>709</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
+                            <fields>
+                                <active translate="label">
+                                    <label>Enabled</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                                    <sort_order>1</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </active>
+                            </fields>
+                        </omise_offsite_citipoints>
+
                         <omise_offsite_alipay type="group">
                             <label>Alipay</label>
                             <comment>Accepting payments through Alipay - one of China's most popular online payment methods - gives you access to over 450 million registered Chinese consumers (only available in Thailand).</comment>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -134,7 +134,7 @@
                         </omise_offsite_internet_banking>
 
                         <omise_offsite_citipoints type="group">
-                            <label>Citipoints</label>
+                            <label>Pay With Citipoints</label>
                             <comment>Accepting payments through citipoints.</comment>
                             <sort_order>709</sort_order>
                             <show_in_default>1</show_in_default>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -134,7 +134,7 @@
                         </omise_offsite_internet_banking>
 
                         <omise_offsite_citipoints type="group">
-                            <label>City Pay with Points</label>
+                            <label>Citi Pay with Points</label>
                             <comment>Accepting payments through Citi Reward Points.</comment>
                             <sort_order>709</sort_order>
                             <show_in_default>1</show_in_default>


### PR DESCRIPTION
#### 1. Objective

This PR enables Pay with Citi Points Method.

Note: Payment is available only for customers with Thai account.
More info about Citi Points Payment is available here: https://www.omise.co/pay-with-points

#### 2. Description of change
- Added PHP Model , Validator Controller classes.
- Added configuration in backend to enable Payment method called "Pay with Citipoints".
Backend > Omise > Module Setting
<img width="822" alt="Screen Shot 2019-12-13 at 15 29 58" src="https://user-images.githubusercontent.com/5526195/70785682-8ffd7b80-1dbd-11ea-9964-e0a8ac5cc179.png">
Frontend:
<img width="334" alt="Screen Shot 2019-12-13 at 15 37 06" src="https://user-images.githubusercontent.com/5526195/70786294-e9b27580-1dbe-11ea-9fe5-9ed92f32ddb0.png">

#### 3. Quality assurance

**:wrench: Environments:**
- **Platform version**: Magento CE 1.9
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 5.6.

**:pencil2: Details:**
Turn on a Pay with Citipoints in the admin panel, check if payment is available on the checkout page.

Turn off a Pay with Citipoints method on the admin panel, the option should not be listed on the checkout page anymore.

Make an order and successful payment with the Pay with Citipoints method.

Verify if the proper amount and payment method are displayed in Omise Dashboard

#### 4. Impact of the change
The new Payment Method is available for Thai merchants using Magento 2.
#### 5. Priority of change
Normal
#### 6. Additional Notes
None