### PR TITLE
[FRON-1435]: Incorrect webhook endpoint being displayed has been fixed.

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -49,7 +49,7 @@ class Webhook extends Field
 
         // if $storeId is not null then we are in the sub-store view.
         // We want to set the current store so that we get desired base URL
-        if($storeId) {
+        if ($storeId) {
             $this->storeManager->setCurrentStore($storeId);
         }
 

--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -4,8 +4,9 @@ namespace Omise\Payment\Block\Adminhtml\System\Config\Form\Field;
 
 use Magento\Backend\Block\Template\Context;
 use Magento\Config\Block\System\Config\Form\Field;
-use Magento\Framework\Url;
 use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\Request\Http;
 
 class Webhook extends Field
 {
@@ -21,15 +22,18 @@ class Webhook extends Field
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\Framework\Url                  $urlHelper
-     * @param array                                   $data
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\Request\Http $http
+     * @param array $data
      */
     public function __construct(
         Context $context,
-        Url     $urlHelper,
+        StoreManagerInterface $storeManager,
+        Http $request,
         array   $data = []
     ) {
-        $this->urlHelper = $urlHelper;
+        $this->storeManager = $storeManager;
+        $this->request = $request;
         parent::__construct($context, $data);
     }
 
@@ -40,6 +44,15 @@ class Webhook extends Field
      */
     protected function _getElementHtml(AbstractElement $element)
     {
-        return $this->urlHelper->getRouteUrl(self::URI, ['_secure' => true]);
+        // fetch the store ID from the URL. The value will be NULL if the storeview is a default view.
+        $storeId = $this->request->getParam('website') ?? $this->request->getParam('store');
+
+        // if $storeId is not null then we are in the sub-store view.
+        // We want to set the current store so that we get desired base URL
+        if($storeId) {
+            $this->storeManager->setCurrentStore($storeId);
+        }
+
+        return $this->storeManager->getStore()->getBaseUrl() . self::URI;
     }
 }


### PR DESCRIPTION
#### 1. Objective

Issue of incorrect web-hook endpoint being displayed for the sub-store in the admin configuration page has been fixed. The users of the plugin was copying the webhook endpoint from our plugin and save it to the Omise dashboard. Plugin displayed incorrect webhook endpoint for sub-store. So, simply copying and pasting it to the Omise dashboard would result on webhook not working.

**Jira Ticket**:
https://omise.atlassian.net/browse/FRON-1435

#### 2. Description of change

The class `Magento\Framework\Url` and corresponding code used to create the URL has been removed. The class `Magento\Store\Model\StoreManagerInterface` is used to get the base URL specific to the sub-stores. The class `Magento\Framework\App\Request\Http` is used to get the store ID from the URL for a sub-store.

If the store configuration page is set to a sub-store then we set the the current store by passing the store ID fetched from the URL to the `setCurrentStore()` of the `StoreManagerInterface`. If the store configuration page is the default one then skip the `setCurrentStore()` part because by default the store is set to the default.

Examples of the URL for the store configuration page
- Default store
- http://127.0.0.1:81/admin/admin/system_config/edit/section/payment/key/806c9851e5dc6fe6d48745779f53d5a59820fd07262753a7851dbd0785cad7d4/

- Sub store (Singapore): Website view
- http://127.0.0.1:81/admin/admin/system_config/edit/section/payment/key/806c9851e5dc6fe6d48745779f53d5a59820fd07262753a7851dbd0785cad7d4/website/2/
- Sub store (Singapore): Store view
- http://127.0.0.1:81/admin/admin/system_config/edit/section/payment/key/806c9851e5dc6fe6d48745779f53d5a59820fd07262753a7851dbd0785cad7d4/store/2/

- Sub store (Thailand): Website view
- http://127.0.0.1:81/admin/admin/system_config/edit/section/payment/key/806c9851e5dc6fe6d48745779f53d5a59820fd07262753a7851dbd0785cad7d4/website/3/
- Sub store (Thailand): Store view
- http://127.0.0.1:81/admin/admin/system_config/edit/section/payment/key/806c9851e5dc6fe6d48745779f53d5a59820fd07262753a7851dbd0785cad7d4/store/3/

#### 3. Quality assurance

- Go to the dashboard
- Click on the stores menu
- Click on the Configuration sub-menu under Settings
- Click on the Sales > Payment methods
- Expand the Omise Payment Gateway plugin
- Go to the webhook field. You will see endpoint like `http://127.0.0.1:81/my/omise/callback/webhook`
- Scroll to the top of the page and change the store view to a sub-store.
- Go to the webhook field again. You will see a different endpoint. For example if you have setup a sub-store for Singapore and set the storeview `Code` as `sg` then you will see the webhook endpoint as `http://127.0.0.1:81/sg/omise/callback/webhook`

**🔧 Environments:**
- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15