### PR TITLE
Fixing order success page content.

### DIFF
--- a/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/PaynowAdditionalInformation.php
@@ -36,8 +36,7 @@ class PaynowAdditionalInformation extends \Magento\Framework\View\Element\Templa
                 'paynow_qrcode' => $paymentData['additional_information']['qr_code_encoded'],
                 'order_amount' => number_format($paymentData['amount_ordered'], 2) .' '.$orderCurrency
             ]);
+            return parent::_toHtml();
         }
-        
-        return parent::_toHtml();
     }
 }


### PR DESCRIPTION
#### 1. Objective

This PR fixes issue that shows Paynow QR Payment content on order success page for all other payment methods.

Following screen showing order success with installment payment:
![image](https://user-images.githubusercontent.com/5526195/81375264-5f7efb00-912b-11ea-992a-898d28c54bcf.png) 

#### 2. Description of change

Updated Block class - Returning `parent::_toHtml();` only if selected payment method is Paynow.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.3.3.
- **Omise plugin version**: Omise-Magento 2.10
- **PHP version**: 7.2.16.

**✏️ Details:**
Steps to reproduce issue:
1. Choose  any payment method at checkout page except 'Paynow QR payment'.
2. Place order
3. After placing the order success page shows QR code content on order success page.

#### 4. Impact of the change

All payment methods should work normally in Magento 2. 

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA