### PR TITLE
Release note for 2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v2.22.0 _(Mar 17, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.22.0)
+
+### 🚀 Enhancements
+- Add Mobile banking BAY for TH (PR [#329](https://github.com/omise/omise-magento/pull/329))
+- Add Mobile banking KBANK for TH (PR [#329](https://github.com/omise/omise-magento/pull/329))
+- Add UOB Installment for TH (PR [#330](https://github.com/omise/omise-magento/pull/330))
+- Add Rabbit LINE Pay for TH (PR [#330](https://github.com/omise/omise-magento/pull/330))
+
 ## [v2.21.0 _(Mar 09, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.21.0)
 
 ### 🚀 Enhancements

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.21.0",
+    "version": "2.22.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.21.0">
+    <module name="Omise_Payment" setup_version="2.22.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
## [v2.22.0 _(Mar 17, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.22.0)

### 🚀 Enhancements
- Add Mobile banking BAY for TH (PR [#329](https://github.com/omise/omise-magento/pull/329))
- Add Mobile banking KBANK for TH (PR [#329](https://github.com/omise/omise-magento/pull/329))
- Add UOB Installment for TH (PR [#330](https://github.com/omise/omise-magento/pull/330))
- Add Rabbit LINE Pay for TH (PR [#330](https://github.com/omise/omise-magento/pull/330))
