### PR TITLE
[PLUGINS-36]: The site was redirected to success page even when payma…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 👾 Bug Fixes
+- Fix bug where redirects didnt handle redirects correctly (PR [#334](https://github.com/omise/omise-magento/pull/334))
+
 ## [v2.23.0 _(Apr 1, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.23.0)
 
 ### 🚀 Enhancements

--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -131,11 +131,6 @@ class Offsite extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        // Do not proceed if webhook is enabled
-        if ($this->config->isWebhookEnabled()) {
-            return $this->redirect(self::PATH_SUCCESS);
-        }
-
         try {
             $charge = $this->charge->find($charge_id);
 
@@ -154,6 +149,11 @@ class Offsite extends Action
                     __('Payment failed. ' . ucfirst($charge->failure_message) . ', please contact our support
                     if you have any questions.')
                 );
+            }
+
+            // Do not proceed if webhook is enabled
+            if ($this->config->isWebhookEnabled()) {
+                return $this->redirect(self::PATH_SUCCESS);
             }
 
             $payment->setTransactionId($charge->id);

--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -84,11 +84,6 @@ class Offsite extends Action
      */
     public function execute()
     {
-        // Do not proceed if webhook is enabled
-        if ($this->config->isWebhookEnabled()) {
-            return $this->redirect(self::PATH_SUCCESS);
-        }
-
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {
@@ -134,6 +129,11 @@ class Offsite extends Action
             $this->session->restoreQuote();
 
             return $this->redirect(self::PATH_CART);
+        }
+
+        // Do not proceed if webhook is enabled
+        if ($this->config->isWebhookEnabled()) {
+            return $this->redirect(self::PATH_SUCCESS);
         }
 
         try {

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -61,11 +61,6 @@ class Threedsecure extends Action
      */
     public function execute()
     {
-        // Do not proceed if webhook is enabled
-        if ($this->config->isWebhookEnabled()) {
-            return $this->redirect(self::PATH_SUCCESS);
-        }
-
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {
@@ -114,6 +109,11 @@ class Threedsecure extends Action
                 return $this->redirect(self::PATH_CART);
             }
 
+            return $this->redirect(self::PATH_SUCCESS);
+        }
+
+        // Do not proceed if webhook is enabled
+        if ($this->config->isWebhookEnabled()) {
             return $this->redirect(self::PATH_SUCCESS);
         }
 

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -112,11 +112,6 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_SUCCESS);
         }
 
-        // Do not proceed if webhook is enabled
-        if ($this->config->isWebhookEnabled()) {
-            return $this->redirect(self::PATH_SUCCESS);
-        }
-
         try {
             $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
 
@@ -124,6 +119,11 @@ class Threedsecure extends Action
 
             if ($result instanceof Invalid) {
                 throw new \Magento\Framework\Exception\LocalizedException($result->getMessage());
+            }
+
+            // Do not proceed if webhook is enabled
+            if ($this->config->isWebhookEnabled()) {
+                return $this->redirect(self::PATH_SUCCESS);
             }
 
             $order->setState(Order::STATE_PROCESSING);

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "homepage": "https://github.com/omise/omise-magento",
     "authors": [
         {
-          "name": "Omise",
-          "email": "support@omise.co"
+            "name": "Omise",
+            "email": "support@omise.co"
         }
     ],
-    "version": "2.23.0",
+    "version": "2.23.1",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.23.0">
+    <module name="Omise_Payment" setup_version="2.23.1">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
#### 1. Objective

The site was redirected to success page even when payment failed. 

**Related information**:
Related issue(s): [#333](https://github.com/omise/omise-magento/pull/333)

#### 2. Description of change

The logic to check whether webhook is enabled or not is moved just before the try...catch block in `Controller/Callback/Offsite.php` and `Threedsecure.php` so that the failed cases could be handled before checking the webhook status.

#### 3. Quality assurance

- Add an item in the cart, checkout using FPX payment method
- Select Fail options from the payment page
- It will be redirected to the payment failed page

Payment page
![Screen Shot 2565-04-07 at 10 31 51](https://user-images.githubusercontent.com/101558497/162119114-e17563e1-024b-4f8f-a182-b8beb9c72282.png)

Payment failed page
![Screen Shot 2565-04-07 at 10 28 58](https://user-images.githubusercontent.com/101558497/162119120-38de5061-29cb-46df-87ea-68fe742eb5fd.png)

