### PR TITLE
Hiding input card details form on selecting payment with saved card.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -119,6 +119,13 @@ define(
             },
 
             /**
+             * @return {bool}
+             */
+            chargeWithSavedCard: function(){
+                $('#payment_form_omise_cc').css({display: 'none'});
+            },
+
+            /**
              * Start performing place order action,
              * by disable a place order button and show full screen loader component.
              */

--- a/view/frontend/web/template/payment/omise-cc-form.html
+++ b/view/frontend/web/template/payment/omise-cc-form.html
@@ -48,7 +48,7 @@
                     <!-- ko foreach: getCustomerCards() -->
                         <li style="list-style: none; margin-bottom: 2rem;">
                             <input name="payment[omise_card]" type="radio"
-                                data-bind="attr: {id: 'Card' + value}, checked: $parent.omiseCard, value: value"/>
+                                data-bind="attr: {id: 'Card' + value}, checked: $parent.omiseCard, event: {change : $parent.chargeWithSavedCard}, value: value"/>
 
                             <label data-bind="attr: {for: 'Card' + value}"><!-- ko  text: label --><!-- /ko --></label>
 


### PR DESCRIPTION
#### 1. Objective

This PR fixes the issue on checkout page related to card payment. When customer choses to pay with saved cards, It still shows input form for card details. This PR hides input form as soon as customer selects saved cards.

**Related information**:
Internal Ticket: https://phabricator.omise.co/T22650

#### 2. Description of change

- Updated omise-cc-form.phtml file to bind event with function
- Added new function to omise-cc-method.js

#### 3. Quality assurance

**🔧 Environments:**
- **Platform version**: Magento CE 2.3.4.
- **Omise plugin version**: Omise-Magento 2.11.
- **PHP version**: 7.2.1.

**✏️ Details:**
Note: Assuming you have saved card already in your account.

Actual behaviour:
- Add product to cart and go to checkout page
- Select Credit/Debit card as payment method
- Click on "Use a new card", This should show input form for credit card
- Click on saved card, input form for credit card still shows up.

Expected behaviour:
- Add product to cart and go to checkout page
- Select Credit/Debit card as payment method
- Click on "Use a new card", This should show input form for credit card
- Click on saved card, this should hide input form for credit card

#### 4. Impact of the change

Credit/Debit card payment should work normally

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA