### PR TITLE
Adding billing address information to card while creating token

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -263,16 +263,14 @@ define(
                 var selectedBillingAddress = quote.billingAddress();
                 var address = {
                     state          : selectedBillingAddress.region,
-                    postal_code: selectedBillingAddress.postcode,
-                    phone_number: selectedBillingAddress.telephone,
-                    country: selectedBillingAddress.countryId,
-                    city: selectedBillingAddress.city
+                    postal_code    : selectedBillingAddress.postcode,
+                    phone_number   : selectedBillingAddress.telephone,
+                    country        : selectedBillingAddress.countryId,
+                    city           : selectedBillingAddress.city
                 }
-                if(selectedBillingAddress.street.length) {
-                    address.street1 = selectedBillingAddress.street[0]
-                    if(selectedBillingAddress.street[1]) {
-                        address.street2 = selectedBillingAddress.street[1]
-                    }
+                address.street1 = selectedBillingAddress.street[0]
+                if(selectedBillingAddress.street[1]) {
+                    address.street2 = selectedBillingAddress.street[1]
                 }
                 return address
             }

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -154,7 +154,7 @@ define(
                     expiration_year  : this.omiseCardExpirationYear(),
                     security_code    : this.omiseCardSecurityCode()
                 };
-
+                Object.assign(card, this.getSelectedTokenBillingAddress());
                 Omise.setPublicKey(this.getPublicKey());
                 Omise.createToken('card', card, function(statusCode, response) {
                     if (statusCode === 200) {
@@ -257,6 +257,24 @@ define(
                             redirectOnSuccessAction.execute();
                         }
                     });
+            },
+
+            getSelectedTokenBillingAddress: function() {
+                var selectedBillingAddress = quote.billingAddress();
+                var address = {
+                    state          : selectedBillingAddress.region,
+                    postal_code: selectedBillingAddress.postcode,
+                    phone_number: selectedBillingAddress.telephone,
+                    country: selectedBillingAddress.countryId,
+                    city: selectedBillingAddress.city
+                }
+                if(selectedBillingAddress.street.length) {
+                    address.street1 = selectedBillingAddress.street[0]
+                    if(selectedBillingAddress.street[1]) {
+                        address.street2 = selectedBillingAddress.street[1]
+                    }
+                }
+                return address
             }
         });
     }


### PR DESCRIPTION
#### 1. Objective

This PR adds billing address information to charge while creating token. If customer pays using card payment, billing address information should be stored in charge.

Checkout Page:
<img width="1021" alt="Screen Shot 2020-06-11 at 12 07 59" src="https://user-images.githubusercontent.com/5526195/84348932-6b555580-abe0-11ea-856b-5a5011722a2f.png">

Omise Dashboard:
<img width="1147" alt="Screen Shot 2020-06-11 at 12 37 31" src="https://user-images.githubusercontent.com/5526195/84348956-77d9ae00-abe0-11ea-8b09-afb697c715a2.png">


**Related information**:
Related issue(s): # https://phabricator.omise.co/T13092

#### 2. Description of change

- Updated Javascript file to fetch information from quote billing address and store in `card` object.

#### 3. Quality assurance

**🔧 Environments:**
- **Platform version**: Magento CE 2.3.4.
- **Omise plugin version**: Omise-Magento 2.11.
- **PHP version**: 7.2.1.

**✏️ Details:**

- Add product to card
- go to checkout page.
- place order using card payment.
- After order placement check charge created in omise dashboard, it should have appropriate billing addres information

#### 4. Impact of the change
All payment methods should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA