### PR TITLE
Adding billing address information to card payment charge token.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -34,6 +34,8 @@ define(
 
             code: 'omise_cc',
 
+            billingAddressCountries: ["US", "GB", "CA"],
+
             /**
              * Get a checkout form data
              *
@@ -161,7 +163,10 @@ define(
                     expiration_year  : this.omiseCardExpirationYear(),
                     security_code    : this.omiseCardSecurityCode()
                 };
-
+                var selectedBillingAddress = quote.billingAddress();
+                if(self.billingAddressCountries.indexOf(selectedBillingAddress.countryId) > -1) {
+                    Object.assign(card, this.getSelectedTokenBillingAddress(selectedBillingAddress));
+                }
                 Omise.setPublicKey(this.getPublicKey());
                 Omise.createToken('card', card, function(statusCode, response) {
                     if (statusCode === 200) {
@@ -264,6 +269,21 @@ define(
                             redirectOnSuccessAction.execute();
                         }
                     });
+            },
+
+            getSelectedTokenBillingAddress: function(selectedBillingAddress) {
+                var address = {
+                    state          : selectedBillingAddress.region,
+                    postal_code    : selectedBillingAddress.postcode,
+                    phone_number   : selectedBillingAddress.telephone,
+                    country        : selectedBillingAddress.countryId,
+                    city           : selectedBillingAddress.city
+                }
+                address.street1 = selectedBillingAddress.street[0]
+                if(selectedBillingAddress.street[1]) {
+                    address.street2 = selectedBillingAddress.street[1]
+                }
+                return address
             }
         });
     }


### PR DESCRIPTION
#### 1. Objective

This PR adds billing address information to charge while creating token. If customer pays using card payment, billing address information should be stored in charge.

Billing address information will be added to charge token only from countries like US, GB, CA.

Billing Address:

<img width="451" alt="Screen Shot 2020-11-10 at 15 11 57" src="https://user-images.githubusercontent.com/5526195/98648234-95b26700-2368-11eb-9afe-520710444ad2.png">


Omise Dashboard:

<img width="775" alt="Screen Shot 2020-11-10 at 15 12 52" src="https://user-images.githubusercontent.com/5526195/98648268-a236bf80-2368-11eb-96a7-7513a18d1ef4.png">



**Related information**:
Related issue(s): # https://phabricator.omise.co/T13092 , https://omise.atlassian.net/browse/FES-106

#### 2. Description of change

- Updated Javascript file to fetch information from quote billing address and store in `card` object.

#### 3. Quality assurance

**🔧 Environments:**
- **Platform version**: Magento CE 2.4.1.
- **Omise plugin version**: Omise-Magento 2.13.
- **PHP version**: 7.3.9.

**✏️ Details:**

- Add product to card
- go to checkout page.
- place order using card payment.
- After order placement check charge created in omise dashboard, it should have appropriate billing addres information

#### 4. Impact of the change
All payment methods should work normally.

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA