### PR TITLE
provide fpx logo in checkout screen

### DIFF
--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -96,6 +96,15 @@
     background: url('../images/kbank.svg')rgb(247, 226, 226);
 }
 
+div.fpx {
+    background: url('../images/fpx.svg');
+    width: 68px;
+    height: 22px;
+    float: right;
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
 #omise_offsite_truemoneyphoneNumber, #omise_offline_conveniencestoreEmail, #omise_offline_conveniencestorePhoneNumber, #omise_offline_conveniencestoreCustomerName {
     width: 225px;
 }

--- a/view/frontend/web/template/payment/offsite-fpx-form.html
+++ b/view/frontend/web/template/payment/offsite-fpx-form.html
@@ -66,7 +66,7 @@
         </form>
         <div class="actions-toolbar">
             <div class="checkout-agreements-block">
-                <span>clicking on tht "Place Order" button, you agree to FPX's</span>
+                <span>By clicking on the "Place Order" button, you agree to FPX's</span>
                 <a href="https://www.mepsfpx.com.my/FPXMain/termsAndConditions.jsp" target="_blank">
                     Terms and Conditions
                 </a>

--- a/view/frontend/web/template/payment/offsite-fpx-form.html
+++ b/view/frontend/web/template/payment/offsite-fpx-form.html
@@ -11,7 +11,7 @@
                visible: isRadioButtonVisible(),
                enable: isActive()" />
         <label data-bind="attr: {'for': getCode()}" class="label">
-            <span data-bind="text: getTitle()"></span>
+            <span data-bind="text: getTitle()"></span><div class="fpx"></div>
         </label>
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">
@@ -32,12 +32,6 @@
             <!-- /ko -->
             <!--/ko-->
         </div>
-        <div class="checkout-agreements-block">
-            <!-- ko foreach: $parent.getRegion('before-place-order') -->
-            <!-- ko template: getTemplate() --><!-- /ko -->
-            <!--/ko-->
-        </div>
-
         <!-- ko if: banks().length -->
         <form class="form" data-bind="attr: {
               id: getCode() + 'Form',
@@ -71,6 +65,12 @@
             </fieldset>
         </form>
         <div class="actions-toolbar">
+            <div class="checkout-agreements-block">
+                <span>clicking on tht "Place Order" button, you agree to FPX's</span>
+                <a href="https://www.mepsfpx.com.my/FPXMain/termsAndConditions.jsp" target="_blank">
+                    Terms and Conditions
+                </a>
+            </div>
             <div class="primary">
                 <button class="action primary checkout" type="submit"
                         disabled="disabled"

--- a/view/frontend/web/template/payment/offsite-fpx-form.html
+++ b/view/frontend/web/template/payment/offsite-fpx-form.html
@@ -32,6 +32,11 @@
             <!-- /ko -->
             <!--/ko-->
         </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+            <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
         <!-- ko if: banks().length -->
         <form class="form" data-bind="attr: {
               id: getCode() + 'Form',
@@ -64,13 +69,13 @@
                 </div>
             </fieldset>
         </form>
+        <div class="terms-and-conditions-block">
+            <span>By clicking on the "Place Order" button, you agree to FPX's</span>
+            <a href="https://www.mepsfpx.com.my/FPXMain/termsAndConditions.jsp" target="_blank">
+                Terms and Conditions
+            </a>
+        </div>
         <div class="actions-toolbar">
-            <div class="checkout-agreements-block">
-                <span>By clicking on the "Place Order" button, you agree to FPX's</span>
-                <a href="https://www.mepsfpx.com.my/FPXMain/termsAndConditions.jsp" target="_blank">
-                    Terms and Conditions
-                </a>
-            </div>
             <div class="primary">
                 <button class="action primary checkout" type="submit"
                         disabled="disabled"


### PR DESCRIPTION
- Add FPX logo to checkout screen due to FPX CI
- Add FPX term and condition to checkout screen

#### 1. Objective

Regarding to FPX CI so FPX request Omise to display their payment method under the checkout screen with FPX logo and also display a link to their term and conditions page.

**Related information**:

https://omise.atlassian.net/browse/APM2-206

#### 2. Description of change

![Screen Shot 2564-12-01 at 17 11 09](https://user-images.githubusercontent.com/90759391/144215537-1a14dfd4-bfb6-4d66-bade-3c01bb82e8f5.png)
#### 3. Quality assurance

FPX logo along with term and condition link displayed on checkout screen for Malaysia merchant whose enable FPX payment method.

**🔧 Environments:**


 **Platform version**: Magento CE 2.2.3.
**Omise plugin version**: Omise-Magento 2.2.0
 **PHP version**: 7.0.16.

**✏️ Details:**

#### 4. Impact of the change

None

#### 5. Priority of change

High
