### PR TITLE
Adding True money payment method

### DIFF
--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
@@ -1,7 +1,6 @@
 <?php
 class Omise_Gateway_Block_Form_Offsitetruemoney extends Mage_Payment_Block_Form
 {
-
     /**
      * Preparing global layout
      * You can redefine this method in child classes for changing layout
@@ -27,8 +26,18 @@ class Omise_Gateway_Block_Form_Offsitetruemoney extends Mage_Payment_Block_Form
             'payment_form_block_to_html_before',
             array('block' => $this)
         );
-
         return parent::_toHtml();
     }
-    
+
+    /**
+     * Returns billing phone number from current quote
+     * @return string
+     */
+    public function getOmiseTruePhoneNumber() {
+        $phoneNumber = Mage::getSingleton('checkout/session')
+            ->getQuote()
+            ->getBillingAddress()
+            ->getTelephone();
+        return (isset($phoneNumber)) ? $phoneNumber : '';
+     }
 }

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
@@ -1,0 +1,34 @@
+<?php
+class Omise_Gateway_Block_Form_Offsitetruemoney extends Mage_Payment_Block_Form
+{
+
+    /**
+     * Preparing global layout
+     * You can redefine this method in child classes for changing layout
+     *
+     * @return Mage_Core_Block_Abstract
+     *
+     * @see    Mage_Core_Block_Abstract
+     */
+    protected function _prepareLayout()
+    {
+        $this->setTemplate('payment/form/omise/omiseoffsitetruemoney.phtml');
+        return $this;
+    }
+
+    /**
+     * Render block HTML
+     *
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        Mage::dispatchEvent(
+            'payment_form_block_to_html_before',
+            array('block' => $this)
+        );
+
+        return parent::_toHtml();
+    }
+    
+}

--- a/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Form/Offsitetruemoney.php
@@ -33,7 +33,8 @@ class Omise_Gateway_Block_Form_Offsitetruemoney extends Mage_Payment_Block_Form
      * Returns billing phone number from current quote
      * @return string
      */
-    public function getOmiseTruePhoneNumber() {
+    public function getOmiseTruePhoneNumber()
+    {
         $phoneNumber = Mage::getSingleton('checkout/session')
             ->getQuote()
             ->getBillingAddress()

--- a/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * True money payment info
+ */
+class Omise_Gateway_Block_Info_Truemoney extends Mage_Payment_Block_Info
+{
+
+    /**
+     * Prepare true money related payment info
+     *
+     * @param Varien_Object|array $transport
+     * @return Varien_Object
+     */
+    protected function _prepareSpecificInformation($transport = null)
+    {
+        if (null !== $this->_paymentSpecificInformation) {
+            return $this->_paymentSpecificInformation;
+        }
+
+        $transport = parent::_prepareSpecificInformation($transport);
+        $info = $this->getInfo()->getAdditionalInformation();
+
+        $data = [ Mage::helper('omise_gateway')->__('Phone number') => $info['phone_number']];
+
+        return $transport->setData(array_merge($data, $transport->getData()));
+    }
+}

--- a/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
@@ -13,8 +13,7 @@ class Omise_Gateway_Block_Info_Truemoney extends Mage_Payment_Block_Info
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if (null !== $this->_paymentSpecificInformation)
-        {
+        if (null !== $this->_paymentSpecificInformation) {
             return $this->_paymentSpecificInformation;
         }
         $transport = parent::_prepareSpecificInformation($transport);

--- a/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
+++ b/src/app/code/community/Omise/Gateway/Block/Info/Truemoney.php
@@ -13,15 +13,13 @@ class Omise_Gateway_Block_Info_Truemoney extends Mage_Payment_Block_Info
      */
     protected function _prepareSpecificInformation($transport = null)
     {
-        if (null !== $this->_paymentSpecificInformation) {
+        if (null !== $this->_paymentSpecificInformation)
+        {
             return $this->_paymentSpecificInformation;
         }
-
         $transport = parent::_prepareSpecificInformation($transport);
         $info = $this->getInfo()->getAdditionalInformation();
-
         $data = [ Mage::helper('omise_gateway')->__('Phone number') => $info['phone_number']];
-
         return $transport->setData(array_merge($data, $transport->getData()));
     }
 }

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Offsitetruemoney.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Offsitetruemoney.php
@@ -1,0 +1,79 @@
+<?php
+class Omise_Gateway_Model_Payment_Offsitetruemoney extends Omise_Gateway_Model_Payment_SimpleOffsite_Payment
+{
+
+    /**
+     * @var string
+     */
+    protected $_code = 'omise_offsite_truemoney';
+
+    /**
+     * @var string
+     */
+    protected $_formBlockType = 'omise_gateway/form_offsitetruemoney';
+
+    /**
+     * @var string
+     */
+    protected $_infoBlockType = 'omise_gateway/info_truemoney';
+
+    /**
+     * @var string
+     */
+    protected $_callbackUrl = 'omise/callback_validateoffsitetruemoney';
+
+    /**
+     * @var array
+     */
+    protected $_currencies = array('THB');
+
+    /**
+     * @var string
+     */
+    protected $_type = 'truemoney';
+
+    /**
+     * Payment Method features
+     *
+     * @var bool
+     */
+    protected $_isGateway          = true;
+    protected $_canReviewPayment   = true;
+    protected $_isInitializeNeeded = true;
+
+    /**
+     * @param Varien_Object $payment
+     * @param float $amount
+     *
+     * @return Omise_Gateway_Model_Api_Charge
+     * @throws Mage_Core_Exception
+     */
+    public function process(Varien_Object $payment, $amount) {
+        $order = $payment->getOrder();
+
+        return parent::_process(
+            $payment,
+            array(
+                'amount'      => $this->getAmountInSubunits($amount, $order->getBaseCurrencyCode()),
+                'currency'    => $order->getBaseCurrencyCode(),
+                'description' => 'Processing payment with '.$this->getPaymentTitle().'. Magento order ID: ' . $order->getIncrementId(),
+                'source'      => array('type' => $this->_type, 'phone_number' => $payment->getAdditionalInformation('phone_number')),
+                'return_uri'  => $this->getCallbackUri(),
+                'metadata'    => array(
+                    'order_id' => $order->getIncrementId()
+                )
+            )
+        );
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see app/code/core/Mage/Payment/Model/Method/Abstract.php
+     */
+    public function assignData($data)
+    {
+        parent::assignData($data);
+        $this->getInfoInstance()->setAdditionalInformation('phone_number', $data->getData('phone_number'));
+    }
+}

--- a/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitetruemoneyController.php
+++ b/src/app/code/community/Omise/Gateway/controllers/Callback/ValidateoffsitetruemoneyController.php
@@ -1,0 +1,13 @@
+<?php
+class Omise_Gateway_Callback_ValidateoffsitetruemoneyController extends Omise_Gateway_Controller_Base
+{
+    const PAYMENT_TITLE = 'True Money';
+    /**
+     * @return Mage_Core_Controller_Varien_Action|void
+     * @throws Mage_Core_Exception
+     */
+    public function indexAction()
+    {
+        return $this->validate();
+    }
+}

--- a/src/app/code/community/Omise/Gateway/etc/config.xml
+++ b/src/app/code/community/Omise/Gateway/etc/config.xml
@@ -203,6 +203,13 @@
                 <default_monthly_minimum_subunits_thb>30000</default_monthly_minimum_subunits_thb>
             </omise_offsite_installment>
 
+            <omise_offsite_truemoney>
+                <active>0</active>
+                <payment_action>order</payment_action>
+                <model>omise_gateway/payment_offsitetruemoney</model>
+                <title>True Money</title>
+            </omise_offsite_truemoney>
+
         </payment>
     </default>
 </config>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -198,7 +198,7 @@
 
                         <omise_offsite_truemoney type="group">
                             <label>True Money</label>
-                            <comment>Enables customers to pay using True Money method.</comment>
+                            <comment>Enables customers to pay using True Money.</comment>
                             <sort_order>730</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -195,6 +195,28 @@
                                 </active>
                             </fields>
                         </omise_offsite_installment>
+
+                        <omise_offsite_truemoney type="group">
+                            <label>True Money</label>
+                            <comment>Enables customers to pay using True Money method</comment>
+                            <sort_order>730</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <frontend_model>omise_gateway/adminhtml_system_config_fieldset_payment</frontend_model>
+                            <fields>
+                                <active translate="label">
+                                    <label>Enabled</label>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                                    <sort_order>1</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>1</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </active>
+                            </fields>
+                        </omise_offsite_truemoney>
+			
                     </fields>
                 </omise_payment>
             </groups>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -216,7 +216,6 @@
                                 </active>
                             </fields>
                         </omise_offsite_truemoney>
-			
                     </fields>
                 </omise_payment>
             </groups>

--- a/src/app/code/community/Omise/Gateway/etc/system.xml
+++ b/src/app/code/community/Omise/Gateway/etc/system.xml
@@ -198,7 +198,7 @@
 
                         <omise_offsite_truemoney type="group">
                             <label>True Money</label>
-                            <comment>Enables customers to pay using True Money method</comment>
+                            <comment>Enables customers to pay using True Money method.</comment>
                             <sort_order>730</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsitetruemoney.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsitetruemoney.phtml
@@ -10,7 +10,7 @@
             <input id="<?php echo $_code; ?>_phone_number" type="text"
                 name="payment[phone_number]"
                 title="<?php echo $this->__('Phone Number'); ?>"
-                value="<?php echo $this->escapeHtml($this->getInfoData('phone_number')); ?>"
+                value="<?php echo $this->escapeHtml($this->getOmiseTruePhoneNumber()); ?>"
                 maxlength="10"
                 class="input-text required-entry validate-length maximum-length-10 minimum-length-10 validate-digits" />
         </div>

--- a/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsitetruemoney.phtml
+++ b/src/app/design/frontend/base/default/template/payment/form/omise/omiseoffsitetruemoney.phtml
@@ -1,0 +1,18 @@
+<?php $_code = $this->getMethodCode(); ?>
+
+<ul id="payment_form_<?php echo $_code; ?>" class="form-list" style="display:none;">
+    <!-- True money phone number form-->
+    <li>
+        <label for="<?php echo $_code; ?>_phone_number" class="required">
+            <em>*</em><?php echo $this->__('Phone Number'); ?>
+        </label>
+        <div class="input-box">
+            <input id="<?php echo $_code; ?>_phone_number" type="text"
+                name="payment[phone_number]"
+                title="<?php echo $this->__('Phone Number'); ?>"
+                value="<?php echo $this->escapeHtml($this->getInfoData('phone_number')); ?>"
+                maxlength="10"
+                class="input-text required-entry validate-length maximum-length-10 minimum-length-10 validate-digits" />
+        </div>
+    </li>
+</ul>


### PR DESCRIPTION
#### 1. Objective

Enable True Money Payment support.
More info about TrueMoney payment available [here](https://www.omise.co/truemoney)

#### 2. Description of change

Added Virtual and PHP classes to support True Money payment.
Added `PHTML` UI rendering files.

UI is very simple, and flow from a user perspective is the same as in the case of other payment method.
Added payment info in checkout page sidebar to show Phone number to be used for transaction.

1. Enable payment method in backend
<img width="782" alt="Screen Shot 2020-01-14 at 12 03 13" src="https://user-images.githubusercontent.com/5526195/72317391-b15acb80-36cb-11ea-8775-0bcf133cee52.png">

2. Payment info section in checkout page
<img width="576" alt="Screen Shot 2020-01-14 at 12 09 32" src="https://user-images.githubusercontent.com/5526195/72317469-00a0fc00-36cc-11ea-91e1-7a548195d2f7.png">

<img width="326" alt="Screen Shot 2020-01-14 at 12 10 11" src="https://user-images.githubusercontent.com/5526195/72317490-0c8cbe00-36cc-11ea-9bf5-8bd9be547980.png">

#### 3. Quality assurance
### 🔧 Environments:
Platform version: Magento CE 1.9
Omise plugin version: Omise-Magento 2.1.
PHP version: 5.6.
### ✏️ Details:
Turn on a True Money in the admin panel, check if payment is available on the checkout page.

Turn off a True Money method on the admin panel, the option should not be listed on the checkout page anymore.

Make an order and successful payment with the True Money method.

Verify if the proper amount and payment method are displayed in Omise Dashboard.

#### 4. Impact of the change

All Payment Method available for Thai merchants should work normally Magento 1

#### 5. Priority of change

Normal

#### 6. Additional Notes

None