### PR TITLE
[FRON-1473]: Forgot to rename the method name where it was called. Fi…

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -118,7 +118,7 @@ class Offsite extends Action
         
         $paymentMethod = $payment->getMethod();
 
-        if (!$this->helper->isOffsitePayment($paymentMethod)) {
+        if (!$this->helper->isOffsitePaymentMethod($paymentMethod)) {
             $this->invalid(
                 $order,
                 __('Invalid payment method. Please contact our support if you have any questions.')


### PR DESCRIPTION
#### 1. Objective

The method `isOffisitePayment` was renamed to `isOffsitePaymentMethod` but I forgot to change the method name where it was called. This PR fixes the issue.
