### PR TITLE
feature/FRON-1473: Payment instructions is sent to the customer's ema…

### DIFF
--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -60,10 +60,20 @@ class OmiseHelper extends AbstractHelper
      *
      * @var array
      */
-    private $offlinePaymentMethods = [
+    private $imageCodePaymentMethods = [
         Paynow::CODE,
         Promptpay::CODE,
         Tesco::CODE
+    ];
+
+    /**
+     * @var array
+     */
+    private $offlinePaymentMethods = [
+        Paynow::CODE,
+        Promptpay::CODE,
+        Tesco::CODE,
+        Conveniencestore::CODE
     ];
 
     /**
@@ -186,23 +196,34 @@ class OmiseHelper extends AbstractHelper
     }
 
     /**
-     * This method checks and return TRUE if $paymentMethod is offline payment which is payable by image code
-     * otherwise returns false.
+     * Check if payment method is among the payment methods which is payable by image code and
+     *
      * @param string $paymentMethod
      * @return boolean
      */
     public function isPayableByImageCode($paymentMethod)
     {
+        return in_array($paymentMethod, $this->imageCodePaymentMethods);
+    }
+
+    /**
+     * Check if payment method is one of the offline payment methods or not
+     *
+     * @param string $paymentMethod
+     * @return boolean
+     */
+    public function isOfflinePaymentMethod($paymentMethod)
+    {
         return in_array($paymentMethod, $this->offlinePaymentMethods);
     }
 
     /**
-     * This method checks and return TRUE if $paymentMethod is an offsite payment
-     * otherwise returns false.
+     * Check if payment method is one of the offsite payment methods or not
+     *
      * @param string $paymentMethod
      * @return boolean
      */
-    public function isOffsitePayment($paymentMethod)
+    public function isOffsitePaymentMethod($paymentMethod)
     {
         return in_array($paymentMethod, $this->offsitePaymentMethods);
     }
@@ -315,13 +336,7 @@ class OmiseHelper extends AbstractHelper
     public function isOmisePayment($paymentMethod)
     {
         $offsiteOfflinePaymentMethods = array_merge($this->offsitePaymentMethods, $this->offlinePaymentMethods);
-        $omisePaymentMethods = array_merge(
-            $offsiteOfflinePaymentMethods,
-            [
-                Config::CODE,
-                Conveniencestore::CODE
-            ]
-        );
+        $omisePaymentMethods = array_merge($offsiteOfflinePaymentMethods, [ Config::CODE ]);
 
         return in_array($paymentMethod, $omisePaymentMethods);
     }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -196,7 +196,7 @@ class OmiseHelper extends AbstractHelper
     }
 
     /**
-     * Check if payment method is among the payment methods which is payable by image code and
+     * Check if payment method is among the payment methods which is payable by image code or not
      *
      * @param string $paymentMethod
      * @return boolean

--- a/Model/Data/Email.php
+++ b/Model/Data/Email.php
@@ -144,6 +144,10 @@ class Email
                 $emailData->addData(['validUntil' => date("d-m-Y H:i:s", strtotime('+1 day'))]);
                 $this->emailTemplate = 'send_email_promptpay_template';
                 break;
+            case 'econtext':
+                // for convenience store
+                $emailData->addData(['link' => $payment->getAdditionalInformation('charge_authorize_uri')]);
+                $this->emailTemplate = 'send_email_convenience_store_template';
             default:
                 return $this;
         }

--- a/Model/Data/Email.php
+++ b/Model/Data/Email.php
@@ -148,6 +148,7 @@ class Email
                 // for convenience store
                 $emailData->addData(['link' => $payment->getAdditionalInformation('charge_authorize_uri')]);
                 $this->emailTemplate = 'send_email_convenience_store_template';
+                break;
             default:
                 return $this;
         }

--- a/Observer/PaymentCreationObserver.php
+++ b/Observer/PaymentCreationObserver.php
@@ -42,8 +42,8 @@ class PaymentCreationObserver implements ObserverInterface
             $order->setCanSendNewEmailFlag(false);
         }
 
-        // Offline QR code payment emails
-        if ($this->_helper->isPayableByImageCode($paymentMethod)) {
+        // Offline QR code payment and convenience store emails
+        if ($this->_helper->isOfflinePaymentMethod($paymentMethod)) {
             $this->_email->sendEmail($order);
         }
 

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../Email/etc/email_templates.xsd">
-<template id="send_email_tesco_template" label="Email Form" file="tesco_template.html" type="html" 
-    module="Omise_Payment" area="frontend"/>
-<template id="send_email_paynow_template" label="Email Form" file="paynow_template.html" type="html" 
-    module="Omise_Payment" area="frontend"/>
-<template id="send_email_promptpay_template" label="Email Form" file="promptpay_template.html" type="html" 
-    module="Omise_Payment" area="frontend"/>
+    <template id="send_email_tesco_template" label="Email Form" file="tesco_template.html" type="html" module="Omise_Payment" area="frontend"/>
+    <template id="send_email_paynow_template" label="Email Form" file="paynow_template.html" type="html" module="Omise_Payment" area="frontend"/>
+    <template id="send_email_promptpay_template" label="Email Form" file="promptpay_template.html" type="html" module="Omise_Payment" area="frontend"/>
+    <template id="send_email_convenience_store_template" label="Email Form" file="convenience_store_template.html" type="html" module="Omise_Payment" area="frontend"/>
 </config>

--- a/view/frontend/email/convenience_store_template.html
+++ b/view/frontend/email/convenience_store_template.html
@@ -3,11 +3,11 @@
 <div>
     <p>
         {{trans "%thankyou" thankyou="Thank you for your order."}}</p>
-        {{trans "%message" message="You are now one step away from completing the order. Please follow the link to find the payment instructions to complete the payment "}}.
+        {{trans "%message" message="You are now one step away from completing the order. Please follow the link to find the payment instructions to complete the payment. "}}
     </p>
     <p>
         <br /><br /><a style="color: black; border-style: solid; border-width: 1px 1px 1px 1px; text-decoration: none; padding: 4px; border-radius: 5px" href="{{var data.link|raw }}" _blank="">
-            {{trans "%paymentInstructions" paymentInstructions="Payment Instructions"}}.
+            {{trans "%paymentInstructions" paymentInstructions="Payment Instructions"}}
         </a><br /><br />
     </p>
     <p>

--- a/view/frontend/email/convenience_store_template.html
+++ b/view/frontend/email/convenience_store_template.html
@@ -1,0 +1,20 @@
+<!--@subject {{trans "Convenience Store Payment"}}  @-->
+{{template config_path="design/email/header_template"}}
+<div>
+    <p>
+        {{trans "%thankyou" thankyou="Thank you for your order."}}</p>
+        {{trans "%message" message="You are now one step away from completing the order. Please follow the link to find the payment instructions to complete the payment "}}.
+    </p>
+    <p>
+        <br /><br /><a style="color: black; border-style: solid; border-width: 1px 1px 1px 1px; text-decoration: none; padding: 4px; border-radius: 5px" href="{{var data.link|raw }}" _blank="">
+            {{trans "%paymentInstructions" paymentInstructions="Payment Instructions."}}
+        </a><br /><br />
+    </p>
+    <p>
+        {{trans "%orderid" orderid="Order ID:"}} <strong>{{var data.orderId|raw}}</strong><br/>
+        {{trans "%amounttopay" amounttopay="Amount to pay:"}} <strong>{{var data.amount|raw}}</strong><br/>
+    </p>
+    
+    <p style="margin-top: 50px"><i>{{var data.storename|raw}}</i></p>
+</div>
+{{template config_path="design/email/footer_template"}}

--- a/view/frontend/email/convenience_store_template.html
+++ b/view/frontend/email/convenience_store_template.html
@@ -7,7 +7,7 @@
     </p>
     <p>
         <br /><br /><a style="color: black; border-style: solid; border-width: 1px 1px 1px 1px; text-decoration: none; padding: 4px; border-radius: 5px" href="{{var data.link|raw }}" _blank="">
-            {{trans "%paymentInstructions" paymentInstructions="Payment Instructions."}}
+            {{trans "%paymentInstructions" paymentInstructions="Payment Instructions"}}.
         </a><br /><br />
     </p>
     <p>


### PR DESCRIPTION
#### 1. Objective

Send the payment instructions to the customer's email for convenience store payment method.

Jira Ticket: ([#1473](https://opn-ooo.atlassian.net/browse/FRON-1473))

#### 2. Description of change

Added an email template `convenience_store_template.html` for the convenience store. In `OmiseHelper.php`, the previous `offlinePaymentMethods` property is changed to `imageCodePaymentMethods` so that `offlinePaymentMethods` could include Convenience store as well. Method `isPayableByImageCode` is replaced by `offlinePaymentMethods` in the `PaymentCreationObserver` since we have to send email for convenience store as well.

#### 3. Quality assurance

Make sure your store is setup for Japan. Place an order using convenience store. You should see following email
<img width="876" alt="Screen Shot 2565-05-26 at 16 40 10" src="https://user-images.githubusercontent.com/101558497/170942126-ac243cd3-72ca-493a-a001-565d177f1474.png">

**🔧 Environments:**

- Platform version: Magento CE 2.4.3
- Omise plugin version: Omise-Magento 2.23.2
- PHP version: 7.1.15
