### PR TITLE
Fixing duplicate messages in the order comment section, Typo correction Fix.

### DIFF
--- a/Controller/Adminhtml/Ordersync/Index.php
+++ b/Controller/Adminhtml/Ordersync/Index.php
@@ -111,7 +111,7 @@ class Index extends \Magento\Backend\App\Action
         if ($order) {
             try {
                 $this->syncStatus->sync($order);
-                $this->messageManager->addSuccessMessage(__('Order status has been updated by maunal sync.'));
+                $this->messageManager->addSuccessMessage(__('Order status has been updated by manual sync.'));
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());
             } catch (\Exception $e) {

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -76,8 +76,7 @@ class SyncStatus
                 break;
                 case self::STATUS_FAILED:
                     $this->cancelOrderInvoice($order);
-                    $order->addStatusHistoryComment(__('Omise: Payment failed.<br/>%1 (code: %2) (manual sync).', $charge['failure_message'], $charge['failure_code']));
-                    $order->registerCancellation(__('Payment failed. ' . ucfirst($charge['failure_message']) . ', please contact our support if you have any questions.'))
+                    $order->registerCancellation(__('Omise: Payment failed.<br/>%1 (code: %2) (manual sync).', $charge['failure_message'], $charge['failure_code']))
                       ->save();
                     $order->save();
                 break;
@@ -91,10 +90,8 @@ class SyncStatus
                 break;
                 case self::STATUS_EXPIRED:
                     $this->cancelOrderInvoice($order);
-                    $order->registerCancellation(__('Payment trasaction has been expired.'))
+                    $order->registerCancellation(__('Omise: Payment expired. (manual sync).'))
                       ->save();
-                    $order->addStatusHistoryComment(__('Omise: Payment expired. (manual sync).'));
-                    $order->save();
                 break;
                 case self::STATUS_REVERSED:
                     $order->addStatusHistoryComment(__('Omise: Payment reversed. (manual sync).'));


### PR DESCRIPTION
#### 1. Objective

- On manual sync in the backend, Failed order has duplicate order comment. This PR is to fix this.

<img width="1272" alt="Screen Shot 2020-10-28 at 13 40 22" src="https://user-images.githubusercontent.com/5526195/97401446-6c82e700-1923-11eb-96ad-f0c6d4f197d0.png">

- Correct typo mistake for "Manual sync" notification message.

<img width="1086" alt="Screen Shot 2020-10-29 at 09 18 24" src="https://user-images.githubusercontent.com/5526195/97517458-d3f27280-19c7-11eb-9b71-30cf8b5e9e20.png">

#### 2. Description of change

- Updated Model/SyncStatus.php. Removed line which cause duplicate message.

#### 3. Quality assurance
**🔧 Environments:**
i.e.
- **Platform version**: Magento CE 2.4.1.
- **Omise plugin version**: Omise-Magento 2.13.
- **PHP version**: 7.4.1.


#### 4. Impact of the change

None

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA