### PR TITLE
Allow GrabPay to have payment in THB

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-grabpay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-grabpay-method.js
@@ -21,7 +21,7 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_offsite_grabpay',
-            restrictedToCurrencies: ['sgd', 'myr']
+            restrictedToCurrencies: ['thb', 'sgd', 'myr']
         });
     }
 );


### PR DESCRIPTION
#### 1. Objective

Add 'thb' as a supported currency for GrabPay.

#### 2. Description of change

N/A

#### 3. Quality assurance

**🔧 Environments:**

- **Platform version**: Magento CE 2.2.3
- **Omise plugin version**: Omise-Magento 2.24.0
- **PHP version**: 7.1.15

**✏️ Details:**

Make sure that GrabPay can be used in Thailand with THB currency.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal.

#### 6. Additional Notes

N/A