### PR TITLE
Release v2.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.20.1 _(Nov 30, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.1)
+
+### 👾 Bug Fixes
+- Fix expiry cron worker incorrectly expiring orders sporadically (PR [#316](https://github.com/omise/omise-magento/pull/316))
+- Fix internet banking charges not being marked as expired (PR [#315](https://github.com/omise/omise-magento/pull/315))
 
 ## [v2.20.0 _(Nov 09, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.0)
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.0",
+    "version": "2.20.1",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.0">
+    <module name="Omise_Payment" setup_version="2.20.1">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
# CHANGELOG

## [v2.20.1 _(Nov 30, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.1)

### 👾 Bug Fixes
- Fix expiry cron worker incorrectly expiring orders sporadically (PR [#316](https://github.com/omise/omise-magento/pull/316))
- Fix internet banking charges not being marked as expired (PR [#315](https://github.com/omise/omise-magento/pull/315))