### PR TITLE
Implementing cron job to update order status of expired omise charge.

### DIFF
--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -214,10 +214,7 @@ class OrderSyncStatus
                 'payment/omise/cron_last_order_id',
                 $this->lastProcessedOrderId
             );
-            $types = array('config','layout','block_html','collections','reflection','db_ddl','eav','config_integration','config_integration_api','full_page','translate','config_webservice');
-            foreach ($types as $type) {
-                $this->cacheTypeList->cleanType($type);
-            }
+            $this->cacheTypeList->cleanType('config');
             foreach ($this->cacheFrontendPool as $cacheFrontend) {
                 $cacheFrontend->getBackend()->clean();
             }

--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -1,0 +1,119 @@
+<?php
+namespace Omise\Payment\Cron;
+
+use Exception;
+
+class OrderSyncStatus 
+{
+    private $order;
+    private $paymentMethodArray = [
+                                "omise_cc",
+                                "omise_offline_conveniencestore",
+                                "omise_offline_paynow",
+                                "omise_offline_promptpay",
+                                "omise_offline_tesco",
+                                "omise_offsite_alipay",
+                                "omise_offsite_truemoney"
+                            ];
+
+    private $orderStatusArray = ['pending_payment', 'processing'];
+
+    private $orderRepository;
+
+    private $refreshCounter = 1;
+
+    protected $timezone;
+
+    private $config;
+
+    /**
+     * @var \Omise\Payment\Model\Api\Charge
+     */
+    protected $apiCharge;
+
+    public function __construct(
+        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
+        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
+        \Omise\Payment\Model\Api\Charge $apiCharge,
+        //\Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezone,
+        \Omise\Payment\Model\Config\Config $config
+    ) {
+        $this->_orderCollectionFactory = $orderCollectionFactory;
+        $this->orderRepository = $orderRepository;
+        $this->apiCharge = $apiCharge;
+        //$this->timezone = $timezone;
+        $this->config = $config;
+    }
+
+    /**
+     * Get the list of orders to be sync the status
+     */
+    public function execute()
+    {
+        $orderIds = $this->getOrderIds();
+        //$date = $this->timezone->formatDateTime();
+        $date = strtotime("now");
+        $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/cron_new.log');
+		$logger = new \Zend\Log\Logger();
+		$logger->addWriter($writer);
+		$logger->info("mayur : ".$date);
+
+        if (!empty($orderIds)) {
+            foreach ($orderIds as $order) {
+                $logger->info("mayur : ".$order['entity_id']);
+                $this->loadOrder($order['entity_id']);
+                $expiryDate = $this->refreshExpiryDate();
+                //$this->updateOrderStatus($expiryDate);;
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Get the list of orders to be Sync.
+     *
+     * @return array List of order IDs
+     */
+    public function getOrderIds()
+    {
+        $orderStatus = implode(',', $this->orderStatusArray);
+        $paymentMethods = implode(',', $this->paymentMethodArray);
+        $orders = $this->_orderCollectionFactory->create();
+        $orders->distinct(true);
+        $orders->addFieldToSelect(['entity_id','increment_id','created_at']);
+        $orders->addFieldToFilter('main_table.status', ['in' => $orderStatus]);
+        $orders->addFieldToFilter('sop.method', ['in' => $paymentMethods]);
+        $orders->join(['sop' => 'sales_order_payment'], 'sop.parent_id=main_table.entity_id', '');
+        $orders->addAttributeToSort('entity_id', 'desc')->setPageSize(2)->setCurPage(1);
+        $orderIds = $orders->getData();
+        return $orderIds;
+    }
+
+    private function loadOrder($orderId)
+    {
+        $this->order = $this->orderRepository->get($orderId);
+    }
+
+    private function refreshExpiryDate()
+    {
+        $payment    = $this->order->getPayment();
+        $chargeId   = $payment->getAdditionalInformation('charge_id');
+        $expiryDate = $payment->getAdditionalInformation('omise_expiry_date');
+        if(!isset($expiryDate) && isset($chargeId) && $this->refreshCounter > 0) {
+            //$charge = $this->apiCharge->find($chargeId);
+            $charge = \OmiseCharge::retrieve($chargeId, $this->config->getPublicKey(), $this->config->getSecretKey());
+            $expiryDate = $charge['expires_at'];
+            $payment->setAdditionalInformation('omise_expiry_date', $expiryDate);
+            $this->refreshCounter--;
+        }
+        return $expiryDate;
+    }
+
+    private function updateOrderStatus($expiryDate)
+    {
+        if($expiryDate){
+           
+        }
+        
+    }
+}

--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -20,6 +20,10 @@ class OrderSyncStatus
 
     private $orderRepository;
 
+    private $recordIndex = 0;
+
+    private $pageCounter = 1;
+
     private $refreshCounter = 1;
 
     protected $timezone;
@@ -50,7 +54,12 @@ class OrderSyncStatus
      */
     public function execute()
     {
-        $orderIds = $this->getOrderIds();
+        $this->sync();
+        return $this;
+    }
+
+    private function sync($) {
+        $orderIds    = $this->getOrderIds();
         //$date = $this->timezone->formatDateTime();
         $date = strtotime("now");
         $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/cron_new.log');
@@ -66,7 +75,6 @@ class OrderSyncStatus
                 //$this->updateOrderStatus($expiryDate);;
             }
         }
-        return $this;
     }
 
     /**

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -39,7 +39,7 @@ class SyncStatus
      * @param Order $order
      * @return void
      */
-    private function cancelOrderInvoice($order)
+    public function cancelOrderInvoice($order)
     {
         if ($order->hasInvoices()) {
             $invoice = $order->getInvoiceCollection()->getLastItem();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -37,6 +37,11 @@
                     <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook</frontend_model>
                 </field>
+                <field id="enable_cron_autoexpirysync" translate="label comment" type="select" sortOrder="71" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Cron Autosync Order Status</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Enabling cron checks orders with expired charge status to mark them as canceled.</comment>
+                </field>
 
                 <group id="omise_cc" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Credit Card Payment</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -40,7 +40,7 @@
                 <field id="enable_cron_autoexpirysync" translate="label comment" type="select" sortOrder="71" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable Cron Autosync Order Status</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>Enabling cron checks orders with expired charge status to mark them as canceled.</comment>
+                    <comment>Enabling cron allows Magento to check orders with expired charge status and mark them as canceled.</comment>
                 </field>
 
                 <group id="omise_cc" translate="label" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="omise">
+        <schedule_generate_every>1</schedule_generate_every>
+        <schedule_ahead_for>4</schedule_ahead_for>
+        <schedule_lifetime>2</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>600</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="omise_order_sync_status" instance="Omise\Payment\Cron\OrderSyncStatus" method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="omise">
         <job name="omise_order_sync_status" instance="Omise\Payment\Cron\OrderSyncStatus" method="execute">
             <schedule>* * * * *</schedule>
         </job>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
     <group id="omise">
         <job name="omise_order_sync_status" instance="Omise\Payment\Cron\OrderSyncStatus" method="execute">
-            <schedule>* * * * *</schedule>
+            <schedule>*/10 * * * *</schedule>
         </job>
     </group>
 </config>


### PR DESCRIPTION
#### 1. Objective

This PR is to create cron job which checks all orders with pending and processing status, if order charge is expired then marking invoice and order status as "Canceled".

Added following configuration to enable/disable cronjob in Magento Admin (Backend): Store > Configuration > Sales > Payment Methods > Omise

<img width="981" alt="image" src="https://user-images.githubusercontent.com/5526195/100418102-babb0f80-30b4-11eb-8105-578e60f249a2.png">


**Related information**: 
Related issue(s): #https://omise.atlassian.net/browse/FES-132

#### 2. Description of change

- Added cron by creating new file etc/crontab.xml.
- Created new file etc/cron_groups.cml to make run cron independently from other cron jobs.
- Actual cron php file Cron/SyncStatus.php
- Updated reusable method to be public in Model/SyncStatus.php.

#### 3. Quality assurance
**🔧 Environments:**

i.e.
- **Platform version**: Magento CE 2.4.1.
- **Omise plugin version**: Omise-Magento 2.4.
- **PHP version**: 7.3.9.

**✏️ Details:**

- execute command `php bin/magento c:f` to refresh cached files and add cron configuration to Magento.
- execute command `php bin/magento cron:run --group=omise` to manually execute the cron for testing.

Steps for testing this feature:
1. Go to Magento Backend : Sales > Order. There should be orders with status "**pending/processing**".
2. From Terminal/CMD, execute command `php bin/magento cron:run --group=omise`
3. Wait for approximate of 5 minutes. Order status of expired charge orders will be updated to **Canceled**

#### 4. Impact of the change

All Payment methods should work normally. 

#### 5. Priority of change

Normal

#### 6. Additional Notes

NA