### PR TITLE
release 2.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.20.3 _(Jan 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.3)
+
+### 👾 Bug Fixes
+- Fix invoice generated before charge is captured (PR [#320](https://github.com/omise/omise-magento/pull/320))
+
 ## [v2.20.2 _(Dec 03, 2021)_](https://github.com/omise/omise-magento/releases/tag/v2.20.2)
 
 ### 👾 Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.2",
+    "version": "2.20.3",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.2">
+    <module name="Omise_Payment" setup_version="2.20.3">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
# CHANGELOG

## [v2.20.3 _(Jan 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.3)

### 👾 Bug Fixes
- Fix invoice generated before charge is captured (PR [#320](https://github.com/omise/omise-magento/pull/320))
