### PR TITLE
update for magento-composer-installer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "~5.5.0|~5.6.0|~7",
-        "magento/magento-composer-installer": "0.1.13|0.2.0",
+        "magento/magento-composer-installer": ">=0.1.13",
         "magento/module-payment": ">=100.1",
         "magento/module-checkout": ">=100.1",
         "magento/module-sales": ">=100.1",


### PR DESCRIPTION
#### 1. Objective

update the composer to make it installable on Magento has magento-composer-installer package >= 0.2.1

**Related information**:


#### 2. Description of change

updated the composer requirement 

#### 3. Quality assurance


**🔧 Environments:**

i.e.
- **Platform version**: Magento CE 2.4.2.
- **Omise plugin version**: Omise-php 2.11.1.
- **PHP version**: 7.4.20

**✏️ Details:**

Explain how to manually test this feature.
Install magento 2.4.2 run `composer update` so it updates the  magento-composer-installer. after that `composer require omise/omise-magento`
if it doesn't errors about incompatible with magento-composer-installer then it means it works.

#### 4. Impact of the change
N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes
N/A