### PR TITLE
Cancel the order and restore cart as soon as user cancels offsite payment transaction

### DIFF
--- a/src/app/code/community/Omise/Gateway/Controller/Base.php
+++ b/src/app/code/community/Omise/Gateway/Controller/Base.php
@@ -109,6 +109,7 @@ abstract class Omise_Gateway_Controller_Base extends Mage_Core_Controller_Front_
      * If payment is awaiting to capture then updating order status as 'payment_review'. In case of 3-D secured payment,
      * it will be 'processing'.
      * @param Omise_Gateway_Model_Order $order
+     * @param Omise_Gateway_Model_Api_Charge $charge
      * @return Mage_Core_Controller_Varien_Action
      */
     protected function paymentAwaiting($order, $charge) {


### PR DESCRIPTION
#### 1. Objective

This PR addresses the issue when user cancels the payment. After cancellation payment, user returns back to Magento site on success page and cart is cleared. As order isn't placed, if user choose to create same order with different payment method, then he has to do whole process of checkout again. This PR changes the workflow by cancelling order and restoring cart after payment cancellation.

#### 2. Description of change

- Updated callback class by adding new methods.

Before PR implementation, Payment cancellation lands on success page.
<img width="1232" alt="Screen Shot 2020-01-27 at 15 29 50" src="https://user-images.githubusercontent.com/5526195/73159887-2b527200-411a-11ea-88f7-abafff2ac75c.png">
After PR implementation, Payment cancellations restores cart items and lands on cart page.
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/5526195/73160318-3a85ef80-411b-11ea-9882-84408a338006.png">


#### 3. Quality assurance

**🔧 Environments:**
Platform version: Magento CE 1.9
Omise plugin version: Omise-Magento 2.1.
PHP version: 5.6.

**✏️ Details:**
1. Add product to cart and checkout with any offsite payment method.
2. Payment success should return to Magento checkout success page.
3. Payment failure should return to Magento checkout failure page.
4. After cancellation of payment, order should get cancelled and cart should restored. Cancellation of payment should return to checkout/cart page.

#### 4. Impact of the change

User doesn't need to add items to cart after cancellation of payment.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA