### PR TITLE
[FRON-972]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.20.4 _(Feb 14, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.4)
+
+### 👾 Bug Fixes
+- Fix duplicate invoices being sent via email (PR [#320](https://github.com/omise/omise-magento/pull/325))
+
 ## [v2.20.3 _(Jan 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.3)
 
 ### 👾 Bug Fixes

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -88,7 +88,7 @@ class OmiseEmailHelper extends AbstractHelper
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {
             $key = 'omise:invoice:sent:'. $invoice->getId();
-            if(!$this->cache->load($key)) {
+            if (!$this->cache->load($key)) {
                 $this->invoiceSender->send($invoice, true);
                 $this->cache->save('', $key, [], 300);
             }

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -58,6 +58,12 @@ class OmiseEmailHelper extends AbstractHelper
         parent::__construct($context);
     }
 
+    /**
+     * sendInvoiceAndConfirmationEmails
+     * 
+     * @param $order
+     * @return void
+     */
     public function sendInvoiceAndConfirmationEmails($order)
     {
         if (!$order->getEmailSent()) {
@@ -70,16 +76,21 @@ class OmiseEmailHelper extends AbstractHelper
         }
     }
 
+    /**
+     * sendInvoiceEmail
+     *
+     * @param $order
+     * @return void
+     */
     public function sendInvoiceEmail($order)
     {
         $this->checkoutSession->setForceInvoiceMailSentOnSuccess(true);
-
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {
-            $id = $invoice->getId();
-            if(!$this->cache->load('omise:invoice:sent:'. $id)) {
+            $key = 'omise:invoice:sent:'. $invoice->getId();
+            if(!$this->cache->load($key)) {
                 $this->invoiceSender->send($invoice, true);
-                $this->cache->save('1', 'omise:invoice:sent:'. $id, [], 300);
+                $this->cache->save('1', $key, [], 300);
             }
         }
     }

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -60,7 +60,7 @@ class OmiseEmailHelper extends AbstractHelper
 
     /**
      * sendInvoiceAndConfirmationEmails
-     * 
+     *
      * @param $order
      * @return void
      */
@@ -90,7 +90,7 @@ class OmiseEmailHelper extends AbstractHelper
             $key = 'omise:invoice:sent:'. $invoice->getId();
             if(!$this->cache->load($key)) {
                 $this->invoiceSender->send($invoice, true);
-                $this->cache->save('1', $key, [], 300);
+                $this->cache->save('', $key, [], 300);
             }
         }
     }

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -29,24 +29,31 @@ class OmiseEmailHelper extends AbstractHelper
     protected $config;
 
     /**
+     * @var \Magento\Framework\App\CacheInterface
+     */
+    protected $cache;
+
+    /**
      * @param \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender
      * @param \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\App\Helper\Context $context
      * @param Config $config
-     *
+     * @param \Magento\Framework\App\CacheInterface $cache
      */
     public function __construct(
         \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender,
         \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender,
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Framework\App\Helper\Context $context,
-        Config $config
+        Config $config,
+        \Magento\Framework\App\CacheInterface $cache
     ) {
         $this->orderSender = $orderSender;
         $this->invoiceSender = $invoiceSender;
         $this->checkoutSession = $checkoutSession;
         $this->config = $config;
+        $this->cache = $cache;
 
         parent::__construct($context);
     }
@@ -69,7 +76,11 @@ class OmiseEmailHelper extends AbstractHelper
 
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {
-            $this->invoiceSender->send($invoice, true);
+            $id = $invoice->getId();
+            if(!$this->cache->load('omise:invoice:sent:'. $id)) {
+                $this->invoiceSender->send($invoice, true);
+                $this->cache->save('1', 'omise:invoice:sent:'. $id, [], 300);
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.3",
+    "version": "2.20.4",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.3">
+    <module name="Omise_Payment" setup_version="2.20.4">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

Only allow the sending of invoices to happen 1 time.

#### 2. Description of change

On sending of invoice the invoice id is added to magento cache, cache is checked for presence of invoice key before sending

#### 3. Quality assurance

Ensure that invoice emails are only sent one time

**🔧 Environments:**

- **Platform version**: Magento CE 2.20.4.
- **Omise plugin version**: Omise-Magento 2.13
- **PHP version**: 7.0.16.

**✏️ Details:**

Create a charge on magneto store that is processed by 3DS. Ensure invoice emails are only send once.

#### 4. Impact of the change

N/A

#### 5. Priority of change

High

#### 6. Additional Notes
None