### PR TITLE
Preparing to release 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [v2.15 _(Dec 03, 2020)_](https://github.com/omise/omise-magento/releases/tag/v2.15)
+
+### 🚀 Enhancements
+- Removing 3DS configuration from backend. (PR [#279](https://github.com/omise/omise-magento/pull/279))
+- Implementing cron job to update order status of expired omise charge. (PR [#281](https://github.com/omise/omise-magento/pull/281))
+
+
 ## [v2.14 _(Nov 10, 2020)_](https://github.com/omise/omise-magento/releases/tag/v2.14)
 
 ### 🚀 Enhancements

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.14.0",
+    "version": "2.15.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.14.0">
+    <module name="Omise_Payment" setup_version="2.15.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

This is the required change to make the release version 2.15.

This release contains following PRs:
### 🚀 Enhancements
- Removing 3DS configuration from backend. (PR [#279](https://github.com/omise/omise-magento/pull/279))
- Implementing cron job to update order status of expired omise charge. (PR [#281](https://github.com/omise/omise-magento/pull/281))

#### 2. Description of change

Changed version of the plugin in `modules.xml` and `composer.json`
`2.14` => `2.15`
Updated CHANGELOG.md

#### 3. Quality assurance

N/A

**🔧 Environments:**

- **Platform version**: Magento CE 2.4.
- **Omise plugin version**: Omise-Magento 2.14.
- **PHP version**: 7.4.2.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A