### PR TITLE
v2.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## [v2.18.5 _(Jul 29, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18.5)
+
+### 👾 Bug Fixes
+- FPX banks list default to empty (PR [#303](https://github.com/omise/omise-magento/pull/303))
+
 ## [v2.18.4 _(Jul 29, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18.4)
 
 ### 👾 Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.18.4",
+    "version": "2.18.5",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.18.4">
+    <module name="Omise_Payment" setup_version="2.18.5">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
## [v2.18.5 _(Jul 29, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.18.5)

### 👾 Bug Fixes
- FPX banks list default to empty (PR [#303](https://github.com/omise/omise-magento/pull/303))