### PR TITLE
WIP - Generate invoice after success

### DIFF
--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -54,10 +54,11 @@ class PaymentDetailsHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $payment     = SubjectReader::readPayment($handlingSubject);
-        $payment     = $payment->getPayment();
-        $paymentType = isset($response['charge']->source['type']) ? $response['charge']->source['type'] : null;
-        $order       = $payment->getOrder();
+        $payment       = SubjectReader::readPayment($handlingSubject);
+        $payment       = $payment->getPayment();
+        $paymentType   = isset($response['charge']->source['type']) ? $response['charge']->source['type'] : null;
+        $paymentMethod = $payment->getMethod();
+        $order         = $payment->getOrder();
 
         $payment->setAdditionalInformation('charge_id', $response['charge']->id);
         $payment->setAdditionalInformation('charge_authorize_uri', $response['charge']->authorize_uri);
@@ -85,7 +86,7 @@ class PaymentDetailsHandler implements HandlerInterface
             $payment->setAdditionalInformation('barcode', $barcode);
         }
 
-        if ($this->_helper->isPayableByImageCode($paymentType)) {
+        if ($this->_helper->isPayableByImageCode($paymentMethod)) {
             $payment->setAdditionalInformation(
                 'image_code',
                 $response['charge']->source['scannable_code']['image']['download_uri']

--- a/Gateway/Response/PendingInvoiceHandler.php
+++ b/Gateway/Response/PendingInvoiceHandler.php
@@ -28,11 +28,15 @@ class PendingInvoiceHandler implements HandlerInterface
     public function handle(array $handlingSubject, array $response)
     {
         $is3dsecured = $this->helper->is3DSecureEnabled($response['charge']);
-        if (!$is3dsecured && $handlingSubject['paymentAction'] != self::ACTION_AUTHORIZE_CAPTURE) {
-            return;
-        }
+
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
         $payment = SubjectReader::readPayment($handlingSubject);
+        $paymentMethod = $payment->getPayment()->getMethod();
+
+        if ((!$is3dsecured && $handlingSubject['paymentAction'] != self::ACTION_AUTHORIZE_CAPTURE) ||
+        $this->helper->isOfflineOrOffsite($paymentMethod)) {
+            return;
+        }
 
         $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
         $invoice->register();

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -1,0 +1,55 @@
+<?php
+namespace Omise\Payment\Helper;
+
+use Magento\Framework\App\Helper\AbstractHelper;
+
+class OmiseEmailHelper extends AbstractHelper
+{
+    /**
+     * @var \Magento\Sales\Model\Order\Email\Sender\OrderSender
+     */
+    protected $orderSender;
+
+    /**
+     * @var \Magento\Sales\Model\Order\Email\Sender\InvoiceSender
+     */
+    protected $invoiceSender;
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $checkoutSession;
+
+    /**
+     * @param \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender
+     * @param \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param \Magento\Framework\App\Helper\Context $context
+     *
+     */
+    public function __construct(
+        \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender,
+        \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender,
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Framework\App\Helper\Context $context
+    ) {
+        $this->orderSender = $orderSender;
+        $this->invoiceSender = $invoiceSender;
+        $this->checkoutSession = $checkoutSession;
+        parent::__construct($context);
+    }
+
+    public function sendInvoiceAndConfirmationEmails($orderIds, $order)
+    {
+        $invoiceCollection = $order->getInvoiceCollection();
+
+        if (count($orderIds)) {
+            $this->checkoutSession->setForceOrderMailSentOnSuccess(true);
+            $this->orderSender->send($order, true);
+
+            foreach ($invoiceCollection as $invoice) {
+                $this->invoiceSender->send($invoice, true);
+            }
+        }
+    }
+}

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -3,6 +3,15 @@ namespace Omise\Payment\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Store\Model\ScopeInterface;
+use Omise\Payment\Model\Config\Internetbanking;
+use Omise\Payment\Model\Config\Alipay;
+use Omise\Payment\Model\Config\Pointsciti;
+use Omise\Payment\Model\Config\Installment;
+use Omise\Payment\Model\Config\Truemoney;
+use Omise\Payment\Model\Config\Fpx;
+use Omise\Payment\Model\Config\Paynow;
+use Omise\Payment\Model\Config\Promptpay;
+use Omise\Payment\Model\Config\Tesco;
 use SimpleXMLElement;
 use DOMDocument;
 
@@ -113,21 +122,57 @@ class OmiseHelper extends AbstractHelper
         }
         return $xhtml->saveXML(null, LIBXML_NOEMPTYTAG);
     }
-    
+
     /**
-     * This method checks and return TRUE if $paymentType is offline payment which is payable by image code
+     * This method checks and return TRUE if $paymentMethod is offline payment which is payable by image code
+     * otherwise returns false.
+     * @param string $paymentMethod
+     * @return boolean
+     */
+    public function isPayableByImageCode($paymentMethod)
+    {
+        return in_array(
+            $paymentMethod,
+            [
+                Paynow::CODE,
+                Promptpay::CODE,
+                Tesco::CODE
+            ]
+        );
+    }
+
+    /**
+     * This method checks and return TRUE if $paymentMethod is an offsite paymetn
+     * otherwise returns false.
+     * @param string $paymentMethod
+     * @return boolean
+     */
+    public function isOffsitePayment($paymentMethod)
+    {
+       return in_array(
+            $paymentMethod,
+            [
+                Alipay::CODE,
+                Internetbanking::CODE,
+                Installment::CODE,
+                Truemoney::CODE,
+                Pointsciti::CODE,
+                Fpx::CODE
+            ]
+        );
+    }
+
+    /**
+     * This method checks and return TRUE if $paymentType is offline or offsite
      * otherwise returns false.
      * @param string $paymentType
      * @return boolean
      */
-    public function isPayableByImageCode($paymentType)
+    public function isOfflineOrOffsite($paymentMethod)
     {
-        return (
-            $paymentType === 'paynow'
-            || $paymentType === 'promptpay'
-            || $paymentType === 'bill_payment_tesco_lotus'
-        );
+        return $this->isPayableByImageCode($paymentMethod) || $this->isOffsitePayment($paymentMethod);
     }
+
 
     /**
      * Check order payment processed using Omise payment methods.
@@ -164,7 +209,7 @@ class OmiseHelper extends AbstractHelper
     }
 
     /**
-     * Checks if 3d secured setting enabled from charge data.
+     * Checks if charge flow is direct (not offline or offsite).
      * @param \Omise\Payment\Model\Api\Charge $charge
      * @return boolean
      */

--- a/Observer/PaymentCreationObserver.php
+++ b/Observer/PaymentCreationObserver.php
@@ -10,6 +10,7 @@ class PaymentCreationObserver implements ObserverInterface
      * @var \Omise\Payment\Helper\OmiseHelper
      */
     private $_helper;
+
     /**
      * @var \Omise\Payment\Model\Data\Email
      */
@@ -33,15 +34,14 @@ class PaymentCreationObserver implements ObserverInterface
     public function execute(Observer $observer)
     {
         $order   = $observer->getEvent()->getOrder();
-        $paymentType = $order->getPayment()->getAdditionalInformation('payment_type');
+        $paymentMethod = $order->getPayment()->getMethod();
 
-        // Hotfixed for FPX, can refactor for other backends.
-        if ($paymentType == 'fpx') {
+        if ($this->_helper->isOfflineOrOffsite($paymentMethod)) {
             $order->setCanSendNewEmailFlag(false);
         }
 
         // Offline QR code payment emails
-        if ($this->_helper->isPayableByImageCode($paymentType)) {
+        if ($this->_helper->isPayableByImageCode($paymentMethod)) {
             $this->_email->sendEmail($order);
         }
         return $this;

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -114,7 +114,7 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
 
             <omise_offsite_fpx>
                 <active>0</active>
-                <title>FPX Payment</title>
+                <title>Online Banking (FPX)</title>
                 <model>OmiseFPXAdapter</model>
                 <is_gateway>1</is_gateway>
                 <can_initialize>1</can_initialize>


### PR DESCRIPTION
This is a WIP and should not be merged. Will say about 50% there

It can be used to work onto or as a frame of reference. The PR aims to do the following:
- For offsite and offline payments, send order confirmation and invoice emails only after payment successful from our API.
- For offsite and offline payments, only generate invoices after payment successful. We also remove the feature which we mark the invoice as cancelled if payment failed (not needed anymore).
- Refactored some parts of the workflow to make it clearer and reuse code

Problems facing:
- EmailGenerationHelper class doesn't get called or run when called from offsite payments (possibly due to dependency injector not working for some reason)
- Need to check invoice emails are sending fine for offsite (might be a race condition from when we generate to when we send. Can move email generation to offsite.php and completely obsolete the SendEmailOnSuccessObserver which should fix it and also make the code cleaner.
- Need to test if card payments work the same. 3ds should work the same as offline and non 3ds payments should just work the same.