### PR TITLE
v2.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+
+## [v2.18.2 _(Jul 06, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18.2)
+
+### 👾 Bug Fixes
+- Fix FPX Magento plugin does not indicate the banks with offline status (PR [#295](https://github.com/omise/omise-magento/pull/295))
+
+
 ## [v2.18.1 _(Jun 15, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18.1)
 
 ### 🚀 Enhancements

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.18.1",
+    "version": "2.18.2",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.18.1">
+    <module name="Omise_Payment" setup_version="2.18.2">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective
release new fix for FPX Magento plugin does not indicate the banks with offline status

This section will be used in the release notes. 

**Related information**:
Related issue(s): #EM-596

#### 2. Description of change

#### 3. Quality assurance

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

i.e.
- **Platform version**: Magento CE 2.4.2.
- **Omise plugin version**: Omise-php 2.11.1.
- **PHP version**: 7.4.21.

**✏️ Details:**

#### 4. Impact of the change


<img width="827" alt="Screen Shot 2021-07-06 at 10 13 35 AM" src="https://user-images.githubusercontent.com/84313029/124551847-f002b980-de5c-11eb-93db-59ef31babaeb.png">



#### 5. Priority of change

Normal, High or Immediate.

#### 6. Additional Notes

Any further information that you would like to add.