### PR TITLE
Feature/fron 1521

### DIFF
--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -203,6 +203,14 @@ class Threedsecure extends Action
             return (new CaptureResultValidator)->validate($charge);
         }
 
+        if ($this->config->isWebhookEnabled()) {
+            // preventing the order being canceled when the return_uri is hit directly
+            // by the user and not by the Omise server
+            if ($charge['status'] === 'pending' && $charge['authorized'] == false) {
+                return true;
+            }
+        }
+
         return (new AuthorizeResultValidator)->validate($charge);
     }
 

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -65,6 +65,10 @@ class Threedsecure extends Action
      */
     public function execute()
     {
+        if (!$this->helper->validate3DSReferer()) {
+            return $this->redirect(self::PATH_CART);
+        }
+
         $order = $this->session->getLastRealOrder();
 
         if (! $order->getId()) {
@@ -201,14 +205,6 @@ class Threedsecure extends Action
     {
         if ($charge['capture']) {
             return (new CaptureResultValidator)->validate($charge);
-        }
-
-        if ($this->config->isWebhookEnabled()) {
-            // preventing the order being canceled when the return_uri is hit directly
-            // by the user and not by the Omise server
-            if ($charge['status'] === 'pending' && $charge['authorized'] == false) {
-                return true;
-            }
         }
 
         return (new AuthorizeResultValidator)->validate($charge);

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -366,13 +366,13 @@ class OmiseHelper extends AbstractHelper
     }
 
     /**
-     * Validate whether the a URI was triggered by Omiser server or not
+     * Validate whether the a URI was triggered by Omise server or not
      */
     public function validate3DSReferer()
     {
         $refererValue = $this->header->getHttpReferer();
         $isProduction = strpos($refererValue, 'https://api.omise.co') === 0;
-        $isStaging = strpos($this->header->getHttpReferer(), 'https://api.staging-omise.co') === 0;
+        $isStaging = strpos($refererValue, 'https://api.staging-omise.co') === 0;
 
         return $isProduction || $isStaging;
     }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -364,4 +364,16 @@ class OmiseHelper extends AbstractHelper
     {
         return in_array($paymentMethod, $this->cardPaymentMethods);
     }
+
+    /**
+     * Validate whether the a URI was triggered by Omiser server or not
+     */
+    public function validate3DSReferer()
+    {
+        $refererValue = $this->header->getHttpReferer();
+        $isProduction = strpos($refererValue, 'https://api.omise.co') === 0;
+        $isStaging = strpos($this->header->getHttpReferer(), 'https://api.staging-omise.co') === 0;
+
+        return $isProduction || $isStaging;
+    }
 }


### PR DESCRIPTION
#### 1. Objective

Prevent cancelation of order when a user enters the return URI directly in the browser tab in the middle of the transaction.

This section will be used in the release notes. 

Jira Ticket: [#1521](https://opn-ooo.atlassian.net/browse/FRON-1521)

#### 2. Description of change

Added a logic that will check the `REFERER` header to determine whether the `return_uri` was hit by the Omise server or directly by the user. If the `return_uri` is hit by the user then s/he will be directed to the cart page without affecting the order status.

#### 3. Quality assurance

- Setup to use manual capture
- Add items to cart
- Checkout via Card. You will be redirected to the authorize page
- Do nothing on authorize page. Open a new tab
   - Go to the return URI `http://{YOUR_BASE_PATH}/omise/callback/threedsecure`
   - You should be redirected to the _**cart page**_.
 - Go to the authorize page and complete the transaction
 - You should be redirected to the t_**hank you page**_.

After completing these steps, check the **_order status_**. It should not be **_cancelled_**.

_**Cart page**_ (Should be displayed if a user directly access the return URI)
<img width="1383" alt="Screen Shot 2565-06-14 at 12 06 58" src="https://user-images.githubusercontent.com/101558497/173500094-a907622f-3f13-4a5e-abf6-8bd12717e588.png">

_**Thank you page**_ (Should be displayed after the payment is complete)
<img width="1436" alt="Screen Shot 2565-06-14 at 12 37 16" src="https://user-images.githubusercontent.com/101558497/173501362-556144ec-7e72-421d-883e-337d772e8724.png">

**_Order page_**
<img width="1416" alt="Screen Shot 2565-06-14 at 12 40 37" src="https://user-images.githubusercontent.com/101558497/173501655-ca82ef72-29c1-47fb-988e-b7bd47d9a102.png">


**🔧 Environments:**

- Platform version: Magento 2.4.4
Omise plugin version: Omise-Magento 2.26.0
PHP version: 7.4.28