### PR TITLE
release 2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [v2.21.0 _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
 
 ### 🚀 Enhancements
-- Add Alipay plus wallets for SG (PR [#309](https://github.com/omise/omise-magento/pull/309))
+- Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))
+- Add Mobile banking SCB for TH (PR [#327](https://github.com/omise/omise-magento/pull/327))
 
 ## [v2.20.4 _(Feb 14, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [v2.21.0-alpha _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0-alpha)
+## [v2.21.0 _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
 
 ### 🚀 Enhancements
 - Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [v2.21.0 _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
+## [v2.21.0 _(Mar 08, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
 
 ### 🚀 Enhancements
 - Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [v2.21.0 _(Mar 08, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
+## [v2.21.0 _(Mar 09, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
 
 ### 🚀 Enhancements
 - Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.21.0 _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
+
+### 🚀 Enhancements
+- Add Alipay plus wallets for SG (PR [#309](https://github.com/omise/omise-magento/pull/309))
+
 ## [v2.20.4 _(Feb 14, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.20.4)
 
 ### 👾 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## [v2.21.0 _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
+## [v2.21.0-alpha _(Feb 28, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0-alpha)
 
 ### 🚀 Enhancements
 - Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.21.0",
+    "version": "2.21.0-alpha",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.20.4",
+    "version": "2.21.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.21.0-alpha",
+    "version": "2.21.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.20.4">
+    <module name="Omise_Payment" setup_version="2.21.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
# CHANGELOG
## [v2.21.0 _(Mar 09, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)

### 🚀 Enhancements
- Add Mobile banking OCBC PAO for SG (PR [#327](https://github.com/omise/omise-magento/pull/327))
- Add Mobile banking SCB for TH (PR [#327](https://github.com/omise/omise-magento/pull/327))
