### PR TITLE
Card payment throws error while checkout for PHP 7.4 version

### DIFF
--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -44,7 +44,10 @@ class PaymentDetailsHandler implements HandlerInterface
 
         $payment->setAdditionalInformation('charge_id', $response['charge']->id);
         $payment->setAdditionalInformation('charge_authorize_uri', $response['charge']->authorize_uri);
-        $payment->setAdditionalInformation('payment_type', $response['charge']->source['type']);
+        $payment->setAdditionalInformation(
+            'payment_type',
+            isset($response['charge']->source['type']) ? $response['charge']->source['type'] : null
+        );
         
         if ($response['charge']->source['type'] === 'bill_payment_tesco_lotus') {
             $barcode = $this->downloadPaymentFile($response['charge']->source['references']['barcode']);

--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -41,20 +41,18 @@ class PaymentDetailsHandler implements HandlerInterface
     {
         $payment = SubjectReader::readPayment($handlingSubject);
         $payment = $payment->getPayment();
+        $paymentType = isset($response['charge']->source['type']) ? $response['charge']->source['type'] : null;
 
         $payment->setAdditionalInformation('charge_id', $response['charge']->id);
         $payment->setAdditionalInformation('charge_authorize_uri', $response['charge']->authorize_uri);
-        $payment->setAdditionalInformation(
-            'payment_type',
-            isset($response['charge']->source['type']) ? $response['charge']->source['type'] : null
-        );
+        $payment->setAdditionalInformation('payment_type', $paymentType);
         
-        if ($response['charge']->source['type'] === 'bill_payment_tesco_lotus') {
+        if ($paymentType === 'bill_payment_tesco_lotus') {
             $barcode = $this->downloadPaymentFile($response['charge']->source['references']['barcode']);
             $payment->setAdditionalInformation('barcode', $barcode);
         }
 
-        if ($this->_helper->isPayableByImageCode($response['charge']->source['type'])) {
+        if ($this->_helper->isPayableByImageCode($paymentType)) {
             $payment->setAdditionalInformation('image_code', $response['charge']->source['scannable_code']['image']['download_uri']);
         }
     }


### PR DESCRIPTION
#### 1. Objective

This PR is to fix error while order checkout with card payments breaks for latest versions of PHP 7.4.

Error Screenshot:
<img width="1440" alt="Screen Shot 2020-09-08 at 08 11 12" src="https://user-images.githubusercontent.com/5526195/92424503-c0d4da80-f1ae-11ea-95b7-46ded64e54b3.png">

**Related information**:
Internal issue(s): https://phabricator.omise.co/T23017

#### 2. Description of change

Updated PaymentDetailsHandler class. Checked if $charge->source['type'] is null then assigned to new variable. 

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.4.
- **Omise plugin version**: Omise-Magento 2.12
- **PHP version**: 7.4.2

**✏️ Details:**
Actual behaviour:
1. Add product to cart and checkout using card payment.
2. Placing order throws and error.

Expected behaviour:
1. Add product to cart and checkout using card payment.
2. Order should get placed without throwing any error.

#### 4. Impact of the change

All payments should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA