### PR TITLE
[PLUGINS-1371]: The issue of Sync order status button has been fixed.…

### DIFF
--- a/Model/Api/Event.php
+++ b/Model/Api/Event.php
@@ -4,6 +4,7 @@ namespace Omise\Payment\Model\Api;
 
 use Exception;
 use OmiseEvent;
+use Omise\Payment\Model\Api\Charge;
 
 /**
  * @property string $object
@@ -18,6 +19,14 @@ use OmiseEvent;
 class Event extends BaseObject
 {
     /**
+     * @param Omise\Payment\Model\Api\Charge $charge
+     */
+    public function __construct(Charge $charge)
+    {
+        $this->charge = $charge;
+    }
+
+    /**
      * @param  string $id
      *
      * @return \Omise\Payment\Model\Api\Error|self
@@ -25,7 +34,7 @@ class Event extends BaseObject
     public function find($id)
     {
         try {
-            $event         = OmiseEvent::retrieve($id);
+            $event = OmiseEvent::retrieve($id);
             $event['data'] = $this->transformDataToObject($event['data']);
             $this->refresh($event);
         } catch (Exception $e) {
@@ -47,7 +56,7 @@ class Event extends BaseObject
     {
         switch ($data['object']) {
             case 'charge':
-                $data = (new Charge)->find($data['id']);
+                $data = $this->charge->find($data['id']);
                 break;
         }
 

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -55,7 +55,7 @@ class Config
         return $this->scopeConfig->getValue(
             'payment/' . $code . '/' . $field,
             MagentoScopeInterface::SCOPE_STORE,
-            $this->storeId
+            $this->storeId ?? null
         );
     }
 

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -17,6 +17,13 @@ class Config
     const MODULE_NAME = 'Omise_Payment';
 
     /**
+     * To fetch value from specific store. It will fetch from default is no storeId passed
+     *
+     * @var integer
+     */
+    private $storeId = null;
+
+    /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
@@ -24,6 +31,17 @@ class Config
     public function __construct(MagentoScopeConfigInterface $scopeConfig)
     {
         $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Change the store ID from the default store to fetch store specific values
+     *
+     * @param  integer|null  $storeId
+     * @return $this
+     */
+    public function setStoreId($storeId = null)
+    {
+        $this->storeId = $storeId;
     }
 
     /**
@@ -36,7 +54,8 @@ class Config
     {
         return $this->scopeConfig->getValue(
             'payment/' . $code . '/' . $field,
-            MagentoScopeInterface::SCOPE_STORE
+            MagentoScopeInterface::SCOPE_STORE,
+            $this->storeId
         );
     }
 

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -58,83 +58,135 @@ class SyncStatus
     public function sync($order)
     {
         $chargeId = $this->helper->getOrderChargeId($order);
-        if ($chargeId) {
-            $charge = \OmiseCharge::retrieve($chargeId, $this->config->getPublicKey(), $this->config->getSecretKey());
-            switch ($charge['status']) {
-                case self::STATUS_SUCCESSFUL:
-                    $refunded_amount = isset($charge['refunded_amount'])
-                        ? $charge['refunded_amount']
-                        : $charge['refunded'];
-                    if ($charge['funding_amount'] == $refunded_amount) {
-                        $order->addStatusHistoryComment(
-                            __(
-                                'Omise: Payment refunded.<br/>An amount %1 %2 has been refunded (manual sync).',
-                                number_format($order->getGrandTotal(), 2, '.', ''),
-                                $order->getOrderCurrencyCode()
-                            )
-                        );
-                    } else {
-                        if ($order->getState() != Order::STATE_COMPLETE
-                            && $order->getState() != Order::STATE_PROCESSING) {
-                            $order->setState(Order::STATE_PROCESSING);
-                            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
 
-                            $invoice = $this->helper->createInvoiceAndMarkAsPaid($order, $charge['id']);
-                            $this->emailHelper->sendInvoiceAndConfirmationEmails($order);
-
-                            $order->addStatusHistoryComment(
-                                __(
-                                    'Omise: Payment successful.<br/>An amount %1 %2 has been paid (manual sync).',
-                                    number_format($order->getGrandTotal(), 2, '.', ''),
-                                    $order->getOrderCurrencyCode()
-                                )
-                            );
-                        }
-                    }
-                    $order->save();
-                    break;
-                case self::STATUS_FAILED:
-                    $this->cancelOrderInvoice($order);
-                    $order->registerCancellation(
-                        __(
-                            'Omise: Payment failed.<br/>%1 (code: %2) (manual sync).',
-                            $charge['failure_message'],
-                            $charge['failure_code']
-                        )
-                    )->save();
-                    $order->save();
-                    break;
-                case self::STATUS_PENDING:
-                    $order->addStatusHistoryComment(
-                        __('Omise: Payment is still in progress.<br/>
-                            You might wait for a moment before click sync the status again or contact Omise support
-                            team at support@omise.co if you have any questions (manual sync).')
-                    );
-                    if ($order->getState() != Order::STATE_PENDING_PAYMENT) {
-                        $order->setState(Order::STATE_PENDING_PAYMENT)->setStatus(Order::STATE_PENDING_PAYMENT);
-                    }
-                    $order->save();
-                    break;
-                case self::STATUS_EXPIRED:
-                    $this->cancelOrderInvoice($order);
-                    $order->registerCancellation(__('Omise: Payment expired. (manual sync).'))
-                      ->save();
-                    break;
-                case self::STATUS_REVERSED:
-                    $order->addStatusHistoryComment(__('Omise: Payment reversed. (manual sync).'));
-                    if ($order->getState() != Order::STATE_CANCELED) {
-                        $order->setState(Order::STATE_CANCELED)->setStatus(Order::STATE_CANCELED);
-                    }
-                    $order->save();
-                    break;
-                default:
-                    throw new LocalizedException(
-                        __('Cannot read the payment status. Please try sync again or contact Omise support team
-                            at support@omise.co if you have any questions.')
-                    );
-            }
-        } else {
+        if (!$chargeId) {
             throw new LocalizedException(__('Unable to find Omise charge ID'));
         }
+
+        // set the store to fetch configuration values from store specific to the order
+        $this->config->setStoreId($order->getStore()->getId());
+        $charge = \OmiseCharge::retrieve($chargeId, $this->config->getPublicKey(), $this->config->getSecretKey());
+
+        switch ($charge['status']) {
+            case self::STATUS_SUCCESSFUL:
+                $this->markPaymentSuccessful($order, $charge);
+                break;
+            case self::STATUS_FAILED:
+                $this->markPaymentFailed($order, $charge);
+                break;
+            case self::STATUS_PENDING:
+                $this->markOrderPending($order);
+                break;
+            case self::STATUS_EXPIRED:
+                $this->markPaymentExpired($order);
+                break;
+            case self::STATUS_REVERSED:
+                $this->markPaymentReversed($order);
+                break;
+            default:
+                throw new LocalizedException(
+                    __('Cannot read the payment status. Please try sync again or contact Omise support team
+                        at support@omise.co if you have any questions.')
+                );
+        }
+    }
+
+    /**
+     * @param Order $order
+     * @param array $charge
+     */
+    private function markPaymentSuccessful($order, $charge)
+    {
+        $refunded_amount = isset($charge['refunded_amount'])
+            ? $charge['refunded_amount']
+            : $charge['refunded'];
+
+        if ($charge['funding_amount'] == $refunded_amount) {
+            $order->addStatusHistoryComment(
+                __(
+                    'Omise: Payment refunded.<br/>An amount %1 %2 has been refunded (manual sync).',
+                    number_format($order->getGrandTotal(), 2, '.', ''),
+                    $order->getOrderCurrencyCode()
+                )
+            );
+
+            $order->save();
+            return;
+        }
+
+        if ($order->getState() != Order::STATE_COMPLETE && $order->getState() != Order::STATE_PROCESSING) {
+            $order->setState(Order::STATE_PROCESSING);
+            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
+
+            $invoice = $this->helper->createInvoiceAndMarkAsPaid($order, $charge['id']);
+            $this->emailHelper->sendInvoiceAndConfirmationEmails($order);
+
+            $order->addStatusHistoryComment(
+                __(
+                    'Omise: Payment successful.<br/>An amount %1 %2 has been paid (manual sync).',
+                    number_format($order->getGrandTotal(), 2, '.', ''),
+                    $order->getOrderCurrencyCode()
+                )
+            );
+        }
+
+        $order->save();
+    }
+
+    /**
+     * @param Order $order
+     * @param array $charge
+     */
+    private function markPaymentFailed($order, $charge)
+    {
+        $this->cancelOrderInvoice($order);
+        $order->registerCancellation(
+            __(
+                'Omise: Payment failed.<br/>%1 (code: %2) (manual sync).',
+                $charge['failure_message'],
+                $charge['failure_code']
+            )
+        )->save();
+        $order->save();
+    }
+
+    /**
+     * @param Order $order
+     */
+    private function markOrderPending($order)
+    {
+        $order->addStatusHistoryComment(
+            __('Omise: Payment is still in progress.<br/>
+                You might wait for a moment before click sync the status again or contact Omise support
+                team at support@omise.co if you have any questions (manual sync).')
+        );
+        if ($order->getState() != Order::STATE_PENDING_PAYMENT) {
+            $order->setState(Order::STATE_PENDING_PAYMENT)->setStatus(Order::STATE_PENDING_PAYMENT);
+        }
+        $order->save();
+    }
+
+    /**
+     * @param Order $order
+     */
+    private function markPaymentExpired($order)
+    {
+        $this->cancelOrderInvoice($order);
+        $order->registerCancellation(__('Omise: Payment expired. (manual sync).'))
+            ->save();
+    }
+
+    /**
+     * @param Order $order
+     */
+    private function markPaymentReversed($order)
+    {
+        $order->addStatusHistoryComment(__('Omise: Payment reversed. (manual sync).'));
+
+        if ($order->getState() != Order::STATE_CANCELED) {
+            $order->setState(Order::STATE_CANCELED)->setStatus(Order::STATE_CANCELED);
+        }
+
+        $order->save();
     }
 }


### PR DESCRIPTION
Jira Ticket: https://omise.atlassian.net/browse/FRON-1371

#### 1. Objective
Fix the issue with the `Sync Order Status` button in the orders page of the admin panel.

#### 2. Description of change
The system was searching for a charge in the default store where it should have been searching in the store from where the order was ordered.

Now, the charge will be fetched by passing charge ID along with public and private keys. With this, the app will look into the right account in the Omise for the charge. Some refactoring is done in the SyncStatus.php class.

#### 3. Quality assurance
Setup a multi stores in the Magento with 3 stores. In the payment methods, enable credit card payment and set the Payment Action to Authorize Only. After that obtain public and private key for at least 3 different country and test the following scenarios:

- default store MYR, sub store SGD (Both keys are from different country)
- default store MYR with Omise key A, sub store using MYR with Omise key B (Both keys from Malaysia but different account)
- default store MYR, sub store SGD, sub store THB ( all three keys from different countries)

After creating an order with status `Payment Pending`:
- Go to the specific order page
- Look for the charge ID and search it in the Omise dashboard
- Go to the charge page and mark it as
  - Paid
  - Failed
- On Mangeto dashboard, go the order page
- Click `Sync Order Status` button

The status should change from `Payment Pending` to `Processing` and a invoice should be created.

To test refund
- Take any paid order and copy the charge ID
- Search for the charge ID in the Omise dashboard
- Go to the charge page and refund the charge
- On Magento dashboard, go to the order page
- Click `Sync Order Status` button
- Go to the `Comments History`

You should see a comment in following format

> Omise: Payment refunded.
> An amount 4.00 MYR has been refunded (manual sync).


🔧 Environments:

First, I obtained test keys for Omise and tested this in my local machine with following configurations:

Platform version: Magento CE 2.4.3
Omise plugin version: Omise-Magento 2.23.0
PHP version: 7.1.15