### PR TITLE
Fixing wrong calculation of installment amount per month showing 

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offline-conveniencestore-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offline-conveniencestore-method.js
@@ -97,7 +97,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return + window.checkoutConfig.totalsData.grand_total;
+                return + window.checkoutConfig.quoteData.grand_total;
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -139,7 +139,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return + window.checkoutConfig.totalsData.grand_total;
+                return + window.checkoutConfig.totalsData.base_grand_total;
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -139,7 +139,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return parseInt(window.checkoutConfig.quoteData.grand_total);
+                return + parseInt(window.checkoutConfig.quoteData.grand_total);
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -139,7 +139,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return + parseInt(window.checkoutConfig.quoteData.grand_total);
+                return + window.checkoutConfig.quoteData.grand_total;
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -139,7 +139,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return + window.checkoutConfig.quoteData.grand_total;
+                return parseInt(window.checkoutConfig.quoteData.grand_total);
             },
 
             /**

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -139,7 +139,7 @@ define(
              * @return {integer}
              */
             getTotal: function () {
-                return + window.checkoutConfig.totalsData.base_grand_total;
+                return + window.checkoutConfig.quoteData.grand_total;
             },
 
             /**


### PR DESCRIPTION
#### 1. Objective

On a checkout page, installment amount to be paid every month is calculated wrong as order tax amount isn't included to calculate installment amount.

For example:
_Expected behaviour:_
**Cart Total:** 4200
**Product price:** 4000
**Tax:** 200
**Installment Fees:** 8%
**Duration in month:** 3 months

**Installment per month** = (4200 * 0.008) = 33.6 

_Actual Behaviour:_
**Cart Total:** 4200
**Product price:** 4000
**Tax:** 200
**Installment Fees:** 8%
**Duration in month:** 3 months

**Installment per month** = (4000 * 0.008) = 32

This PR fixes the issue by including order tax amount as grand total to calculate installment fees. 

#### 2. Description of change

Change in javascript file while is responsible to calculate and display installments per month amount.

<img width="1407" alt="Screen Shot 2020-04-15 at 13 01 20" src="https://user-images.githubusercontent.com/5526195/79303764-e91b1e80-7f19-11ea-9e94-d84aefd55eed.png">

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.1.5.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**


#### 4. Impact of the change

All payment methods should work normally in Magento 2.

#### 5. Priority of change

Normal

#### 6. Additional Notes
NA