### PR TITLE
release 2.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v2.20.2 _(Dec 03, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.2)
+
+### 👾 Bug Fixes
+- Fix FPX logo never display on checkout screen (PR [#318](https://github.com/omise/omise-magento/pull/318))
+- Add FPX term and condition link on checkout screen (PR [#318](https://github.com/omise/omise-magento/pull/318))
+
+# CHANGELOG
+
 ## [v2.20.1 _(Nov 30, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.1)
 
 ### 👾 Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.1",
+    "version": "2.20.2",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.1">
+    <module name="Omise_Payment" setup_version="2.20.2">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
# CHANGELOG

## [v2.20.2 _(Dec 03, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.2)

### 👾 Bug Fixes
- Fix FPX logo never display on checkout screen (PR [#318](https://github.com/omise/omise-magento/pull/318))
- Add FPX term and condition link on checkout screen (PR [#318](https://github.com/omise/omise-magento/pull/318))