### PR TITLE
new release 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v2.18 _(Jun 10, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18)
+
+### 🚀 Enhancements
+- Add support for Magento 2.4.2. (PR [#289](https://github.com/omise/omise-magento/pull/289))
+
+
 ## [v2.17 _(Jun 08, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.17)
 
 ### 🚀 Enhancements

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.17.0",
+    "version": "2.18.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.17.0">
+    <module name="Omise_Payment" setup_version="2.18.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

release the new support for Magento 2.4.2

**Related information**:
Related issue(s): #< EM-513 > (optional)

#### 2. Description of change

Support for Magento 2.4.2

#### 3. Quality assurance

install Magento 2.4.2, and run "composer require omise/omise-magento"

**🔧 Environments:**

i.e.
- **Platform version**: Magento 2.4.2.
- **Omise plugin version**: Omise-php 2.11.1.
- **PHP version**: 7.3.

**✏️ Details:**

#### 4. Impact of the change

No big impact other than supporting Magento 2.4.2

#### 5. Priority of change

Normal,

#### 6. Additional Notes

N/A