### PR TITLE
[FRON-1465]: Check for the validity of the public and secret keys in the payment section when merchants adds them.

### DIFF
--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -5,7 +5,6 @@ namespace Omise\Payment\Model\Api;
 use Magento\Framework\Exception\LocalizedException;
 use OmiseCapabilities;
 use Omise\Payment\Model\Config\Config;
-use Magento\Store\Model\StoreManagerInterface;
 
 class Capabilities extends BaseObject
 {
@@ -16,31 +15,27 @@ class Capabilities extends BaseObject
      * @param \Omise\Payment\Model\Config\Config $config
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      */
-    public function __construct(Config $config, StoreManagerInterface $storeManager)
+    public function __construct(Config $config)
     {
         $this->config = $config;
-        $this->storeManager = $storeManager;
 
-        $this->initOmise();
+        $this->init();
     }
 
     /**
      * Initialize the Omise plugin
      */
-    private function initOmise()
+    private function init()
     {
-        $storeId = $this->storeManager->getStore()->getId();
-        $this->config->setStoreId($storeId);
-
-        // Initialize only if both keys are present
-        if (!$this->config->getPublicKey() || !$this->config->getSecretKey()) {
-            return false;
+        if (!$this->config->canInitialize()) {
+            return;
         }
 
         try {
             $this->capabilities = OmiseCapabilities::retrieve();
         } catch (\Exception $e) {
-            throw new LocalizedException(__('unable to load OmiseCapabilities api'));
+            // throw new LocalizedException(__('unable to load OmiseCapabilities api'));
+            throw new \Exception($e->getMessage());
         }
     }
 

--- a/Model/Api/Capabilities.php
+++ b/Model/Api/Capabilities.php
@@ -34,8 +34,7 @@ class Capabilities extends BaseObject
         try {
             $this->capabilities = OmiseCapabilities::retrieve();
         } catch (\Exception $e) {
-            // throw new LocalizedException(__('unable to load OmiseCapabilities api'));
-            throw new \Exception($e->getMessage());
+            throw new LocalizedException(__('unable to load OmiseCapabilities api'));
         }
     }
 

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -4,9 +4,20 @@ namespace Omise\Payment\Model\Api;
 
 use Exception;
 use OmiseCustomer;
+use Omise\Payment\Model\Config\Config;
 
 class Customer extends BaseObject
 {
+    /**
+     * Injecting dependencies
+     * @param \Omise\Payment\Model\Config\Config $config
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param  string $id
      *
@@ -14,6 +25,9 @@ class Customer extends BaseObject
      */
     public function find($id)
     {
+        if (!$this->config->canInitialize()) {
+            return;
+        }
         try {
             $this->refresh(OmiseCustomer::retrieve($id));
         } catch (Exception $e) {

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace Omise\Payment\Model\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface as MagentoScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface as MagentoScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Config
 {
@@ -28,9 +30,29 @@ class Config
      */
     protected $scopeConfig;
 
-    public function __construct(MagentoScopeConfigInterface $scopeConfig)
+    private $canInitialize = false;
+
+    public function __construct(MagentoScopeConfigInterface $scopeConfig, StoreManagerInterface $storeManager)
     {
         $this->scopeConfig = $scopeConfig;
+        $this->storeManager = $storeManager;
+        $this->init();
+    }
+
+    private function init()
+    {
+        $storeId = $this->storeManager->getStore()->getId();
+        $this->setStoreId($storeId);
+
+        // Initialize only if both keys are present
+        if ($this->getPublicKey() && $this->getSecretKey()) {
+            $this->canInitialize = true;
+        }
+    }
+
+    public function canInitialize()
+    {
+        return $this->canInitialize;
     }
 
     /**

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -5,6 +5,8 @@ namespace Omise\Payment\Plugin;
 use Magento\Config\Model\Config as CoreConfig;
 use Omise\Payment\Model\Config\Config;
 use OmiseCapabilities;
+use OmiseAuthenticationFailureException;
+use Magento\Framework\Exception\LocalizedException;
 
 class ConfigSectionPaymentPlugin
 {
@@ -39,9 +41,11 @@ class ConfigSectionPaymentPlugin
                 try {
                     // Fetching capabilities to check the supplied keys validity
                     OmiseCapabilities::retrieve($keys['public_key'], $keys['secret_key']);
-                } catch (\Exception $e) {
+                } catch (OmiseAuthenticationFailureException $e) {
                     $errors = $e->getOmiseError();
-                    throw new \Exception($this->errorCodes[$errors['code']]);
+                    throw new LocalizedException(__($this->errorCodes[$errors['code']]));
+                } catch (Exception $e) {
+                    throw new LocalizedException(__('unable to load OmiseCapabilities api'));
                 }
             }
         }

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -17,7 +17,9 @@ class ConfigSectionPaymentPlugin
      */
     private $errorCodes = [
         'authentication_failure' => 'The keys for Omise Payment are invalid',
-        'key_expired_error' => 'The keys for Omise Payment are expired.'
+        'key_expired_error' => 'The keys for Omise Payment are expired.',
+        'locked_account_error' => 'The account is locked. Please contact support@omise.co.',
+        'not_authorized' => 'An attempt was made to perform an unauthorized action.',
     ];
 
     /**
@@ -46,7 +48,7 @@ class ConfigSectionPaymentPlugin
 
                     $errorMessage = array_key_exists($errors['code'], $this->errorCodes)
                         ? $this->errorCodes[$errors['code']]
-                        : $e->getMessage();
+                        : 'unable to load OmiseCapabilities api';
 
                     throw new LocalizedException(__($errorMessage));
                 } catch (Exception $e) {
@@ -77,8 +79,12 @@ class ConfigSectionPaymentPlugin
 
         // If keys are not updated then the CoreConfig won't have the value so we have to pull it from the config
         return [
-            'public_key' => $hasPublicKeyUpdated ? $configFields[$publicKeyIndex]['value'] : $this->config->getPublicKey(),
-            'secret_key' => $hasSecretKeyUpdated ? $configFields[$secretKeyIndex]['value'] : $this->config->getSecretKey()
+            'public_key' => $hasPublicKeyUpdated
+                ? $configFields[$publicKeyIndex]['value']
+                : $this->config->getPublicKey(),
+            'secret_key' => $hasSecretKeyUpdated
+                ? $configFields[$secretKeyIndex]['value']
+                : $this->config->getSecretKey()
         ];
     }
 }

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Omise\Payment\Plugin;
+
+use Magento\Config\Model\Config as CoreConfig;
+use Omise\Payment\Model\Config\Config;
+use OmiseCapabilities;
+
+class ConfigSectionPaymentPlugin
+{
+    /**
+     * Error code sent from the API and the message to be displayed on screen
+     *
+     * @var array
+     */
+    private $errorCodes = [
+        'authentication_failure' => 'The keys for Omise Payment are invalid',
+        'key_expired_error' => 'The keys for Omise Payment are expired.'
+    ];
+
+    /**
+     * @param \Omise\Payment\Model\Config\Config $config
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param \Magento\Config\Model\Config $coreConfig
+     */
+    public function beforeSave(CoreConfig $coreConfig)
+    {
+        if ('payment' === $coreConfig->getData('section')) {
+            $keys = $this->getKeys($coreConfig->toArray());
+
+            // if both keys are empty then we ignore the check.
+            if ($keys['public_key'] || $keys['secret_key']) {
+                try {
+                    // Fetching capabilities to check the supplied keys validity
+                    OmiseCapabilities::retrieve($keys['public_key'], $keys['secret_key']);
+                } catch (\Exception $e) {
+                    $errors = $e->getOmiseError();
+                    throw new \Exception($this->errorCodes[$errors['code']]);
+                }
+            }
+        }
+
+        return [ $coreConfig ];
+    }
+
+    /**
+     * Fetch appropriate keys by sandbox status
+     *
+     * @param array $configData
+     */
+    private function getKeys($configData)
+    {
+        $configFields = $configData['groups']['omise']['fields'];
+
+        $publicKey = ($configFields['sandbox_status']) ? 'test_public_key' : 'live_public_key';
+        $secretKey = ($configFields['sandbox_status']) ? 'test_secret_key' : 'live_secret_key';
+
+        $this->config->setStoreId($configData['store']);
+
+        return [
+            'public_key' => array_key_exists('value', $configFields[$publicKey])
+                ? $configFields[$publicKey]['value']
+                : $this->config->getPublicKey(),
+            'secret_key' => array_key_exists('value', $configFields[$secretKey])
+                ? $configFields[$secretKey]['value']
+                : $this->config->getSecretKey()
+        ];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1151,4 +1151,8 @@
             <argument name="code" xsi:type="const">Omise\Payment\Model\Config\Config::CODE</argument>
         </arguments>
     </virtualType>
+
+    <type name="Magento\Config\Model\Config">
+        <plugin name="admin_system_config_save_plugin" type="Omise\Payment\Plugin\ConfigSectionPaymentPlugin" sortOrder="1"/>
+    </type>
 </config>


### PR DESCRIPTION
#### 1. Objective

Prevent merchants from entering invalid Omise Payment keys.

Jira Ticket: #1465 (https://omise.atlassian.net/browse/FRON-1465)

#### 2. Description of change

Created a new plugin or interceptor `ConfigSectionPaymentPlugin` which holds logic to check the validity of the keys before saving it to the database. Did some refactoring on the `Omise\Payment\Model\Config\Config.php`.

#### 3. Quality assurance

**Run these command before testing:**
```
php bin/magento cache:flush
php bin/magento setup:di:compile
```

Go the the payment configuration section and test the following cases.

**Should be a success:**
- Add accurate public and secret keys
- Add empty public and secret keys

**Should fail**
- Add either one of the keys accurate and let other be empty
- Add incorrect keys to any of them

<img width="717" alt="Screen Shot 2565-05-19 at 10 43 41" src="https://user-images.githubusercontent.com/101558497/169200080-39781c42-866a-4f12-95e4-6e309f67411e.png">

**🔧 Environments:**

- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15