### PR TITLE
Adding configuration to restrict payment method from specific countries.

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -63,6 +63,20 @@
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_cc/3ds</config_path>
                     </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="181" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_cc/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="182" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_cc/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
                 </group>
                 <group id="omise_offsite_internetbanking" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Internet Banking Payment</label>
@@ -77,6 +91,20 @@
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_internetbanking/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="151" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offsite_internetbanking/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="152" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offsite_internetbanking/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
                     </field>
                 </group>
                 <group id="omise_offsite_alipay" translate="label" sortOrder="160" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -93,6 +121,18 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_alipay/title</config_path>
                     </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="181" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="182" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
                 </group>
                 <group id="omise_offsite_pointsciti" translate="label" sortOrder="190" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Citi Pay with Points</label>
@@ -107,6 +147,20 @@
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_pointsciti/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="211" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offsite_pointsciti/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="212" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offsite_pointsciti/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
                     </field>
                 </group>
                 <group id="omise_offline_tesco" translate="label" sortOrder="220" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -123,6 +177,20 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offline_tesco/title</config_path>
                     </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="241" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offline_tesco/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="242" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offline_tesco/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
                 </group>
                 <group id="omise_offsite_installment" translate="label" sortOrder="250" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Installment Payment</label>
@@ -137,6 +205,20 @@
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_installment/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="271" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offsite_installment/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="272" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offsite_installment/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
                     </field>
                 </group>
                 <group id="omise_offsite_truemoney" translate="label" sortOrder="280" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -153,6 +235,20 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offsite_truemoney/title</config_path>
                     </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="301" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offsite_truemoney/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="302" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offsite_truemoney/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
                 </group>
                 <group id="omise_offline_conveniencestore" translate="label" sortOrder="310" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Convenience Store Payment</label>
@@ -167,6 +263,20 @@
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offline_conveniencestore/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="331" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offline_conveniencestore/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="332" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offline_conveniencestore/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
                     </field>
                 </group>
                 <group id="omise_offline_paynow" translate="label" sortOrder="340" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -183,6 +293,18 @@
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offline_paynow/title</config_path>
                     </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="361" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="362" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
                 </group>
                 <group id="omise_offline_promptpay" translate="label" sortOrder="370" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable PromptPay QR Payment</label>
@@ -197,6 +319,20 @@
                         <label>Title</label>
                         <comment>This controls the title which the user sees during checkout.</comment>
                         <config_path>payment/omise_offline_promptpay/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="391" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offline_promptpay/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If set to specific, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="392" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offline_promptpay/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
                     </field>
                 </group>
             </group>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,7 +10,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMInternetbankingValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMInternetbankingValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -21,6 +21,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMInternetbankingConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMInternetbankingValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMInternetbankingCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMInternetbankingCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMInternetbankingConfig</argument>
         </arguments>
     </virtualType>
 
@@ -44,7 +58,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMInstallmentValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMInstallmentValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -56,11 +70,27 @@
             </argument>
         </arguments>
     </virtualType>
+
+    <virtualType name="OmiseAPMInstallmentValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMInstallmentCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMInstallmentCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMInstallmentConfig</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="OmiseAPMInstallmentConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
             <argument name="configInterface" xsi:type="object">OmiseAPMInstallmentConfig</argument>
         </arguments>
     </virtualType>
+
     <virtualType name="OmiseAPMInstallmentConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
             <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Installment::CODE</argument>
@@ -75,7 +105,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMTruemoneyValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMTruemoneyValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -88,11 +118,27 @@
             </argument>
         </arguments>
     </virtualType>
+
+    <virtualType name="OmiseAPMTruemoneyValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMTruemoneyCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMTruemoneyCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMTruemoneyConfig</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="OmiseAPMTruemoneyConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
             <argument name="configInterface" xsi:type="object">OmiseAPMTruemoneyConfig</argument>
         </arguments>
     </virtualType>
+
     <virtualType name="OmiseAPMTruemoneyConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
             <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Truemoney::CODE</argument>
@@ -107,7 +153,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMTescoValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMTescoValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -118,6 +164,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMTescoConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+     <virtualType name="OmiseAPMTescoValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMTescoCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMTescoCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMTescoConfig</argument>
         </arguments>
     </virtualType>
     
@@ -141,7 +201,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMAlipayValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMAlipayValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -152,6 +212,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMAlipayConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMAlipayValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMAlipayCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+     <virtualType name="OmiseAPMAlipayCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMAlipayConfig</argument>
         </arguments>
     </virtualType>
     
@@ -175,7 +249,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMPointscitiValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMPointscitiValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -186,6 +260,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMPointscitiConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+    
+    <virtualType name="OmiseAPMPointscitiValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMPointscitiCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMPointscitiCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMPointscitiConfig</argument>
         </arguments>
     </virtualType>
     
@@ -209,7 +297,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMPaynowValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMPaynowValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -220,6 +308,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMPaynowConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMPaynowValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMPaynowCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMPaynowCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMPaynowConfig</argument>
         </arguments>
     </virtualType>
 
@@ -243,7 +345,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMPromptpayValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMPromptpayValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -254,6 +356,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMPromptpayConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMPromptpayValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMPromptpayCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMPromptpayCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMPromptpayConfig</argument>
         </arguments>
     </virtualType>
 
@@ -277,7 +393,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseAPMConveniencestoreValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMConveniencestoreValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>
     </virtualType>
@@ -288,6 +404,20 @@
             <argument name="handlers" xsi:type="array">
                 <item name="default" xsi:type="string">OmiseAPMConveniencestoreConfigValueHandler</item>
             </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMConveniencestoreValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMConveniencestoreCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMConveniencestoreCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMConveniencestoreConfig</argument>
         </arguments>
     </virtualType>
     
@@ -373,7 +503,7 @@
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form\Cc</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
             <argument name="valueHandlerPool" xsi:type="object">OmiseCCValueHandlerPool</argument>
-            <argument name="validatorPool" xsi:type="object">OmiseValidatorPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMCCValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseCreditCardCommandPool</argument>
         </arguments>
     </virtualType>
@@ -453,6 +583,21 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="OmiseAPMCCValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="configInterface" xsi:type="object">OmiseCCConfig</argument>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMCCCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMCCCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseCCConfig</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="OmiseCCConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
         <arguments>
             <argument name="configInterface" xsi:type="object">OmiseCCConfig</argument>
@@ -465,26 +610,19 @@
         </arguments>
     </virtualType>
 
-    <!-- Validator Pool-->
-    <virtualType name="OmiseValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
-        <arguments>
-            <argument name="validators" xsi:type="array">
-            </argument>
-        </arguments>
-    </virtualType>
-
-
     <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualConfigReader" type="Magento\Payment\Gateway\ErrorMapper\VirtualConfigReader">
         <arguments>
             <argument name="fileName" xsi:type="string">omise_error_mapping.xml</argument>
         </arguments>
     </virtualType>
+
     <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualMappingData" type="Magento\Payment\Gateway\ErrorMapper\MappingData">
         <arguments>
             <argument name="reader" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualConfigReader</argument>
             <argument name="cacheId" xsi:type="string">omise_error_mapper</argument>
         </arguments>
     </virtualType>
+    
     <virtualType name="Omise\Payment\Gateway\ErrorMapper\VirtualErrorMessageMapper" type="Magento\Payment\Gateway\ErrorMapper\ErrorMessageMapper">
         <arguments>
             <argument name="messageMapping" xsi:type="object">Omise\Payment\Gateway\ErrorMapper\VirtualMappingData</argument>


### PR DESCRIPTION
#### 1. Objective
Added configuration for all payment methods in the backend which allows to restrict use of payment method depending upon billing address country(s) of a customer.

If admin sets payment method configuration "Allowed Countries" as "All Allowed countries", Customer from any country able to use that payment method.

If admin sets payment method configuration "Allowed Countries" as "Specific Countries", customer from specific countries selected can use those payment method. Customer for which this payment method is restricted, disappears on the checkout page.

<img width="877" alt="image" src="https://user-images.githubusercontent.com/5526195/96573939-ffef6300-12f8-11eb-97aa-0638af96bf6c.png">


**Related information**:
Related issue(s): https://omise.atlassian.net/browse/FES-23

#### 2. Description of change

- Updated di.xml to dependency injection for validation pool to add country validation.
- Updated system.xml to add configuration in backend and use of in-built magneto components such as select country dropdown etc.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.4
- **Omise plugin version**: Omise-Magento 2.13
- **PHP version**: 7.4.1.

**✏️ Details:**
- Default Billing address of customer can be changed in the store frontend.
- Setting payment method configuration "Allowed Countries" as "All Allowed countries": Particular payment method should be available for all customers from any country.
- Setting payment method configuration "Allowed Countries" as "Specific countries": Particular payment method should be available for customer from specific countries selected in configuration. 


#### 4. Impact of the change

All payment methods should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA