### PR TITLE
[PLUGINS-1372]: The issue of capturing a 3DS payment from sub-stores has been fixed.

### DIFF
--- a/Gateway/Http/Client/CCPayment.php
+++ b/Gateway/Http/Client/CCPayment.php
@@ -15,7 +15,8 @@ class CCPayment extends AbstractPayment
 
         // if charge_id already exists than action is 'manual capture'
         if (isset($transferObjectBody[self::CHARGE_ID])) {
-            $charge = $this->apiCharge->find($transferObjectBody[self::CHARGE_ID]);
+            $storeId = $transferObjectBody['metadata']['store_id'];
+            $charge = $this->apiCharge->find($transferObjectBody[self::CHARGE_ID], $storeId);
             return [self::CHARGE => $charge->capture()];
         }
 

--- a/Model/Api/Charge.php
+++ b/Model/Api/Charge.php
@@ -4,6 +4,7 @@ namespace Omise\Payment\Model\Api;
 
 use Exception;
 use OmiseCharge;
+use Omise\Payment\Model\Config\Config;
 
 /**
  * @property string $object
@@ -32,15 +33,29 @@ use OmiseCharge;
  */
 class Charge extends BaseObject
 {
+    private $config;
+
+    /**
+     * Injecting dependencies
+     *
+     * @param Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param  string $id
+     * @param  integer|null $storeId
      *
      * @return Omise\Payment\Model\Api\Error|self
      */
-    public function find($id)
+    public function find($id, $storeId = null)
     {
         try {
-            $this->refresh(OmiseCharge::retrieve($id));
+            $this->config->setStoreId($storeId);
+            $this->refresh(OmiseCharge::retrieve($id, $this->config->getPublicKey(), $this->config->getSecretKey()));
         } catch (Exception $e) {
             return new Error([
                 'code'    => 'not_found',

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -17,6 +17,13 @@ class Config
     const MODULE_NAME = 'Omise_Payment';
 
     /**
+     * To fetch value from specific store. It will fetch from default is no storeId passed
+     *
+     * @var integer
+     */
+    private $storeId = null;
+
+    /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
@@ -24,6 +31,17 @@ class Config
     public function __construct(MagentoScopeConfigInterface $scopeConfig)
     {
         $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Change the store ID from the default store to fetch store specific values
+     *
+     * @param  integer|null  $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId = null)
+    {
+        $this->storeId = $storeId;
     }
 
     /**
@@ -36,7 +54,8 @@ class Config
     {
         return $this->scopeConfig->getValue(
             'payment/' . $code . '/' . $field,
-            MagentoScopeInterface::SCOPE_STORE
+            MagentoScopeInterface::SCOPE_STORE,
+            $this->storeId
         );
     }
 


### PR DESCRIPTION
#### 1. Objective
Users were unable to capture payment of the orders ordered via sub-stores in a multi-store setup. Only the payment of orders ordered from main store was successfully captured.

#### 2. Description of change
The code was retrieving the charge by charge ID without passing the public and secret keys. This forced to the app to look for a charge using main store keys. Since different stores have different keys and the charges are specific to the stores, the charge could not be found in the Omise.

Now, the charge will be fetched by passing charge ID along with public and private keys. With this, the app will look into the right account in the Omise for the charge. Some changes are made to the `Config.php` as well so that the app could fetch the configuration value according to the store.

#### 3. Quality assurance
Setup a multi stores in the Magento with 3 stores. In the payment methods, enable credit card payment and set the `Payment Action` to `Authorize Only`. After that obtain public and private key for at least 3 different country and test the following scenarios:

- default store MYR, sub store SGD (Both keys are from different country)
- default store MYR with Omise key A, sub store using MYR with Omise key B (Both keys from Malaysia but different account)
- default store MYR, sub store SGD, sub store THB ( all three keys from different countries)

**🔧 Environments:**

First, I obtained test keys for Omise and tested this in my local machine with following configurations:
- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.0
- PHP version: 7.1.15