### PR TITLE
Fix webhook to support http POST requests.

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -10,6 +10,11 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
 class Webhook extends Field
 {
     /**
+     * URL for omise webhook.
+     */
+    const URI = 'omise/callback/webhook';
+
+    /**
      * @var \Magento\Framework\Url
      */
     protected $urlHelper;
@@ -35,6 +40,6 @@ class Webhook extends Field
      */
     protected function _getElementHtml(AbstractElement $element)
     {
-        return $this->urlHelper->getRouteUrl('omise/callback/webhook', ['_secure' => true]);
+        return $this->urlHelper->getRouteUrl(self::URI, ['_secure' => true]);
     }
 }

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -2,14 +2,11 @@
 
 namespace Omise\Payment\Controller\Callback;
 
-use Magento\Framework\App\CsrfAwareActionInterface;
-use Magento\Framework\App\RequestInterface;
-use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Omise\Payment\Model\Event;
 
-class Webhook extends Action implements CsrfAwareActionInterface
+class Webhook extends Action
 {
     /**
      * @var \Omise\Payment\Model\Event
@@ -25,24 +22,6 @@ class Webhook extends Action implements CsrfAwareActionInterface
         $this->event = $event;
 
         parent::__construct($context);
-    }
-
-    /**
-     * @param RequestInterface $request
-     * @return InvalidRequestException|null
-     */
-    public function createCsrfValidationException(RequestInterface $request): ? InvalidRequestException
-    {
-        return null;
-    }
-    
-    /**
-     * @param RequestInterface $request
-     * @return boolean|null
-     */
-    public function validateForCsrf(RequestInterface $request): ?bool
-    {
-        return true;
     }
 
     /**

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -2,11 +2,14 @@
 
 namespace Omise\Payment\Controller\Callback;
 
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Omise\Payment\Model\Event;
 
-class Webhook extends Action
+class Webhook extends Action implements CsrfAwareActionInterface
 {
     /**
      * @var \Omise\Payment\Model\Event
@@ -22,6 +25,24 @@ class Webhook extends Action
         $this->event = $event;
 
         parent::__construct($context);
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return InvalidRequestException|null
+     */
+    public function createCsrfValidationException(RequestInterface $request): ? InvalidRequestException
+    {
+        return null;
+    }
+    
+    /**
+     * @param RequestInterface $request
+     * @return boolean|null
+     */
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        return true;
     }
 
     /**

--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -1,0 +1,23 @@
+<?php
+namespace Omise\Payment\Plugin;
+
+class CsrfValidatorSkip
+{
+    /**
+     * @param \Magento\Framework\App\Request\CsrfValidator $subject
+     * @param \Closure $proceed
+     * @param \Magento\Framework\App\RequestInterface $request
+     * @param \Magento\Framework\App\ActionInterface $action
+     */
+    public function aroundValidate(
+        $subject,
+        \Closure $proceed,
+        $request,
+        $action
+    ) {
+        if ($request->getModuleName() == 'omise') {
+            return;
+        }
+        $proceed($request, $action);
+    }
+}

--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -3,6 +3,10 @@ namespace Omise\Payment\Plugin;
 
 class CsrfValidatorSkip
 {
+    protected $urlInterface;
+    public function __construct(\Magento\Framework\UrlInterface $urlInterface) {
+        $this->urlInterface = $urlInterface;
+    }
     /**
      * @param \Magento\Framework\App\Request\CsrfValidator $subject
      * @param \Closure $proceed
@@ -15,7 +19,7 @@ class CsrfValidatorSkip
         $request,
         $action
     ) {
-        if ($request->getModuleName() == 'omise') {
+        if ($request->getModuleName() == 'omise' && strpos($this->urlInterface->getCurrentUrl(), 'omise/callback/webhook')) {
             return;
         }
         $proceed($request, $action);

--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -1,5 +1,6 @@
 <?php
 namespace Omise\Payment\Plugin;
+use Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook;
 
 class CsrfValidatorSkip
 {
@@ -19,7 +20,7 @@ class CsrfValidatorSkip
         $request,
         $action
     ) {
-        if ($request->getModuleName() == 'omise' && strpos($this->urlInterface->getCurrentUrl(), 'omise/callback/webhook')) {
+        if ($request->getModuleName() == 'omise' && strpos($this->urlInterface->getCurrentUrl(), Webhook::URI)) {
             return;
         }
         $proceed($request, $action);

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -10,4 +10,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\App\Request\CsrfValidator">
+        <plugin name="csrf_validator_skip" type="Omise\Payment\Plugin\CsrfValidatorSkip" />
+    </type>
 </config>


### PR DESCRIPTION
#### 1. Objective

This PR fixes webhook which doesn't executes for offline payment methods (e.g. Tesco Lotus Payment). This issue happens as webhook controller doesn't support POST requests.

#### 2. Description of change

Created around plugin to intercept execution of `CsrfValidator` whenever POST request on webhook. This allows Post requests on webhook to execute as expected.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.3.3.
- **Omise plugin version**: Omise-Magento 2.1.
- **PHP version**: 7.0.16.

**✏️ Details:**

Complete payment using any offline payment method. Wehbook should update order status normally as soon as payment has been completed.

Steps to reproduce issue:
1. Checkout with Tesco Lotus Payment.
2. Check order status in backend which must be 'Pending Payment'.
3. Login to Omise dashboard account & mark charge as paid.
4. Check order status in Magento backend which is still 'Pending Payment' instead of 'Processing'.



#### 4. Impact of the change

No impact.

#### 5. Priority of change

High.

#### 6. Additional Notes

[Solution](https://magento.stackexchange.com/questions/253414/magento-2-3-upgrade-breaks-http-post-requests-to-custom-module-endpoint)