### PR TITLE
[FRON-972]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # CHANGELOG
 
+## [v2.20.5 _(Feb 18, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.5)
+
+### 👾 Bug Fixes
+- Delay creation and sending of invoice when initiated via webook (PR [#326](https://github.com/omise/omise-magento/pull/326))
+
 ## [v2.20.4 _(Feb 14, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.4)
 
 ### 👾 Bug Fixes
-- Fix duplicate invoices being sent via email (PR [#320](https://github.com/omise/omise-magento/pull/325))
+- Fix duplicate invoices being sent via email (PR [#325](https://github.com/omise/omise-magento/pull/325))
 
 ## [v2.20.3 _(Jan 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.3)
 

--- a/Gateway/Response/PendingInvoiceHandler.php
+++ b/Gateway/Response/PendingInvoiceHandler.php
@@ -62,6 +62,7 @@ class PendingInvoiceHandler implements HandlerInterface
          * Delay exec of creating invoice and sending for 10secs
          * This allows time for redirect process to complete and dB 'emailSent' value to be updated to true
          */
+        // @codingStandardsIgnoreLine
         sleep(10);
         $this->emailHelper->sendInvoiceEmail($payment->getPayment()->getOrder(), true);
     }

--- a/Gateway/Response/PendingInvoiceHandler.php
+++ b/Gateway/Response/PendingInvoiceHandler.php
@@ -58,10 +58,11 @@ class PendingInvoiceHandler implements HandlerInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObjectInterface **/
         $payment = SubjectReader::readPayment($handlingSubject);
 
-        $invoice = $payment->getPayment()->getOrder()->prepareInvoice();
-        $invoice->register();
-        $payment->getPayment()->getOrder()->addRelatedObject($invoice)->save();
-
-        $this->emailHelper->sendInvoiceEmail($payment->getPayment()->getOrder());
+        /**
+         * Delay exec of creating invoice and sending for 10secs
+         * This allows time for redirect process to complete and dB 'emailSent' value to be updated to true
+         */
+        sleep(10);
+        $this->emailHelper->sendInvoiceEmail($payment->getPayment()->getOrder(), true);
     }
 }

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -59,8 +59,6 @@ class OmiseEmailHelper extends AbstractHelper
     }
 
     /**
-     * sendInvoiceAndConfirmationEmails
-     *
      * @param $order
      * @return void
      */
@@ -77,13 +75,18 @@ class OmiseEmailHelper extends AbstractHelper
     }
 
     /**
-     * sendInvoiceEmail
-     *
      * @param $order
+     * @param $createInvoice
      * @return void
      */
-    public function sendInvoiceEmail($order)
+    public function sendInvoiceEmail($order, $createInvoice = false)
     {
+        if ($createInvoice && !$order->hasInvoices()) {
+            $invoice = $order->prepareInvoice();
+            $invoice->register();
+            $order->addRelatedObject($invoice)->save();
+        }
+
         $this->checkoutSession->setForceInvoiceMailSentOnSuccess(true);
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -90,7 +90,7 @@ class OmiseEmailHelper extends AbstractHelper
         $this->checkoutSession->setForceInvoiceMailSentOnSuccess(true);
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {
-            if(!$invoice->getEmailSent()) {
+            if (!$invoice->getEmailSent()) {
                 $this->invoiceSender->send($invoice, true);
             }
         }

--- a/Helper/OmiseEmailHelper.php
+++ b/Helper/OmiseEmailHelper.php
@@ -87,10 +87,8 @@ class OmiseEmailHelper extends AbstractHelper
         $this->checkoutSession->setForceInvoiceMailSentOnSuccess(true);
         $invoiceCollection = $order->getInvoiceCollection();
         foreach ($invoiceCollection as $invoice) {
-            $key = 'omise:invoice:sent:'. $invoice->getId();
-            if (!$this->cache->load($key)) {
+            if(!$invoice->getEmailSent()) {
                 $this->invoiceSender->send($invoice, true);
-                $this->cache->save('', $key, [], 300);
             }
         }
     }

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -14,7 +14,7 @@ class Capabilities extends BaseObject
         try {
             $this->capabilities = OmiseCapabilities::retrieve();
         } catch (\Exception $e) {
-            throw new LocalizedException(__('Unable to load OmiseCapabilities api - Error: ' . $e->getMessage() ));
+            throw new LocalizedException(__('unable to load OmiseCapabilities api') . ' - Error: '. $e->getMessage());
         }
     }
 

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -14,7 +14,7 @@ class Capabilities extends BaseObject
         try {
             $this->capabilities = OmiseCapabilities::retrieve();
         } catch (\Exception $e) {
-            throw new LocalizedException(__('unable to load OmiseCapabilities api'));
+            throw new LocalizedException(__('Unable to load OmiseCapabilities api - Error: ' . $e->getMessage() ));
         }
     }
 

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -79,12 +79,6 @@ class Complete
             return;
         }
 
-        $paymentMethod = $payment->getMethod();
-        if (!$helper->isPayableByImageCode($paymentMethod) &&
-        $config->getSendInvoiceAtOrderStatus() == MagentoOrder::STATE_PROCESSING) {
-            return;
-        }
-
         if ($order->isPaymentReview() || $order->getState() === MagentoOrder::STATE_PENDING_PAYMENT) {
             if ($charge->isFailed()) {
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.4",
+    "version": "2.20.5",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.5",
+    "version": "2.20.5-alpha",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.4">
+    <module name="Omise_Payment" setup_version="2.20.5">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

Currently the magento plugin has 2 flows that will create and send invoices when merchant is using 3ds (redirect & webook). This PR aims to mitigate this issue by delaying the creation and sending of the invoices by 10secs when initiated via webhook. This delay should allow time for any redirect process to complete and update the order records to reflect that the invoice for the order has been created and sent already.

#### 2. Description of change

A delay has been added above the 'sendInvoiceEmail' method that is called in the PendingInvoiceHandler Class handler method. The creation of the invoice from the PendingInvoiceHandler Class handler method has been moved inside the 'sendInvoiceEmail' method. A 2nd argument has been added to the 'sendInvoiceEmail' to flagh whether or not to created the invoice before sending. 

A slight updated to 'Omise\Payment\Model\Api\Capabilities' class has been made. The purpose of this is to pass the exception message to the custom exception 'LocalizedException' to allow for better error debugging for interrogations. 

#### 3. Quality assurance

3DS checkout process needs to be tested. Ensure that only 1 invoice is created and sent. As we fixing a race condition there may still be very rare edge cases that still send and create 2 invoices. Therefore a 99% success rate is acceptable.

**🔧 Environments:**

Local php development env

i.e.
- **Platform version**: Magento CE 2.4.3.
- **Omise plugin version**: Omise-Magento 2.20.5.
- **PHP version**: 7.4.27.

**✏️ Details:**

Created a order with 3DS enabled and conffirm that only 1 invoice is created and sent

#### 4. Impact of the change

N/A

#### 5. Priority of change

High