### PR TITLE
[plugin-3] Moved the webhook changes did by the contractor. Fi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [v2.23.0 _(Apr 1, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.23.0)
+
+### 🚀 Enhancements
+- Add setting to enable webhook (PR [#333](https://github.com/omise/omise-magento/pull/333))
+
 ## [v2.22.0 _(Mar 17, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.22.0)
 
 ### 🚀 Enhancements

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -61,6 +61,11 @@ class Threedsecure extends Action
      */
     public function execute()
     {
+        // Do not proceed if webhook is enabled
+        if ($this->config->isWebhookEnabled()) {
+            return $this->redirect(self::PATH_SUCCESS);
+        }
+
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {

--- a/Controller/Callback/Webhook.php
+++ b/Controller/Callback/Webhook.php
@@ -37,6 +37,10 @@ class Webhook extends Action
      */
     public function execute()
     {
+        if (! $this->event->config->isWebhookEnabled()) {
+            return;
+        }
+
         if (! $this->getRequest()->isPost()) {
             // TODO: Only accept for POST verb.
             return;

--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -15,24 +15,25 @@ class OrderSyncStatus
      * @var array
      */
     private $paymentMethodArray = [
-                                "omise_cc",
-                                "omise_offline_conveniencestore",
-                                "omise_offline_paynow",
-                                "omise_offline_promptpay",
-                                "omise_offline_tesco",
-                                "omise_offsite_alipay",
-                                "omise_offsite_truemoney",
-                                "omise_offsite_installment",
-                                "omise_offsite_alipaycn",
-                                "omise_offsite_alipayhk",
-                                "omise_offsite_dana",
-                                "omise_offsite_gcash",
-                                "omise_offsite_kakaopay",
-                                "omise_offsite_touchngo",
-                                "omise_offsite_internetbanking",
-                                "omise_offsite_mobilebanking",
-                                "omise_offsite_rabbitlinepay",
-                            ];
+        "omise_cc",
+        "omise_offline_conveniencestore",
+        "omise_offline_paynow",
+        "omise_offline_promptpay",
+        "omise_offline_tesco",
+        "omise_offsite_alipay",
+        "omise_offsite_truemoney",
+        "omise_offsite_installment",
+        "omise_offsite_alipaycn",
+        "omise_offsite_alipayhk",
+        "omise_offsite_dana",
+        "omise_offsite_gcash",
+        "omise_offsite_kakaopay",
+        "omise_offsite_touchngo",
+        "omise_offsite_internetbanking",
+        "omise_offsite_mobilebanking",
+        "omise_offsite_rabbitlinepay",
+    ];
+
     /**
      * @var array
      */

--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -13,8 +13,8 @@ class PaymentDetailsHandler implements HandlerInterface
     protected $_helper;
 
     /**
-      * @var \Magento\Framework\HTTP\Client\Curl
-      */
+     * @var \Magento\Framework\HTTP\Client\Curl
+     */
     protected $curlClient;
 
     /**
@@ -23,10 +23,10 @@ class PaymentDetailsHandler implements HandlerInterface
     protected $transactionBuilder;
 
     /**
-      * @param \Omise\Payment\Helper\OmiseHelper $helper
-      * @param \Magento\Framework\HTTP\Client\Curl $curl
-      * @param Transaction\BuilderInterface $transactionBuilder
-      */
+     * @param \Omise\Payment\Helper\OmiseHelper $helper
+     * @param \Magento\Framework\HTTP\Client\Curl $curl
+     * @param Transaction\BuilderInterface $transactionBuilder
+     */
     public function __construct(
         \Omise\Payment\Helper\OmiseHelper $helper,
         \Magento\Framework\HTTP\Client\Curl $curl,

--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -10,19 +10,19 @@ class PaymentDetailsHandler implements HandlerInterface
     /**
      * @var \Omise\Payment\Helper\OmiseHelper
      */
-     protected $_helper;
+    protected $_helper;
 
-     /**
+    /**
       * @var \Magento\Framework\HTTP\Client\Curl
       */
-     protected $curlClient;
+    protected $curlClient;
 
     /**
      * @var \Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface
      */
     protected $transactionBuilder;
 
-     /**
+    /**
       * @param \Omise\Payment\Helper\OmiseHelper $helper
       * @param \Magento\Framework\HTTP\Client\Curl $curl
       * @param Transaction\BuilderInterface $transactionBuilder

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -46,10 +46,10 @@ class Customer extends BaseObject
     }
 
     /**
-      * @param  array $params
-      *
-      * @return \Omise\Payment\Model|\Api\Error|self
-      */
+     * @param  array $params
+     *
+     * @return \Omise\Payment\Model|\Api\Error|self
+     */
     public function update($params)
     {
         try {

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -45,7 +45,7 @@ class Customer extends BaseObject
         return $this;
     }
 
-     /**
+    /**
       * @param  array $params
       *
       * @return \Omise\Payment\Model|\Api\Error|self

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -123,6 +123,16 @@ class Config
     }
 
     /**
+     * Check if using webhook or not
+     *
+     * @return bool
+     */
+    public function isWebhookEnabled()
+    {
+        return $this->getValue('webhook_status');
+    }
+
+    /**
      * Retrieve the order status in which to generate invoice at
      *
      * @return string

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -79,12 +79,6 @@ class Complete
             return;
         }
 
-        $paymentMethod = $payment->getMethod();
-        if (!$helper->isPayableByImageCode($paymentMethod) &&
-        $config->getSendInvoiceAtOrderStatus() == MagentoOrder::STATE_PROCESSING) {
-            return;
-        }
-
         if ($order->isPaymentReview() || $order->getState() === MagentoOrder::STATE_PENDING_PAYMENT) {
             if ($charge->isFailed()) {
 

--- a/Observer/PaymentCreationObserver.php
+++ b/Observer/PaymentCreationObserver.php
@@ -23,8 +23,8 @@ class PaymentCreationObserver implements ObserverInterface
         \Omise\Payment\Helper\OmiseHelper $helper,
         \Omise\Payment\Model\Data\Email $email
     ) {
-        $this->_helper           = $helper;
-        $this->_email           = $email;
+        $this->_helper = $helper;
+        $this->_email = $email;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
           "email": "support@omise.co"
         }
     ],
-    "version": "2.22.0",
+    "version": "2.23.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -32,6 +32,11 @@
                     <label>Secret key for live</label>
                     <comment>The "Live" mode secret key can be found in Omise Dashboard.</comment>
                 </field>
+                <field id="webhook_status" translate="label comment" type="select" sortOrder="61" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Webhook</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Use webhook.</comment>
+                </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Webhook endpoint</label>
                     <comment><![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Omise dashboard</strong></a> <em>(HTTPS only)</em>.]]></comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,6 +13,7 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <sandbox_status>0</sandbox_status>
                 <model>OmiseAdapter</model>
                 <generate_invoice_at_order_status>\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT</generate_invoice_at_order_status>
+                <webhook_status>1</webhook_status>
             </omise>
 
             <omise_cc>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -19,7 +19,7 @@
         <observer name="omise_data_assign_truemoney" instance="Omise\Payment\Observer\TruemoneyDataAssignObserver" />
     </event>
 
-     <event name="payment_method_assign_data_omise_offsite_fpx">
+    <event name="payment_method_assign_data_omise_offsite_fpx">
         <observer name="omise_data_assign_fpx" instance="Omise\Payment\Observer\FpxDataAssignObserver" />
     </event>
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.22.0">
+    <module name="Omise_Payment" setup_version="2.23.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

Currently, the plugin is able to receive order status updates from both return_URI and webhook, whichever comes first. It should have generated one invoice and one email to the customer if the payment is successful. But, in the case of FPX, the customer was getting duplicate invoice of the same order. The PR is to move the code changes done by the contractors and avoid duplicate invoice email sent to the customer.

#### 2. Description of change

A new setting for `webhook` is added which holds value 0 for disable and 1 for enable. A new method `isWebhookEnabled` is added in the `Model/Config/Config.php` which retrieves the value of `webhook_status`. This method is used in the `Controller/Callback/Offsite.php` and `Controller/Callback/Threedsecure.php` to avoid repeat order processing when webhook is enabled because it will be handled by the webhook. The method is also used in the `Controller/Callback/Webhook.php` to stop the order processing when the webhook is disabled.

#### 3. Quality assurance

Checkout with FPX payment method needs to be tested for Malaysian merchants. It should send one email for the order and another email for the invoice of the order. 3DS checkout process also needs to be tested to ensure only one email is received by the customer.

**🔧 Environments:**

Tested this in my local machine with following configurations:

i.e.
- **Platform version**: Magento CE 2.4.3
- **Omise plugin version**: Omise-Magento 2.22.0
- **PHP version**: 7.1.15