### PR TITLE
[APM2-715] Move OCBC Pao as standalone payment

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -18,6 +18,7 @@ use Omise\Payment\Model\Config\Fpx;
 use Omise\Payment\Model\Config\Alipayplus;
 use Omise\Payment\Model\Config\Mobilebanking;
 use Omise\Payment\Model\Config\Rabbitlinepay;
+use Omise\Payment\Model\Config\Ocbcpao;
 use Magento\Framework\Exception\LocalizedException;
 use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseEmailHelper;
@@ -209,6 +210,9 @@ class Offsite extends Action
                         break;
                     case Rabbitlinepay::CODE:
                         $dispPaymentMethod = "Rabbit LINE Pay";
+                        break;
+                    case Ocbcpao::CODE:
+                        $dispPaymentMethod = "OCBC PayAnyone";
                         break;
                 }
                 

--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -212,7 +212,7 @@ class Offsite extends Action
                         $dispPaymentMethod = "Rabbit LINE Pay";
                         break;
                     case Ocbcpao::CODE:
-                        $dispPaymentMethod = "OCBC PayAnyone";
+                        $dispPaymentMethod = "OCBC Pay Anyone";
                         break;
                 }
                 

--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -32,6 +32,7 @@ class OrderSyncStatus
         "omise_offsite_internetbanking",
         "omise_offsite_mobilebanking",
         "omise_offsite_rabbitlinepay",
+        "omise_offsite_ocbcpao",
     ];
 
     /**

--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -18,6 +18,7 @@ use Omise\Payment\Model\Config\Truemoney;
 use Omise\Payment\Model\Config\Alipayplus;
 use Omise\Payment\Model\Config\Mobilebanking;
 use Omise\Payment\Model\Config\Rabbitlinepay;
+use Omise\Payment\Model\Config\Ocbcpao;
 
 use Omise\Payment\Observer\ConveniencestoreDataAssignObserver;
 use Omise\Payment\Observer\FpxDataAssignObserver;
@@ -224,6 +225,12 @@ class APMBuilder implements BuilderInterface
             case Rabbitlinepay::CODE:
                 $paymentInfo[self::SOURCE] = [
                     self::SOURCE_TYPE => 'rabbit_linepay'
+                ];
+                break;
+            case Ocbcpao::CODE:
+                $paymentInfo[self::SOURCE] = [
+                    self::SOURCE_TYPE => 'mobile_banking_ocbc_pao',
+                    self::PLATFORM_TYPE => $this->helper->getPlatformType(),
                 ];
                 break;
         }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -18,6 +18,7 @@ use Omise\Payment\Model\Config\Tesco;
 use Omise\Payment\Model\Config\Alipayplus;
 use Omise\Payment\Model\Config\Mobilebanking;
 use Omise\Payment\Model\Config\Rabbitlinepay;
+use Omise\Payment\Model\Config\Ocbcpao;
 use Omise\Payment\Model\Config\Cc as Config;
 
 use SimpleXMLElement;
@@ -192,6 +193,7 @@ class OmiseHelper extends AbstractHelper
                 Alipayplus::TOUCHNGO_CODE,
                 Mobilebanking::CODE,
                 Rabbitlinepay::CODE,
+                Ocbcpao::CODE,
             ]
         );
     }

--- a/Model/Config/Ocbcpao.php
+++ b/Model/Config/Ocbcpao.php
@@ -1,0 +1,12 @@
+<?php
+namespace Omise\Payment\Model\Config;
+
+use Omise\Payment\Model\Config\Config;
+
+class Ocbcpao extends Config
+{
+    /**
+     * @var string
+     */
+    const CODE = 'omise_offsite_ocbcpao';
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -606,11 +606,11 @@
                     </field>
                 </group>
                 <group id="omise_offsite_ocbcpao" translate="label" sortOrder="490" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable OCBC PayAnyone Payment</label>
-                    <comment>Enable customers to pay using OCBC PayAnyone payment method</comment>
+                    <label>Enable OCBC Pay Anyone Payment</label>
+                    <comment>Enable customers to pay using OCBC Pay Anyone payment method</comment>
                     <field id="active" translate="label comment" type="select" sortOrder="491" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
-                        <comment>Enable OCBC PayAnyone payment method.</comment>
+                        <comment>Enable OCBC Pay Anyone payment method.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_ocbcpao/active</config_path>
                     </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -605,6 +605,35 @@
                         </depends>
                     </field>
                 </group>
+                <group id="omise_offsite_ocbcpao" translate="label" sortOrder="490" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable OCBC PayAnyone Payment</label>
+                    <comment>Enable customers to pay using OCBC PayAnyone payment method</comment>
+                    <field id="active" translate="label comment" type="select" sortOrder="491" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable/Disable</label>
+                        <comment>Enable OCBC PayAnyone payment method.</comment>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>payment/omise_offsite_ocbcpao/active</config_path>
+                    </field>
+                    <field id="title" translate="label" type="text" sortOrder="492" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Title</label>
+                        <comment>This controls the title which the user sees during checkout.</comment>
+                        <config_path>payment/omise_offsite_ocbcpao/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="493" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_offsite_ocbcpao/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If not set to all, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="494" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_offsite_ocbcpao/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
+                </group>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -246,6 +246,19 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_rabbitlinepay>
+
+            <omise_offsite_ocbcpao>
+                <active>0</active>
+                <title>OCBC PayAnyone</title>
+                <model>OmiseOcbcpaoAdapter</model>
+                <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
+                <can_use_checkout>1</can_use_checkout>
+                <can_authorize>1</can_authorize>
+                <can_capture>1</can_capture>
+                <can_review_payment>1</can_review_payment>
+                <payment_action>authorize_capture</payment_action>
+            </omise_offsite_ocbcpao>
         </payment>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -254,7 +254,6 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <is_gateway>1</is_gateway>
                 <can_initialize>1</can_initialize>
                 <can_use_checkout>1</can_use_checkout>
-                <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -249,7 +249,7 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
 
             <omise_offsite_ocbcpao>
                 <active>0</active>
-                <title>OCBC PayAnyone</title>
+                <title>OCBC Pay Anyone</title>
                 <model>OmiseOcbcpaoAdapter</model>
                 <is_gateway>1</is_gateway>
                 <can_initialize>1</can_initialize>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -814,7 +814,55 @@
             <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Rabbitlinepay::CODE</argument>
         </arguments>
     </virtualType>
-    <!-- /Rabbitlinepay ::Value Handler Pool-->
+    <!-- /Rabbitlinepay :: Value Handler Pool-->
+ 
+    <!--  Ocbc Pao payment solution-->
+    <virtualType name="OmiseOcbcpaoAdapter" type="Magento\Payment\Model\Method\Adapter">
+        <arguments>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Ocbcpao::CODE</argument>
+            <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
+            <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseAPMOcbcPaoValueHandlerPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseAPMOcbcpaoValidatorPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- Ocbc Pao :: Value Handler Pool -->
+    <virtualType name="OmiseAPMOcbcpaoValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="default" xsi:type="string">OmiseAPMOcbcpaoConfigValueHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMOcbcpaoValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseAPMOcbcpaoCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMOcbcpaoCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseAPMOcbcpaoConfig</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMOcbcpaoConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+        <arguments>
+            <argument name="configInterface" xsi:type="object">OmiseAPMOcbcpaoConfig</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="OmiseAPMOcbcpaoConfig" type="Magento\Payment\Gateway\Config\Config">
+        <arguments>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\Ocbcpao::CODE</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Ocbc Pao :: Value Handler Pool-->
 
     <!--  Convenience Store payment solution-->
     <virtualType name="OmiseConveniencestoreAdapter" type="Magento\Payment\Model\Method\Adapter">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -822,7 +822,7 @@
             <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Ocbcpao::CODE</argument>
             <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form</argument>
             <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
-            <argument name="valueHandlerPool" xsi:type="object">OmiseAPMOcbcPaoValueHandlerPool</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseAPMOcbcpaoValueHandlerPool</argument>
             <argument name="validatorPool" xsi:type="object">OmiseAPMOcbcpaoValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">OmiseAPMCommandPool</argument>
         </arguments>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -80,6 +80,9 @@
                                                                         <item name="omise_offsite_rabbitlinepay" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
+                                                                        <item name="omise_offsite_ocbcpao" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
+                                                                        </item>
                                                                     </item>
                                                                 </item>
                                                             </item>

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -131,6 +131,16 @@
     background: url('../images/scb_easy.png');
 }
 
+/** OCBC PAO **/
+div.ocbc_pao {
+    background-image: url('../images/payment_ocbc_pao.png');
+    width: 30px;
+    height: 30px;
+    float: right;
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
 div.fpx {
     background: url('../images/fpx.svg');
     width: 68px;

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -131,11 +131,6 @@
     background: url('../images/scb_easy.png');
 }
 
-/** OCBC PAO **/
-#omise_offsite_mobilebankingForm img.ocbc_pao {
-    background-image: url('../images/payment_ocbc_pao.png');
-}
-
 div.fpx {
     background: url('../images/fpx.svg');
     width: 68px;

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-mobilebanking-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-mobilebanking-method.js
@@ -20,7 +20,7 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_offsite_mobilebanking',
-            restrictedToCurrencies: ['thb', 'sgd'],
+            restrictedToCurrencies: ['thb'],
             providers: [
                 {
                     id: "mobile_banking_kbank",
@@ -45,14 +45,6 @@ define(
                     logo: 'bay',
                     currencies: ['thb'],
                     active: false
-                },
-                {
-                    id: "mobile_banking_ocbc_pao",
-                    title: 'OCBC Pay Anyone',
-                    code: 'ocbc_pao',
-                    logo: 'ocbc_pao',
-                    currencies: ['sgd'],
-                    active: true
                 },
             ],
 

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-ocbcpao-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-ocbcpao-method.js
@@ -1,0 +1,27 @@
+define(
+    [
+        'ko',
+        'Omise_Payment/js/view/payment/omise-offsite-method-renderer',
+        'Magento_Checkout/js/view/payment/default',
+        'Magento_Checkout/js/model/quote',
+    ],
+    function (
+        ko,
+        Base,
+        Component,
+        quote
+    ) {
+        'use strict';
+
+        return Component.extend(Base).extend({
+            defaults: {
+                template: 'Omise_Payment/payment/offsite-common-form'
+            },
+
+            isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
+
+            code: 'omise_offsite_ocbcpao',
+            restrictedToCurrencies: ['sgd']
+        });
+    }
+);

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-ocbcpao-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-ocbcpao-method.js
@@ -15,7 +15,7 @@ define(
 
         return Component.extend(Base).extend({
             defaults: {
-                template: 'Omise_Payment/payment/offsite-common-form'
+                template: 'Omise_Payment/payment/offsite-ocbcpao-form'
             },
 
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),

--- a/view/frontend/web/js/view/payment/omise.js
+++ b/view/frontend/web/js/view/payment/omise.js
@@ -28,6 +28,7 @@ define(
             'offsite-touchngo',
             'offsite-mobilebanking',
             'offsite-rabbitlinepay',
+            'offsite-ocbcpao',
         ];
 
         METHOD_RENDERERS.forEach(rendererName => {

--- a/view/frontend/web/template/payment/offsite-common-form.html
+++ b/view/frontend/web/template/payment/offsite-common-form.html
@@ -1,0 +1,54 @@
+<div class="payment-method"
+    data-bind="css: {'_active': (getCode() == isChecked())}, visible: isActive()">
+    <div class="payment-method-title field choice">
+        <input type="radio" name="payment[method]" class="radio"
+            data-bind="attr: {
+               'id': getCode()
+               },
+               value: getCode(),
+               checked: isChecked,
+               click: selectPaymentMethod,
+               visible: isRadioButtonVisible(),
+               enable: isActive()" />
+        <label data-bind="attr: {'for': getCode()}" class="label">
+            <span data-bind="text: getTitle()"></span>
+        </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="payment-method-content">
+        <!-- ko foreach: getRegion('messages') -->
+        <!-- ko template: getTemplate() -->
+        <!-- /ko -->
+        <!--/ko-->
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() -->
+            <!-- /ko -->
+            <!--/ko-->
+        </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
+        <div class="actions-toolbar">
+            <div class="primary">
+                <button class="action primary checkout" type="submit"
+                    disabled="disabled"
+                    data-bind="
+                        click: placeOrder,
+                        attr: {title: $t('Place Order')},
+                        css: {disabled: !isPlaceOrderActionAllowed()},
+                        enable: (getCode() == isChecked())">
+                    <span data-bind="i18n: 'Place Order'"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/view/frontend/web/template/payment/offsite-ocbcpao-form.html
+++ b/view/frontend/web/template/payment/offsite-ocbcpao-form.html
@@ -11,7 +11,7 @@
                visible: isRadioButtonVisible(),
                enable: isActive()" />
         <label data-bind="attr: {'for': getCode()}" class="label">
-            <span data-bind="text: getTitle()"></span>
+            <span data-bind="text: getTitle()"></span><div class="ocbc_pao"></div>
         </label>
         <div data-bind="visible: isSandboxOn()" class="page messages">
             <div role="alert" class="messages">


### PR DESCRIPTION
#### 1. Objective

Currently OCBC requested us to move OCBC PAO out from under Mobile Banking options to standalone payment
So this PR will make a new payment option `OCBC PAO` for magento and remove it from mobile banking

This section will be used in the release notes. 

**Related information**:
Related issue(s): https://omise.atlassian.net/browse/APM2-715

#### 2. Description of change

- add new offsite payment for `ocbc pao`
- remove `ocbc pao` from mobile banking 
- set mobile banking display only when checkout is THB

#### 3. Quality assurance

OCBC PAO can make a charge with IOS or Android successfully

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3
- **Omise plugin version**: Omise-Magento 2.23.2
- **Omise plugin version**: Omise-php v2.13
- **PHP version**: 7.1

**✏️ Details:**

- Using PSP SG for testing
- Enable `mobile_banking_ocbc_pao` source type
- Enable OCBC PAO option on magento admin panel
- make a pay with  OCBC PAO
- charge should created successfully 

#### 4. Impact of the change

<img width="999" alt="image" src="https://user-images.githubusercontent.com/97080697/166881663-610bd285-e93d-41a6-9f2b-8c329e664a45.png">

![image](https://user-images.githubusercontent.com/97080697/166882265-b9980b67-1ee3-4253-9c90-6dd60a77cade.png)

![image](https://user-images.githubusercontent.com/97080697/166882299-0bc48eb9-5689-4c1d-90ff-9b79d3594389.png)

![image](https://user-images.githubusercontent.com/97080697/166882338-da388edf-da4d-436e-89cd-863de3dfbbc3.png)



#### 5. Priority of change

Normal

#### 6. Additional Notes

Any further information that you would like to add.