### PR TITLE
Add support for Google Pay payment method

### DIFF
--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -86,7 +86,7 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if ($payment->getMethod() !== 'omise' && !$this->helper->isCreditCardPayment($payment->getMethod())) {
+        if ($payment->getMethod() !== 'omise' && !$this->helper->isCreditCardPaymentMethod($payment->getMethod())) {
             $this->invalid(
                 $order,
                 __('Invalid payment method. Please contact our support if you have any questions.')

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -83,10 +83,7 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if ($payment->getMethod() !== 'omise'
-            && $payment->getMethod() !== 'omise_cc'
-            && $payment->getMethod() !== CcGooglePay::CODE
-        ) {
+        if ($payment->getMethod() !== 'omise' && !$this->helper->isCreditCardPayment($payment->getMethod())) {
             $this->invalid(
                 $order,
                 __('Invalid payment method. Please contact our support if you have any questions.')

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -9,6 +9,7 @@ use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use Omise\Payment\Gateway\Validator\Message\Invalid;
 use Omise\Payment\Model\Config\Cc as Config;
+use Omise\Payment\Model\Config\CcGooglePay;
 use Omise\Payment\Model\Validator\Payment\AuthorizeResultValidator;
 use Omise\Payment\Model\Validator\Payment\CaptureResultValidator;
 use Omise\Payment\Helper\OmiseEmailHelper;
@@ -82,7 +83,7 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if ($payment->getMethod() !== 'omise' && $payment->getMethod() !== 'omise_cc') {
+        if ($payment->getMethod() !== 'omise' && $payment->getMethod() !== 'omise_cc' && $payment->getMethod() !== CcGooglePay::CODE) {
             $this->invalid(
                 $order,
                 __('Invalid payment method. Please contact our support if you have any questions.')

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -83,7 +83,10 @@ class Threedsecure extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        if ($payment->getMethod() !== 'omise' && $payment->getMethod() !== 'omise_cc' && $payment->getMethod() !== CcGooglePay::CODE) {
+        if ($payment->getMethod() !== 'omise'
+            && $payment->getMethod() !== 'omise_cc'
+            && $payment->getMethod() !== CcGooglePay::CODE
+        ) {
             $this->invalid(
                 $order,
                 __('Invalid payment method. Please contact our support if you have any questions.')

--- a/Cron/OrderSyncStatus.php
+++ b/Cron/OrderSyncStatus.php
@@ -16,6 +16,7 @@ class OrderSyncStatus
      */
     private $paymentMethodArray = [
         "omise_cc",
+        "omise_cc_googlepay",
         "omise_offline_conveniencestore",
         "omise_offline_paynow",
         "omise_offline_promptpay",

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -21,6 +21,7 @@ use Omise\Payment\Model\Config\Rabbitlinepay;
 use Omise\Payment\Model\Config\Ocbcpao;
 use Omise\Payment\Model\Config\Grabpay;
 use Omise\Payment\Model\Config\Cc as Config;
+use Omise\Payment\Model\Config\CcGooglepay;
 use Omise\Payment\Model\Config\Conveniencestore;
 
 use SimpleXMLElement;
@@ -319,7 +320,8 @@ class OmiseHelper extends AbstractHelper
             $offsiteOfflinePaymentMethods,
             [
                 Config::CODE,
-                Conveniencestore::CODE
+                Conveniencestore::CODE,
+                CcGooglepay::CODE
             ]
         );
 

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -360,7 +360,7 @@ class OmiseHelper extends AbstractHelper
      *
      * @return boolean
      */
-    public function isCreditCardPayment($paymentMethod)
+    public function isCreditCardPaymentMethod($paymentMethod)
     {
         return in_array($paymentMethod, $this->cardPaymentMethods);
     }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -68,6 +68,14 @@ class OmiseHelper extends AbstractHelper
     ];
 
     /**
+     * Payment method that utilizes card token to create charges.
+     */
+    private $cardPaymentMethods = [
+        Config::CODE,
+        CcGooglepay::CODE
+    ];
+
+    /**
      * @var Config
      */
     protected $config;
@@ -318,13 +326,24 @@ class OmiseHelper extends AbstractHelper
         $offsiteOfflinePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offlinePaymentMethods);
         $omisePaymentMethods = array_merge(
             $offsiteOfflinePaymentMethods,
+            $this->cardPaymentMethods,
             [
-                Config::CODE,
-                Conveniencestore::CODE,
-                CcGooglepay::CODE
+                Conveniencestore::CODE
             ]
         );
 
         return in_array($paymentMethod, $omisePaymentMethods);
+    }
+
+    /**
+     * Return TRUE if $paymentMethod uses card token to create a charge.
+     *
+     * @param string $paymentMethod
+     *
+     * @return boolean
+     */
+    public function isCreditCardPayment($paymentMethod)
+    {
+        return in_array($paymentMethod, $this->cardPaymentMethods);
     }
 }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -21,7 +21,7 @@ use Omise\Payment\Model\Config\Rabbitlinepay;
 use Omise\Payment\Model\Config\Ocbcpao;
 use Omise\Payment\Model\Config\Grabpay;
 use Omise\Payment\Model\Config\Cc as Config;
-use Omise\Payment\Model\Config\CcGooglepay;
+use Omise\Payment\Model\Config\CcGooglePay;
 use Omise\Payment\Model\Config\Conveniencestore;
 
 use SimpleXMLElement;
@@ -75,6 +75,14 @@ class OmiseHelper extends AbstractHelper
         Promptpay::CODE,
         Tesco::CODE,
         Conveniencestore::CODE
+    ];
+
+    /**
+     * @var array
+     */
+    private $cardPaymentMethods = [
+        Config::CODE,
+        CcGooglePay::CODE
     ];
 
     /**
@@ -336,8 +344,11 @@ class OmiseHelper extends AbstractHelper
      */
     public function isOmisePayment($paymentMethod)
     {
-        $offsiteOfflinePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offlinePaymentMethods);
-        $omisePaymentMethods = array_merge($offsiteOfflinePaymentMethods, [ Config::CODE ]);
+        $omisePaymentMethods = array_merge(
+            $this->offsitePaymentMethods,
+            $this->offlinePaymentMethods,
+            $this->cardPaymentMethods
+        );
 
         return in_array($paymentMethod, $omisePaymentMethods);
     }

--- a/Model/Capabilities.php
+++ b/Model/Capabilities.php
@@ -77,4 +77,14 @@ class Capabilities
     {
         return $this->capabilitiesAPI->getBackends();
     }
+
+    /**
+     *
+     * @return array|null
+     */
+    public function getCardBrands()
+    {
+        $card = $this->getBackendsByType("card");
+        return $card ? current($card)->brands : [];
+    }
 }

--- a/Model/Config/CcGooglePay.php
+++ b/Model/Config/CcGooglePay.php
@@ -1,0 +1,12 @@
+<?php
+namespace Omise\Payment\Model\Config;
+
+use Omise\Payment\Model\Config\Config;
+
+class CcGooglePay extends Config
+{
+    /**
+     * @var string
+     */
+    const CODE = 'omise_cc_googlepay';
+}

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -5,6 +5,7 @@ use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Payment\Api\PaymentMethodListInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Omise\Payment\Model\Capabilities;
+use Omise\Payment\Model\Config\CcGooglePay;
 use Omise\Payment\Model\Config\Fpx;
 use Omise\Payment\Model\Config\Internetbanking;
 use Omise\Payment\Model\Config\Mobilebanking;
@@ -53,6 +54,9 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
                     break;
                 case Internetbanking::CODE:
                     $configs['internet_banking'] = $this->capabilities->getBackendsByType("internet_banking");
+                    break;
+                case CcGooglePay::CODE:
+                    $configs['card_brands'] = $this->capabilities->getCardBrands();
                     break;
             }
         }

--- a/Model/Ui/PluginConfigProvider.php
+++ b/Model/Ui/PluginConfigProvider.php
@@ -3,6 +3,7 @@ namespace Omise\Payment\Model\Ui;
 
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Omise\Payment\Model\Config\Config;
+use Omise\Payment\Model\Config\CcGooglePay;
 
 class PluginConfigProvider implements ConfigProviderInterface
 {
@@ -20,7 +21,12 @@ class PluginConfigProvider implements ConfigProviderInterface
     public function getConfig()
     {
         return [
-            'isOmiseSandboxOn' => $this->config->isSandboxEnabled()
+            'isOmiseSandboxOn' => $this->config->isSandboxEnabled(),
+            CcGooglePay::CODE => [
+                'merchantId' => $this->config->getValue('merchant_id', CcGooglePay::CODE),
+                'requestBillingAddress' => $this->config->getValue('request_billing_address', CcGooglePay::CODE),
+                'requestPhoneNumber' => $this->config->getValue('request_phone_number', CcGooglePay::CODE),
+            ]
         ];
     }
 }

--- a/Model/Ui/PluginConfigProvider.php
+++ b/Model/Ui/PluginConfigProvider.php
@@ -25,7 +25,7 @@ class PluginConfigProvider implements ConfigProviderInterface
             CcGooglePay::CODE => [
                 'merchantId' => $this->config->getValue('merchant_id', CcGooglePay::CODE),
                 'requestBillingAddress' => $this->config->getValue('request_billing_address', CcGooglePay::CODE),
-                'requestPhoneNumber' => $this->config->getValue('request_phone_number', CcGooglePay::CODE),
+                'requestPhoneNumber' => $this->config->getValue('request_phone_number', CcGooglePay::CODE)
             ]
         ];
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -674,7 +674,7 @@
                     </field>
                     <field id="merchant_id" translate="label" type="text" sortOrder="507" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Google Pay Merchant ID</label>
-                        <comment><![CDATA[The merchant ID will be available after registering with the <a href="https://pay.google.com/business/console">Google Pay Business Console</a>.]]></comment>
+                        <comment><![CDATA[The merchant ID will be available after registering with the <a href="https://pay.google.com/business/console">Google Pay Business Console</a>. Only required for live mode.]]></comment>
                         <config_path>payment/omise_cc_googlepay/merchant_id</config_path>
                     </field>
                     <field id="request_billing_address" translate="label comment" type="select" sortOrder="508" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -663,6 +663,57 @@
                         </depends>
                     </field>
                 </group>
+                <group id="omise_cc_googlepay" translate="label" sortOrder="505" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Google Pay Payment</label>
+                    <comment>Enable customers to pay using credit/debit cards connected to their Google account. </comment>
+                    <field id="active" translate="label comment" type="select" sortOrder="506" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Enable/Disable</label>
+                        <comment>Enable Google Pay payment method.</comment>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>payment/omise_cc_googlepay/active</config_path>
+                    </field>
+                    <field id="merchant_id" translate="label" type="text" sortOrder="507" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Google Pay Merchant ID</label>
+                        <comment><![CDATA[The merchant ID will be available after registering with the <a href="https://pay.google.com/business/console">Google Pay Business Console</a>.]]></comment>
+                        <config_path>payment/omise_cc_googlepay/merchant_id</config_path>
+                    </field>
+                    <field id="request_billing_address" translate="label comment" type="select" sortOrder="508" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Request Billing Address</label>
+                        <comment>Request customer's name and billing address from their Google Account upon checkout.</comment>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>payment/omise_cc_googlepay/request_billing_address</config_path>
+                    </field>
+                    <field id="request_phone_number" translate="label comment" type="select" sortOrder="509" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Request Phone Number</label>
+                        <comment>Request customer's phone number from their Google Account upon checkout.</comment>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <config_path>payment/omise_cc_googlepay/request_phone_number</config_path>
+                    </field>
+                    <field id="payment_action" translate="label" type="select" sortOrder="510" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                        <label>Payment Action</label>
+                        <source_model>Omise\Payment\Model\Source\PaymentAction</source_model>
+                        <config_path>payment/omise_cc_googlepay/payment_action</config_path>
+                    </field>
+                    <field id="title" translate="label" type="text" sortOrder="511" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Title</label>
+                        <comment>This controls the title which the user sees during checkout.</comment>
+                        <config_path>payment/omise_cc_googlepay/title</config_path>
+                    </field>
+                    <field id="allowspecific" translate="label comment" type="select" sortOrder="512" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Allowed Countries</label>
+                        <config_path>payment/omise_cc_googlepay/allowspecific</config_path>
+                        <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
+                        <comment>If not set to all, guest customers will not have a billing country and may not be able to checkout.</comment>
+                    </field>
+                    <field id="specificcountry" translate="label" type="multiselect" sortOrder="513" showInDefault="1" showInWebsite="1" showInStore="1">
+                        <label>Payment from Specific countries</label>
+                        <config_path>payment/omise_cc_googlepay/specificcountry</config_path>
+                        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                        <depends>
+                            <field id="allowspecific">1</field>
+                        </depends>
+                    </field>
+                </group>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -685,9 +685,12 @@
                     </field>
                     <field id="request_phone_number" translate="label comment" type="select" sortOrder="509" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Request Phone Number</label>
-                        <comment>Request customer's phone number from their Google Account upon checkout.</comment>
+                        <comment>Request customer's phone number from their Google Account upon checkout when billing address is requested.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_cc_googlepay/request_phone_number</config_path>
+                        <depends>
+                            <field id="request_billing_address">1</field>
+                        </depends>
                     </field>
                     <field id="payment_action" translate="label" type="select" sortOrder="510" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                         <label>Payment Action</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -270,6 +270,21 @@ xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_grabpay>
+
+            <omise_cc_googlepay>
+                <active>0</active>
+                <title>Google Pay</title>
+                <merchant_id></merchant_id>
+                <request_billing_address>0</request_billing_address>
+                <request_phone_number>0</request_phone_number>
+                <model>OmiseCcGooglePayAdapter</model>
+                <is_gateway>1</is_gateway>
+                <can_initialize>1</can_initialize>
+                <can_use_checkout>1</can_use_checkout>
+                <can_capture>1</can_capture>
+                <can_review_payment>1</can_review_payment>
+                <payment_action>authorize_capture</payment_action>
+            </omise_cc_googlepay>
         </payment>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1023,6 +1023,64 @@
     </virtualType>
     <!-- /Response Handler-->
 
+    <!-- Google Pay payment solution -->
+    <virtualType name="OmiseCcGooglePayAdapter" type="Magento\Payment\Model\Method\Adapter">
+        <arguments>
+            <argument name="code" xsi:type="const">Omise\Payment\Model\Config\CcGooglePay::CODE</argument>
+            <argument name="formBlockType" xsi:type="string">Magento\Payment\Block\Form\Cc</argument>
+            <argument name="infoBlockType" xsi:type="string">Magento\Payment\Block\Info</argument>
+            <argument name="valueHandlerPool" xsi:type="object">OmiseCcGooglePayValueHandlerPool</argument>
+            <argument name="validatorPool" xsi:type="object">OmiseCcGooglePayValidatorPool</argument>
+            <argument name="commandPool" xsi:type="object">OmiseCreditCardCommandPool</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay payment solution -->
+
+    <!-- Google Pay :: Value Handler Pool -->
+    <virtualType name="OmiseCcGooglePayValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="default" xsi:type="string">OmiseCcGooglePayConfigValueHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay :: Value Handler Pool -->
+
+    <!-- Google Pay :: Validator Pool -->
+    <virtualType name="OmiseCcGooglePayValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="configInterface" xsi:type="object">OmiseCcGooglePayConfig</argument>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">OmiseCcGooglePayCountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay :: Validator Pool -->
+
+    <!-- Google Pay :: Config Value Handler -->
+    <virtualType name="OmiseCcGooglePayConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+        <arguments>
+            <argument name="configInterface" xsi:type="object">OmiseCcGooglePayConfig</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay :: Config Value Handler -->
+
+    <!-- Google Pay :: Country Validator Handler -->
+    <virtualType name="OmiseCcGooglePayCountryValidator" type="Magento\Payment\Gateway\Validator\CountryValidator">
+        <arguments>
+            <argument name="config" xsi:type="object">OmiseCcGooglePayConfig</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay :: Country Validator Handler -->
+
+    <!-- Google Pay :: Config -->
+    <virtualType name="OmiseCcGooglePayConfig" type="Magento\Payment\Gateway\Config\Config">
+        <arguments>
+            <argument name="methodCode" xsi:type="const">Omise\Payment\Model\Config\CcGooglePay::CODE</argument>
+        </arguments>
+    </virtualType>
+    <!-- /Google Pay :: Config -->
+
     <!-- Credit Card payment solution -->
     <virtualType name="OmiseCcAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,6 +3,10 @@
         <observer name="omise_data_assign" instance="Omise\Payment\Observer\CreditCardDataObserver" />
     </event>
 
+    <event name="payment_method_assign_data_omise_cc_googlepay">
+        <observer name="omise_data_assign_googlepay" instance="Omise\Payment\Observer\CreditCardDataObserver" />
+    </event>
+
     <event name="payment_method_assign_data_omise_offsite_internetbanking">
         <observer name="omise_data_assign" instance="Omise\Payment\Observer\InternetbankingDataAssignObserver" />
     </event>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -26,6 +26,9 @@
                                                                         <item name="omise_cc" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
+                                                                        <item name="omise_cc_googlepay" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">false</item>
+                                                                        </item>
                                                                         <item name="omise_offsite_internetbanking" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
@@ -42,14 +42,14 @@ define(
                 'JCB': 'JCB',
                 'MasterCard': 'MASTERCARD',
                 'Visa': 'VISA',
-            }
-            const cardBrands = []
+            };
+            const cardBrands = [];
             window.checkoutConfig.card_brands.forEach(brand => {
                 if (brandMapping[brand]) {
                     cardBrands.push(brandMapping[brand])
                 }
-            })
-            return cardBrands
+            });
+            return cardBrands;
         }();
         
         /**
@@ -84,7 +84,7 @@ define(
             type: 'CARD',
             parameters: {
                 allowedAuthMethods: allowedCardAuthMethods,
-                allowedCardNetworks: [],
+                allowedCardNetworks: allowedCardNetworks,
                 billingAddressRequired: (window.checkoutConfig.omise_cc_googlepay.requestBillingAddress === '1'),
                 billingAddressParameters: {
                     format: 'FULL',

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
@@ -1,0 +1,376 @@
+define(
+    [
+        'ko',
+        'Omise_Payment/js/view/payment/omise-base-method-renderer',
+        'Magento_Checkout/js/view/payment/default',
+        'mage/storage',
+        'jquery',
+        'Magento_Checkout/js/model/full-screen-loader',
+        'Magento_Checkout/js/action/redirect-on-success',
+        'Magento_Checkout/js/model/quote',
+    ],
+    function (
+        ko,
+        Base,
+        Component,
+        storage,
+        $,
+        fullScreenLoader,
+        redirectOnSuccessAction,
+        quote
+    ) {
+        'use strict';
+
+        /**
+         * Define the version of the Google Pay API referenced when creating configuration.
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataRequest|apiVersion in PaymentDataRequest}
+         */
+        const baseRequest = {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+        };
+        
+        /**
+         * Card networks supported by site and gateway.
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#CardParameters|CardParameters}
+         */
+        const allowedCardNetworks = function() {
+            const brandMapping = {
+                'American Express': 'AMEX',
+                'JCB': 'JCB',
+                'MasterCard': 'MASTERCARD',
+                'Visa': 'VISA',
+            }
+            const cardBrands = []
+            window.checkoutConfig.card_brands.forEach(brand => {
+                if (brandMapping[brand]) {
+                    cardBrands.push(brandMapping[brand])
+                }
+            })
+            return cardBrands
+        }();
+        
+        /**
+         * Card authentication methods supported by site and gateway.
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#CardParameters|CardParameters}
+         */
+        const allowedCardAuthMethods = ["PAN_ONLY"];
+        
+        /**
+         * Identify gateway and site's gateway merchant identifier.
+         *
+         * The Google Pay API response will return an encrypted payment method capable
+         * of being charged by a supported gateway after payer authorization
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#gateway|PaymentMethodTokenizationSpecification}
+         */
+        const tokenizationSpecification = {
+            type: 'PAYMENT_GATEWAY',
+            parameters: {
+                "gateway": "omise",
+                "gatewayMerchantId": window.checkoutConfig.payment.omise_cc.publicKey,
+            }
+        };
+        
+        /**
+         * Describe site's support for the CARD payment method and its required fields.
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#CardParameters|CardParameters}
+         */
+        const baseCardPaymentMethod = {
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: allowedCardAuthMethods,
+                allowedCardNetworks: [],
+                billingAddressRequired: (window.checkoutConfig.omise_cc_googlepay.requestBillingAddress === '1'),
+                billingAddressParameters: {
+                    format: 'FULL',
+                    phoneNumberRequired: (window.checkoutConfig.omise_cc_googlepay.requestPhoneNumber === '1'),
+                },
+            }
+        };
+        
+        /**
+         * Describe site's support for the CARD payment method including optional fields
+         *
+         * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#CardParameters|CardParameters}
+         */
+        const cardPaymentMethod = Object.assign({},
+            baseCardPaymentMethod, {
+                tokenizationSpecification: tokenizationSpecification
+            }
+        );
+        
+        /**
+         * An initialized google.payments.api.PaymentsClient object or null if not yet set
+         *
+         * @see {@link getGooglePaymentsClient}
+         */
+        let paymentsClient = null;
+
+        /**
+         * UI Class object.
+         */
+        let klass = null;
+
+        return Component.extend(Base).extend({
+            defaults: {
+                template: 'Omise_Payment/payment/omise-cc-googlepay-form'
+            },
+
+            isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
+
+            code: 'omise_cc_googlepay',
+            restrictedToCurrencies: ['thb', 'sgd', 'myr'],
+
+            /**
+             * Get a checkout form data.
+             *
+             * @return {Object}
+             */
+            getData: function() {
+                return {
+                    'method': 'omise_cc_googlepay',
+                    'additional_data': {
+                        'omise_card_token': klass.omiseCardToken(),
+                    }
+                };
+            },
+
+            /**
+             * Initiate observable fields.
+             *
+             * @return this
+             */
+            initObservable: function() {
+                this._super()
+                    .observe([
+                        'omiseCardToken',
+                    ]);
+
+                return this;
+            },
+
+            /**
+             * Show custom error message.
+             */
+            displayError: function() {
+                document.getElementById('googlepay-error-message').style.display = "block";
+            },
+
+            /**
+             * Load Google-hosted JavaScript upon landing on the checkout page.
+             */
+            loadGooglePay: function() {
+                klass = this;
+
+                const script = document.createElement('script');
+                script.src = "https://pay.google.com/gp/p/js/pay.js";
+                script.onload = function() {
+                    klass.onGooglePayLoaded();
+                };
+                document.head.appendChild(script);
+                return true;
+            },
+
+            /**
+             * Initialize Google PaymentsClient after Google-hosted JavaScript has loaded
+             *
+             * Display a Google Pay payment button after confirmation of the viewer's
+             * ability to pay.
+             */
+            onGooglePayLoaded: function() {
+                const client = klass.getGooglePaymentsClient();
+                client.isReadyToPay(klass.getGoogleIsReadyToPayRequest())
+                    .then(function(response) {
+                        if (response.result) {
+                            klass.addGooglePayButton();
+                            klass.prefetchGooglePaymentData();
+                        } else {
+                            klass.displayError();
+                        }
+                    })
+                    .catch(function(_err) {
+                        klass.displayError();
+                    });
+            },
+
+            /**
+             * Return an active PaymentsClient or initialize.
+             *
+             * @see {@link https://developers.google.com/pay/api/web/reference/client#PaymentsClient PaymentsClient constructor}
+             * @returns {google.payments.api.PaymentsClient} Google Pay API client
+             */
+            getGooglePaymentsClient: function() {
+                if (paymentsClient === null) {
+                    paymentsClient = new google.payments.api.PaymentsClient({
+                        environment: window.checkoutConfig.isOmiseSandboxOn ? 'TEST' : 'PRODUCTION'
+                    });
+                }
+                return paymentsClient;
+            },
+
+            /**
+             * Configure site's support for payment methods supported by the Google Pay API.
+             *
+             * Each member of allowedPaymentMethods should contain only the required fields,
+             * allowing reuse of this base request when determining a viewer's ability
+             * to pay and later requesting a supported payment method.
+             *
+             * @returns {object} Google Pay API version, payment methods supported by the site
+             */
+            getGoogleIsReadyToPayRequest: function() {
+                return Object.assign({},
+                    baseRequest, {
+                        allowedPaymentMethods: [baseCardPaymentMethod]
+                    }
+                );
+            },
+            
+            /**
+             * Add a Google Pay purchase button alongside an existing checkout button.
+             *
+             * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions|Button options}
+             * @see {@link https://developers.google.com/pay/api/web/guides/brand-guidelines|Google Pay brand guidelines}
+             */
+            addGooglePayButton: function() {
+                const client = klass.getGooglePaymentsClient();
+                const button = client.createButton({
+                    onClick: klass.onGooglePaymentButtonClicked
+                });
+                document.getElementById('googlepay-container').appendChild(button);
+            },
+
+            /**
+             * Prefetch payment data to improve performance.
+             *
+             * @see {@link https://developers.google.com/pay/api/web/reference/client#prefetchPaymentData|prefetchPaymentData()}
+             */
+            prefetchGooglePaymentData: function() {
+                const paymentDataRequest = klass.getGooglePaymentDataRequest();
+                paymentDataRequest.transactionInfo = {
+                    totalPriceStatus: 'NOT_CURRENTLY_KNOWN',
+                    currencyCode: window.checkoutConfig.quoteData.quote_currency_code.toUpperCase(),
+                };
+                const client = klass.getGooglePaymentsClient();
+                client.prefetchPaymentData(paymentDataRequest);
+            },
+
+            /**
+             * Configure support for the Google Pay API.
+             *
+             * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataRequest|PaymentDataRequest}
+             * @returns {object} PaymentDataRequest fields
+            */
+            getGooglePaymentDataRequest: function() {
+                const paymentDataRequest = Object.assign({}, baseRequest);
+                paymentDataRequest.allowedPaymentMethods = [cardPaymentMethod];
+                paymentDataRequest.transactionInfo = klass.getGoogleTransactionInfo();
+                paymentDataRequest.merchantInfo = {
+                    merchantId: window.checkoutConfig.omise_cc_googlepay.merchantId,
+                };
+                return paymentDataRequest;
+            },
+            
+            /**
+             * Provide Google Pay API with a payment amount, currency, and amount status.
+             *
+             * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#TransactionInfo|TransactionInfo}
+             * @returns {object} transaction info, suitable for use as transactionInfo property of PaymentDataRequest
+             */
+            getGoogleTransactionInfo: function() {
+                return {
+                    currencyCode: window.checkoutConfig.quoteData.quote_currency_code.toUpperCase(),
+                    totalPriceStatus: 'FINAL',
+                    totalPrice: parseFloat(window.checkoutConfig.quoteData.grand_total).toFixed(2)
+                };
+            },
+            
+            /**
+             * Show Google Pay payment sheet when Google Pay payment button is clicked.
+             */
+            onGooglePaymentButtonClicked: function() {
+                const paymentDataRequest = klass.getGooglePaymentDataRequest();
+                paymentDataRequest.transactionInfo = klass.getGoogleTransactionInfo();
+            
+                const client = klass.getGooglePaymentsClient();
+                client.loadPaymentData(paymentDataRequest)
+                    .then(function(paymentData) {
+                        klass.createOmiseToken(paymentData);
+                    })
+                    .catch(function(err) {
+                        console.error(err);
+                    });
+            },
+            
+            /**
+             * Create Omise token from the payment data returned by the Google Pay API.
+             */
+            createOmiseToken: function(paymentData) {
+                klass.isPlaceOrderActionAllowed(false);
+                fullScreenLoader.startLoader();
+
+                const token = paymentData?.paymentMethodData?.tokenizationData?.token;
+
+                const tokenizationParams = {
+                    method: 'googlepay',
+                    data: token,
+                };
+
+                const billingAddress = (paymentData?.paymentMethodData?.info?.billingAddress);
+                if (billingAddress) {
+                    Object.assign(tokenizationParams, {
+                        billing_name: billingAddress.name,
+                        billing_city: billingAddress.locality,
+                        billing_country: billingAddress.countryCode,
+                        billing_postal_code: billingAddress.postalCode,
+                        billing_state: billingAddress.administrativeArea,
+                        billing_street1: billingAddress.address1,
+                        billing_street2: [billingAddress.address2, billingAddress.address3].filter(s => s).join(' '),
+                        billing_phone_number: billingAddress.phoneNumber,
+                    });
+                }
+
+                Omise.setPublicKey(window.checkoutConfig.payment.omise_cc.publicKey);
+                Omise.createToken('tokenization', tokenizationParams, function(statusCode, response) {
+                    if (statusCode === 200) {
+                        klass.omiseCardToken(response.id);
+                        klass.processPayment();
+                    } else {
+                        klass.isPlaceOrderActionAllowed(true);
+                        fullScreenLoader.stopLoader();
+                    }
+                });
+            },
+
+            /**
+             * Send charge creation request and finalize payment.
+             */
+            processPayment: function() {
+                var failHandler = klass.buildFailHandler(klass);
+                klass.getPlaceOrderDeferredObject()
+                    .fail(failHandler)
+                    .done(function(orderId) {
+                        var serviceUrl = klass.getMagentoReturnUrl(orderId);
+                        var storageFailHandler = klass.buildFailHandler(klass);
+                        storage.get(serviceUrl, false)
+                            .fail(storageFailHandler)
+                            .done(function (response) {
+                                if (response) {
+                                    if (response.authorize_uri !== "") {
+                                        $.mage.redirect(response.authorize_uri);
+                                    } else {
+                                        redirectOnSuccessAction.execute();
+                                    }
+                                } else {
+                                    storageFailHandler(response);
+                                }
+                            });
+                    });
+            },
+        });
+    }
+);

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
@@ -124,7 +124,6 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_cc_googlepay',
-            restrictedToCurrencies: ['thb', 'sgd', 'myr'],
 
             /**
              * Get a checkout form data.

--- a/view/frontend/web/js/view/payment/omise.js
+++ b/view/frontend/web/js/view/payment/omise.js
@@ -11,6 +11,7 @@ define(
 
         const METHOD_RENDERERS = [
             'cc',
+            'cc-googlepay',
             'offsite-internetbanking',
             'offsite-alipay',
             'offsite-fpx',

--- a/view/frontend/web/template/payment/omise-cc-googlepay-form.html
+++ b/view/frontend/web/template/payment/omise-cc-googlepay-form.html
@@ -1,0 +1,47 @@
+<div class="payment-method"
+    data-bind="css: {'_active': (getCode() == isChecked())}, visible: isActive()">
+    <div class="payment-method-title field choice">
+        <input type="radio" name="payment[method]" class="radio"
+            data-bind="attr: {
+               'id': getCode()
+               },
+               value: getCode(),
+               checked: isChecked,
+               click: selectPaymentMethod,
+               visible: isRadioButtonVisible(),
+               enable: isActive()" />
+        <label data-bind="attr: {'for': getCode()}" class="label">
+            <span data-bind="text: getTitle()"></span>
+        </label>
+        <div data-bind="visible: isSandboxOn()" class="page messages">
+            <div role="alert" class="messages">
+                <div class="message-warning warning message">
+                    <span data-bind="i18n: 'Test mode'"></span> (<a target="_blank" href="https://www.omise.co/what-are-test-keys-and-live-keys"><span data-bind="i18n: 'more info'"></span></a>)
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="payment-method-content">
+        <!-- ko foreach: getRegion('messages') -->
+        <!-- ko template: getTemplate() -->
+        <!-- /ko -->
+        <!--/ko-->
+        <div class="payment-method-billing-address">
+            <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
+            <!-- ko template: getTemplate() -->
+            <!-- /ko -->
+            <!--/ko-->
+        </div>
+        <div class="checkout-agreements-block">
+            <!-- ko foreach: $parent.getRegion('before-place-order') -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
+            <!--/ko-->
+        </div>
+        <div class="actions-toolbar" data-bind="visible: loadGooglePay()">
+          <div id="googlepay-container"></div>
+        </div>
+        <div class="message-error error message" style="display:none" id="googlepay-error-message">
+            This payment method is not currently available, please try again later or use a different payment method.
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
#### 1. Objective

Add support for Google Pay payment method. Allow customers to pay using cards that are connected to their Google Account.

#### 2. Description of change

* Add an option on Admin dashboard to allow customers to pay with Google Pay.
* Add Google-related configurable options such as Merchant ID, Request Billing Address, and Request Phone Number.
* Make it possible to fetch card brands from Capability.
* Google Pay uses card's existing command pool.

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3
- **Omise plugin version**: Omise-Magento 2.24.0
- **PHP version**: 7.1.15

**✏️ Details:**

A new section on the Admin configuration site.
![Screen Shot 2565-05-27 at 10 15 11](https://user-images.githubusercontent.com/61586978/170621940-8eae7d7b-8de9-424d-822a-4385da9fffd1.png)

The Merchant ID, Request Billing Address, and Request Phone Number options are sent directly upon connecting with Google server, depending on business needs.

If Request Billing Address is not enabled, then Request Phone Number will not be visible.

![Screen Shot 2565-05-27 at 17 15 10](https://user-images.githubusercontent.com/61586978/170681307-9285934e-7f83-470d-9f49-9c15b79e6f90.png)

A Google Pay button will appear if it's enabled on the Admin's site.
![Screen Shot 2565-05-27 at 09 49 39](https://user-images.githubusercontent.com/61586978/170621341-2e7e65ab-6014-4adc-bc31-a89d89b49627.png)

Upon readiness check failure, this error message will appear.
![Screen Shot 2565-05-27 at 09 51 33](https://user-images.githubusercontent.com/61586978/170621352-89c93d48-bc60-4e88-a817-4c9dcba8002e.png)

* Testing checklist: with live/test account, and with 3DS/non-3DS enabled.

#### 4. Impact of the change

Customers can now pay with Google Pay.

#### 5. Priority of change

Normal.

#### 6. Additional Notes