### PR TITLE
FPX bank list dropdown default to empty

### DIFF
--- a/view/frontend/web/template/payment/offsite-fpx-form.html
+++ b/view/frontend/web/template/payment/offsite-fpx-form.html
@@ -59,7 +59,8 @@
                                 style="margin-bottom:10px"
                                 data-bind="foreach: banks,
                                     value: selectedFpxBank,
-                                    attr:{class: selectedFpxBank}">
+                                    attr:{class: selectedFpxBank},
+                                    valueAllowUnset: true">
 
                             <option data-bind="attr:{value: code,
                             disabled: !active}, html: $parent.bankLabel(name, active)">


### PR DESCRIPTION
#### 1. Objective

Explain in non-technical terms **WHY this PR is required**.
E.g.: What feature it adds, what problem it solves...

This section will be used in the release notes. 

To allow FPX bank list to default to empty. So customers need to make a conscious selection of which bank to select.