### PR TITLE
T21018 : Order success page is broken after order checkout.

### DIFF
--- a/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
@@ -30,15 +30,13 @@ class PaynowAdditionalInformation extends \Magento\Framework\View\Element\Templa
     protected function _toHtml()
     {
         $paymentData = $this->_checkoutSession->getLastRealOrder()->getPayment()->getData();
-        if (!isset($paymentData['additional_information']['payment_type']) || $paymentData['additional_information']['payment_type'] !== 'paynow') {
-            return;
+        if (isset($paymentData['additional_information']['payment_type']) || $paymentData['additional_information']['payment_type'] === 'paynow') {
+            $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
+            $this->addData([
+                'paynow_qrcode' => $paymentData['additional_information']['qr_code_encoded'],
+                'order_amount' => number_format($paymentData['amount_ordered'], 2) .' '.$orderCurrency
+            ]);
         }
-        $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
-
-        $this->addData([
-            'paynow_qrcode' => $paymentData['additional_information']['qr_code_encoded'],
-            'order_amount' => number_format($paymentData['amount_ordered'], 2) .' '.$orderCurrency
-        ]);
         
         return parent::_toHtml();
     }

--- a/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
@@ -30,7 +30,7 @@ class PaynowAdditionalInformation extends \Magento\Framework\View\Element\Templa
     protected function _toHtml()
     {
         $paymentData = $this->_checkoutSession->getLastRealOrder()->getPayment()->getData();
-        if (isset($paymentData['additional_information']['payment_type']) || $paymentData['additional_information']['payment_type'] === 'paynow') {
+        if (isset($paymentData['additional_information']['payment_type']) && $paymentData['additional_information']['payment_type'] === 'paynow') {
             $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
             $this->addData([
                 'paynow_qrcode' => $paymentData['additional_information']['qr_code_encoded'],

--- a/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
@@ -31,7 +31,7 @@ class PaynowAdditionalInformation extends \Magento\Framework\View\Element\Templa
     {
         $paymentData = $this->_checkoutSession->getLastRealOrder()->getPayment()->getData();
         if (!isset($paymentData['additional_information']['payment_type']) || $paymentData['additional_information']['payment_type'] !== 'paynow') {
-            //return;
+            return;
         }
         $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
 


### PR DESCRIPTION
#### 1. Objective

This PR fixes issue which breaks order success page after checkout is completed using payment methods other than _Paynow QR payment_. PHP error is displayed on the page as below

![image](https://user-images.githubusercontent.com/5526195/81256994-52470b00-905c-11ea-9d6e-6cd5beb6c22a.png)

#### 2. Description of change
If customer checkout using Paynow method, then $paymentData['additional_information']['qr_code_encoded'] variable is set with expected data. For all other payment methods, this variable isn't set and gives error as undefined variable. 

This PR fixes above issue by preventing execution of the code if selected payment method isn't Paynow QR payment.


#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.3.3.
- **Omise plugin version**: Omise-Magento 2.10
- **PHP version**: 7.2.16.

**✏️ Details:**
Steps to reproduce issue:
1. Choose  any payment method at checkout page except 'Paynow QR payment'.
2. Place order
3. After placing the order success page is broken.

#### 4. Impact of the change

All payment methods should work normally in Magento 2. 

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA