### PR TITLE
[FRON-1432]: Preventing Omise plugin to initialize when public and secret keys are not present

### DIFF
--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -33,7 +33,7 @@ class Capabilities extends BaseObject
         $this->config->setStoreId($storeId);
 
         // Initialize only if both keys are present
-        if(!$this->config->getPublicKey() || !$this->config->getSecretKey()) {
+        if (!$this->config->getPublicKey() || !$this->config->getSecretKey()) {
             return false;
         }
 

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -4,13 +4,39 @@ namespace Omise\Payment\Model\Api;
 
 use Magento\Framework\Exception\LocalizedException;
 use OmiseCapabilities;
+use Omise\Payment\Model\Config\Config;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Capabilities extends BaseObject
 {
     private $capabilities;
 
-    public function __construct()
+    /**
+     * Injecting dependencies
+     * @param \Omise\Payment\Model\Config\Config $config
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     */
+    public function __construct(Config $config, StoreManagerInterface $storeManager)
     {
+        $this->config = $config;
+        $this->storeManager = $storeManager;
+
+        $this->initOmise();
+    }
+
+    /**
+     * Initialize the Omise plugin
+     */
+    private function initOmise()
+    {
+        $storeId = $this->storeManager->getStore()->getId();
+        $this->config->setStoreId($storeId);
+
+        // Initialize only if both keys are present
+        if(!$this->config->getPublicKey() || !$this->config->getSecretKey()) {
+            return false;
+        }
+
         try {
             $this->capabilities = OmiseCapabilities::retrieve();
         } catch (\Exception $e) {

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -52,11 +52,11 @@ class Config
      */
     public function getValue($field, $code = self::CODE)
     {
-        return $this->scopeConfig->getValue(
+        return trim($this->scopeConfig->getValue(
             'payment/' . $code . '/' . $field,
             MagentoScopeInterface::SCOPE_STORE,
             $this->storeId ?? null
-        );
+        ));
     }
 
     /**


### PR DESCRIPTION
#### 1. Objective

Fix the issue on checkout page when keys are not configured. In multi-store environment, if a merchant uses Omise payment gateway for one store only and another payment gateway (like Stripe) for other sub-store, the checkout page throws an error when merchant does not configure Omise keys for the sub-store in which they not using Omise payment gateway.

Jira Ticket:
https://omise.atlassian.net/browse/FRON-1432

#### 2. Description of change

A method `initOmise` is added which gets called in the `construct` method of `/omise-magento/Model/Api/Capabilities.php`. The `initOmise` method will fetch the public and secret keys of the current store. It stops the initialization of the plugin if one of the keys is not configured.

#### 3. Quality assurance

Set up two stores, let say one for Malaysia and another for Singapore. 

**Default store (MY),**
- Credit Debit cards (Stripe)
- FPX (Stripe)

**Sub-store (SG)**
- Paynow (Omise)
- Credit Debit cards (Omise)

After the setup, go to the store where Omise payment is not setup. Try adding an item to the cart and go to the checkout page. Before the changes of this PR, you should see blank page or an error page. Switching back to this change, you should see a checkout page and should be able to continue the process.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15