### PR TITLE
[FRON-1535]: Issue of cart not retaining the items when payment faile…

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -24,6 +24,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseEmailHelper;
 use Omise\Payment\Model\Config\Cc as Config;
+use Magento\Checkout\Model\Session as CheckoutSession;
 
 class Offsite extends Action
 {
@@ -65,7 +66,8 @@ class Offsite extends Action
         Charge  $charge,
         OmiseHelper $helper,
         OmiseEmailHelper $emailHelper,
-        Config $config
+        Config $config,
+        CheckoutSession $checkoutSession
     ) {
         parent::__construct($context);
 
@@ -75,6 +77,7 @@ class Offsite extends Action
         $this->helper  = $helper;
         $this->emailHelper = $emailHelper;
         $this->config = $config;
+        $this->checkoutSession  = $checkoutSession;
 
         $this->omise->defineUserAgent();
         $this->omise->defineApiVersion();
@@ -143,10 +146,15 @@ class Offsite extends Action
             }
 
             if ($charge instanceof \Omise\Payment\Model\Api\Error) {
+                // restoring the cart
+                $this->checkoutSession->restoreQuote();
                 throw new LocalizedException(__($charge->getMessage()));
             }
 
             if ($charge->isFailed()) {
+                // restoring the cart
+                $this->checkoutSession->restoreQuote();
+
                 throw new LocalizedException(
                     __('Payment failed. ' . ucfirst($charge->failure_message) . ', please contact our support
                     if you have any questions.')

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -13,6 +13,7 @@ use Omise\Payment\Model\Validator\Payment\AuthorizeResultValidator;
 use Omise\Payment\Model\Validator\Payment\CaptureResultValidator;
 use Omise\Payment\Helper\OmiseEmailHelper;
 use Omise\Payment\Helper\OmiseHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
 
 class Threedsecure extends Action
 {
@@ -46,7 +47,8 @@ class Threedsecure extends Action
         Session $session,
         Config  $config,
         OmiseEmailHelper $emailHelper,
-        OmiseHelper $helper
+        OmiseHelper $helper,
+        CheckoutSession $checkoutSession
     ) {
         parent::__construct($context);
 
@@ -54,6 +56,7 @@ class Threedsecure extends Action
         $this->config  = $config;
         $this->emailHelper = $emailHelper;
         $this->helper = $helper;
+        $this->checkoutSession  = $checkoutSession;
     }
 
     /**
@@ -118,6 +121,8 @@ class Threedsecure extends Action
             $result = $this->validate($charge);
 
             if ($result instanceof Invalid) {
+                // restoring the cart
+                $this->checkoutSession->restoreQuote();
                 throw new \Magento\Framework\Exception\LocalizedException($result->getMessage());
             }
 


### PR DESCRIPTION
#### 1. Objective

Retain the cart items when payment fails.

**Related information**:
Jira Ticket: [#1535](https://opn-ooo.atlassian.net/browse/FRON-1535)

#### 2. Description of change
In the controllers `Offsite.php` and `Threedsecure.php`, we imported `Magento\Checkout\Model\Session` class and called its function `restoreQuote` just before an error is thrown when payment fails.

**Credit card**
<img width="1414" alt="Screen Shot 2565-05-26 at 10 42 18" src="https://user-images.githubusercontent.com/101558497/170419351-7696bb79-baac-4d88-bd7b-72beecf40a9e.png">

**FPX**
<img width="1167" alt="Screen Shot 2565-05-26 at 12 02 55" src="https://user-images.githubusercontent.com/101558497/170419522-3f98ee6d-9a21-4167-b3bd-ed14a31d935f.png">

**Mobile Banking**
<img width="1183" alt="Screen Shot 2565-05-26 at 12 04 41" src="https://user-images.githubusercontent.com/101558497/170419717-fbb3e70b-dcbf-4704-bdf6-08938d287102.png">


#### 3. Quality assurance

First, run these command because we injected new class in the constructor.
```
php bin/magento cache:flush
php bin/magento setup:di:compile
```

- Add items to cart
- Fail the payment

**🔧 Environments:**

- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15