### PR TITLE
[FRON-728] Allow minimum 2000 for installment payment method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "magento/module-payment": ">=100.1",
         "magento/module-checkout": ">=100.1",
         "magento/module-sales": ">=100.1",
-        "omise/omise-php": "2.11.1"
+        "omise/omise-php": "2.13.0"
     },
     "autoload": {
         "files": ["registration.php"],

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -16,7 +16,7 @@ define(
         priceUtils
     ) {
         'use strict';
-        const INSTALLMENT_MIN_PURCHASE_AMOUNT = 3000;
+        const INSTALLMENT_MIN_PURCHASE_AMOUNT = 2000;
 
         return Component.extend(Base).extend({
             defaults: {
@@ -48,7 +48,7 @@ define(
 
             /**
              * Format Price
-             * 
+             *
              * @param {float} amount - Amount to be formatted
              * @return {string}
              */
@@ -91,7 +91,7 @@ define(
              * Get Installment monthly interest rate
              *
              * NOTE: in the future this function should return data from capabilities object.
-             * 
+             *
              * @param {string} id - Bank id
              * @return {float}
              */
@@ -117,7 +117,7 @@ define(
 
             /**
              * Calculates single installment amount
-             * 
+             *
              * @param {string} id - Bank ID
              * @param {integer} terms - number of monthly installments
              * @return {integer}
@@ -147,7 +147,7 @@ define(
 
             /**
              * Get installment terms
-             * 
+             *
              * @return {string|null}
              */
             getTerms: function () {


### PR DESCRIPTION
#### 1. Objective
Allow minimum 2000 to be supported for installment payment options.

#### 2. Description of change
- Magento plugin now uses the 2.13.0 instead of 2.11.1 version.
- Updated some static value from 3000 to 2000 for installment payment.

#### 3. Quality assurance

Tested locally on the following env and installment option is available for 2123 Baht amount.

However, the library bump from the old one 2.11.1 to 2.13.0 needs to be ensured that there are no breaking changes between.

**🔧 Environments:**
- **Platform version**: Magento ver. 2.2.3.
- **Omise plugin version**: Omise-Magento 2.18.5, Omise-PHP 2.13.0.
- **PHP version**: 7.4.23.

**✏️ Details:**

Omise-PHP version has been updated as well as some minor change made within the Omise-Magento library as well to allow having minimum installment to 2000.

#### 5. Priority of change

Normal