### PR TITLE
[FRON-1442]: Issue of new order email not being sent when order is placed with non omise payment method has been fixed.

### DIFF
--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -310,15 +310,15 @@ class OmiseHelper extends AbstractHelper
      */
     public function isOmisePayment($paymentMethod)
     {
-        return in_array(
-            $paymentMethod,
-            array_merge(
-                array_merge($this->offsitePaymentMethods, $this->offsitePaymentImageCode),
-                [
-                    Config::CODE,
-                    Conveniencestore::CODE
-                ]
-            )
+        $offsitePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offsitePaymentImageCode);
+        $omisePaymentMethods = array_merge(
+            $offsitePaymentMethods,
+            [
+                Config::CODE,
+                Conveniencestore::CODE
+            ]
         );
+
+        return in_array($paymentMethod, $omisePaymentMethods);
     }
 }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -32,6 +32,37 @@ class OmiseHelper extends AbstractHelper
     protected $header;
 
     /**
+     * @var array
+     */
+    private $offsitePaymentMethods = [
+        Alipay::CODE,
+        Internetbanking::CODE,
+        Installment::CODE,
+        Truemoney::CODE,
+        Pointsciti::CODE,
+        Fpx::CODE,
+        Alipayplus::ALIPAY_CODE,
+        Alipayplus::ALIPAYHK_CODE,
+        Alipayplus::DANA_CODE,
+        Alipayplus::GCASH_CODE,
+        Alipayplus::KAKAOPAY_CODE,
+        Alipayplus::TOUCHNGO_CODE,
+        Mobilebanking::CODE,
+        Rabbitlinepay::CODE,
+    ];
+
+    /**
+     * Payment method payable by image code
+     *
+     * @var array
+     */
+    private $offsitePaymentImageCode = [
+        Paynow::CODE,
+        Promptpay::CODE,
+        Tesco::CODE
+    ];
+
+    /**
      * @var Config
      */
     protected $config;
@@ -158,14 +189,7 @@ class OmiseHelper extends AbstractHelper
      */
     public function isPayableByImageCode($paymentMethod)
     {
-        return in_array(
-            $paymentMethod,
-            [
-                Paynow::CODE,
-                Promptpay::CODE,
-                Tesco::CODE
-            ]
-        );
+        return in_array($paymentMethod, $this->offsitePaymentImageCode);
     }
 
     /**
@@ -176,25 +200,7 @@ class OmiseHelper extends AbstractHelper
      */
     public function isOffsitePayment($paymentMethod)
     {
-        return in_array(
-            $paymentMethod,
-            [
-                Alipay::CODE,
-                Internetbanking::CODE,
-                Installment::CODE,
-                Truemoney::CODE,
-                Pointsciti::CODE,
-                Fpx::CODE,
-                Alipayplus::ALIPAY_CODE,
-                Alipayplus::ALIPAYHK_CODE,
-                Alipayplus::DANA_CODE,
-                Alipayplus::GCASH_CODE,
-                Alipayplus::KAKAOPAY_CODE,
-                Alipayplus::TOUCHNGO_CODE,
-                Mobilebanking::CODE,
-                Rabbitlinepay::CODE,
-            ]
-        );
+        return in_array($paymentMethod, $this->offsitePaymentMethods);
     }
 
     /**
@@ -306,27 +312,13 @@ class OmiseHelper extends AbstractHelper
     {
         return in_array(
             $paymentMethod,
-            [
-                Alipay::CODE,
-                Internetbanking::CODE,
-                Installment::CODE,
-                Truemoney::CODE,
-                Pointsciti::CODE,
-                Fpx::CODE,
-                Alipayplus::ALIPAY_CODE,
-                Alipayplus::ALIPAYHK_CODE,
-                Alipayplus::DANA_CODE,
-                Alipayplus::GCASH_CODE,
-                Alipayplus::KAKAOPAY_CODE,
-                Alipayplus::TOUCHNGO_CODE,
-                Mobilebanking::CODE,
-                Rabbitlinepay::CODE,
-                Paynow::CODE,
-                Promptpay::CODE,
-                Tesco::CODE,
-                Config::CODE,
-                Conveniencestore::CODE,
-            ]
+            array_merge(
+                array_merge($this->offsitePaymentMethods, $this->offsitePaymentImageCode),
+                [
+                    Config::CODE,
+                    Conveniencestore::CODE
+                ]
+            )
         );
     }
 }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -19,6 +19,7 @@ use Omise\Payment\Model\Config\Alipayplus;
 use Omise\Payment\Model\Config\Mobilebanking;
 use Omise\Payment\Model\Config\Rabbitlinepay;
 use Omise\Payment\Model\Config\Cc as Config;
+use Omise\Payment\Model\Config\Conveniencestore;
 
 use SimpleXMLElement;
 use DOMDocument;
@@ -291,5 +292,41 @@ class OmiseHelper extends AbstractHelper
 
         $invoice->setTransactionId($chargeId)->pay()->save();
         return $invoice;
+    }
+
+    /**
+     * This method checks and return TRUE if $paymentMethod is
+     * offered by our Omise payment plugin otherwise returns false.
+     *
+     * @param string $paymentMethod
+     *
+     * @return boolean
+     */
+    public function isOmisePayment($paymentMethod)
+    {
+        return in_array(
+            $paymentMethod,
+            [
+                Alipay::CODE,
+                Internetbanking::CODE,
+                Installment::CODE,
+                Truemoney::CODE,
+                Pointsciti::CODE,
+                Fpx::CODE,
+                Alipayplus::ALIPAY_CODE,
+                Alipayplus::ALIPAYHK_CODE,
+                Alipayplus::DANA_CODE,
+                Alipayplus::GCASH_CODE,
+                Alipayplus::KAKAOPAY_CODE,
+                Alipayplus::TOUCHNGO_CODE,
+                Mobilebanking::CODE,
+                Rabbitlinepay::CODE,
+                Paynow::CODE,
+                Promptpay::CODE,
+                Tesco::CODE,
+                Config::CODE,
+                Conveniencestore::CODE,
+            ]
+        );
     }
 }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -56,7 +56,7 @@ class OmiseHelper extends AbstractHelper
      *
      * @var array
      */
-    private $offsitePaymentImageCode = [
+    private $offlinePaymentMethods = [
         Paynow::CODE,
         Promptpay::CODE,
         Tesco::CODE
@@ -189,7 +189,7 @@ class OmiseHelper extends AbstractHelper
      */
     public function isPayableByImageCode($paymentMethod)
     {
-        return in_array($paymentMethod, $this->offsitePaymentImageCode);
+        return in_array($paymentMethod, $this->offlinePaymentMethods);
     }
 
     /**
@@ -310,9 +310,9 @@ class OmiseHelper extends AbstractHelper
      */
     public function isOmisePayment($paymentMethod)
     {
-        $offsitePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offsitePaymentImageCode);
+        $offsiteOfflinePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offlinePaymentMethods);
         $omisePaymentMethods = array_merge(
-            $offsitePaymentMethods,
+            $offsiteOfflinePaymentMethods,
             [
                 Config::CODE,
                 Conveniencestore::CODE

--- a/Observer/PaymentCreationObserver.php
+++ b/Observer/PaymentCreationObserver.php
@@ -36,13 +36,17 @@ class PaymentCreationObserver implements ObserverInterface
         $order   = $observer->getEvent()->getOrder();
         $paymentMethod = $order->getPayment()->getMethod();
 
-        // We will send confirmation emails manually, so we disable this.
-        $order->setCanSendNewEmailFlag(false);
+        // Disable only if the payment method is offered by Omise
+        if ($this->_helper->isOmisePayment($paymentMethod)) {
+            // We will send confirmation emails manually
+            $order->setCanSendNewEmailFlag(false);
+        }
 
         // Offline QR code payment emails
         if ($this->_helper->isPayableByImageCode($paymentMethod)) {
             $this->_email->sendEmail($order);
         }
+
         return $this;
     }
 }


### PR DESCRIPTION
#### 1. Objective

Fix the issue of new order email not being sent when order is placed with non omise payment method.

**Jira Ticket**: https://omise.atlassian.net/browse/FRON-1442

#### 2. Description of change

The plugin will set `setCanSendNewEmailFlag` to false only if the payment method is offered by our plugin. Added a new method `isOmisePayment` in the `OmiseHelper` class that will check the passed payment method to an array of payment methods provided by our plugin. If the payment method is non Omise payment method then `isOmisePayment` will return false and the code does nothing for `setCanSendNewEmailFlag` method and vice versa.

#### 3. Quality assurance

Configure email in the Magento. Go to the frontend and checkout with an item. Choose a non Omise payment method like Bank Transfer Payment, Cash on Delivery or Stripe payment methods. You should receive a new order email.

**🔧 Environments:**

- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15