### PR TITLE
[EM-596] fix FPX Magento plugin does not indicate the banks with offl…

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-fpx-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-fpx-method.js
@@ -24,6 +24,15 @@ define(
             restrictedToCurrencies: ['myr'],
             banks: ko.observable(checkoutConfig.fpx.banks),
             selectedFpxBank: ko.observable(),
+            bankLabel: function(name, active) {
+                var bankLabel = name;
+
+                if(!active){
+                    bankLabel = bankLabel + " (offline)";
+                }
+
+                return bankLabel;
+            },
 
             /**
              * Get a checkout form data

--- a/view/frontend/web/template/payment/offsite-fpx-form.html
+++ b/view/frontend/web/template/payment/offsite-fpx-form.html
@@ -61,7 +61,7 @@
                                 value: selectedFpxBank">
 
                         <option data-bind="attr:{value: code,
-                         class:code}, html:'<span>'+name+'</span>'">
+                         class:code, disabled: !active}, html: $parent.bankLabel(name, active)">
                         </option>
                     </select>
                 </div>


### PR DESCRIPTION
…ine status

#### 1. Objective

Fix FPX Magento plugin does not indicate the banks with offline status

This section will be used in the release notes. 

**Related information**:
Related issue(s): #<EM-596> (optional)

#### 2. Description of change

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

i.e.
- **Platform version**: Magento CE 2.4.4
- **Omise plugin version**: Omise-php 2.11.1.
- **PHP version**: 7.4.21

**✏️ Details:**
in magento try to buy anything, go to checkout page, select FPX and see if the offline banks are disabled.

#### 4. Impact of the change

#### 5. Priority of change

Normal, High or Immediate.

#### 6. Additional Notes

Any further information that you would like to add.