### PR TITLE
Enable partial refunds for Credit card payments.

### DIFF
--- a/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
+++ b/src/app/code/community/Omise/Gateway/Model/Payment/Creditcard.php
@@ -27,11 +27,12 @@ class Omise_Gateway_Model_Payment_Creditcard extends Omise_Gateway_Model_Payment
      *
      * @var bool
      */
-    protected $_isGateway        = true;
-    protected $_canAuthorize     = true;
-    protected $_canCapture       = true;
-    protected $_canRefund        = true;
-    protected $_canReviewPayment = true;
+    protected $_isGateway               = true;
+    protected $_canAuthorize            = true;
+    protected $_canCapture              = true;
+    protected $_canRefund               = true;
+    protected $_canRefundInvoicePartial = true;
+    protected $_canReviewPayment        = true;
 
     /**
      * flag if we need to run payment initialize while order place


### PR DESCRIPTION
#### 1. Objective

This PR enables user to refund some QTY of the order. This can be done by creating credit memo and selected required QTY to be refund.

<img width="1408" alt="Screen Shot 2020-05-25 at 14 17 34" src="https://user-images.githubusercontent.com/5526195/82788410-9c205580-9e92-11ea-83b9-d6eb8912577f.png">


#### 2. Description of change

- Updated Model class for credit card payment.

#### 3. Quality assurance

### 🔧 Environments:
Platform version: Magento CE 1.9
Omise plugin version: Omise-Magento 1.21
PHP version: 5.6.

### ✏️ Details:
- Place a order of more than one items QTY each using Credit Card payment method
- Go to Backend -> Orders -> Open recently placed order -> Invoice -> click "Credit memo"
- Select QTY. to be refund.
- click "Update" Qty Button
- Click refund.

Expected result:
- User should be able to create credit memo for few items by selecting QTY.

Actual result:
- User is unable to create credit memo for few items of order. In order to create credit memo, it has to create for whole order.
#### 4. Impact of the change

NA
#### 5. Priority of change

Normal

#### 6. Additional Notes
https://phabricator.omise.co/T21336
