### PR TITLE
Fixing invoice status issue after CC payment.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -77,6 +77,7 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 $charge = $this->processPayment($payment, $invoice->getBaseGrandTotal());
                 if($charge->isSuccessful()) {
                     $invoice->setState(Mage_Sales_Model_Order_Invoice::STATE_PAID)->save();
+                    $state_object->setStatus($order->getConfig()->getStateDefaultStatus(Mage_Sales_Model_Order::STATE_PROCESSING));
                 }
                 $payment->setCreatedInvoice($invoice)
                     ->setIsTransactionClosed(false)

--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -76,8 +76,8 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
                 $invoice = $order->prepareInvoice()->register();
                 $charge = $this->processPayment($payment, $invoice->getBaseGrandTotal());
                 if($charge->isSuccessful()) {
-                    $invoice->setState(Mage_Sales_Model_Order_Invoice::STATE_PAID)->save();
-                    $state_object->setStatus($order->getConfig()->getStateDefaultStatus(Mage_Sales_Model_Order::STATE_PROCESSING));
+                    $invoice->pay();
+                    $state_object->setStatus(Mage_Sales_Model_Order::STATE_PROCESSING);
                 }
                 $payment->setCreatedInvoice($invoice)
                     ->setIsTransactionClosed(false)


### PR DESCRIPTION
#### 1. Objective

This PR addresses the issue in payment using credit card that invoice and order status doesn't get updated to be "paid".

This issue occurs whenever 3DS is enabled in Magento and is not enabled on Omise account. So, it doesn’t redirect to any page to enter OTP.
So whenever we have “auth and capture” after payment order invoice status is still ‘pending’, but it should be ‘paid’ instead.

This PR to fix invoice status to be paid after payment.

#### 2. Description of change

Updated model class for CC payment to update status of invoice to be paid.

#### 3. Quality assurance

Platform version: Magento CE 1.9
Omise plugin version: Omise-Magento 1.21
PHP version: 5.6.

#### 4. Impact of the change

Credit card payment should work normally.

#### 5. Priority of change

High

#### 6. Additional Notes

NA