### PR TITLE
[FRON-1536]: Refactored the code. Added a logic to reverse the cancel…

### DIFF
--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -37,13 +37,7 @@ class Complete
      * @var Omise\Payment\Model\Api\Charge
      */
     private $charge;
-
-    const ORDER_COMMENT = [
-        'CAPTURED' => 'Amount of %1 has been paid via Omise Payment Gateway.',
-        'AWAIT_CAPTURE' => 'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
-        'PAYMENT_FAILED' => 'Payment failed. %1, please contact our support if you have any questions.'
-    ];
-
+x
     /**
      * There are several cases with the following payment methods
      * that would trigger the 'charge.complete' event.

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -39,7 +39,7 @@ class Complete
     private $charge;
 
     const ORDER_COMMENT = [
-        'CAPTURED' => 'Amount of %1 has been paid via Omise Payment Gateway',
+        'CAPTURED' => 'Amount of %1 has been paid via Omise Payment Gateway.',
         'AWAIT_CAPTURE' => 'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
         'PAYMENT_FAILED' => 'Payment failed. %1, please contact our support if you have any questions.'
     ];
@@ -138,7 +138,7 @@ class Complete
     {
         if ($isCaptured) {
             $transaction = $this->payment->addTransaction(Transaction::TYPE_PAYMENT, $this->invoice);
-            $comment = __( 'Amount of %1 has been paid via Omise Payment Gateway.', $amount );
+            $comment = __( self::ORDER_COMMENT['CAPTURED'], $amount );
         } else {
             $transaction = $this->payment->addTransaction(Transaction::TYPE_AUTH, $this->invoice);
             $comment = __( self::ORDER_COMMENT['AWAIT_CAPTURE'], $amount );

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -122,7 +122,8 @@ class Complete
             return;
         }
 
-        // To handle the situation where charge is manually updated as successful from Omise dashboard after the order is canceled.
+        // To handle the situation where charge is manually updated as successful
+        // from Omise dashboard after the order is canceled.
         if ($this->order->getState() === MagentoOrder::STATE_CANCELED && $this->charge->isSuccessful()) {
             $this->processCancelledOrder($helper, $emailHelper);
         }
@@ -138,13 +139,11 @@ class Complete
     {
         if ($isCaptured) {
             $transaction = $this->payment->addTransaction(Transaction::TYPE_PAYMENT, $this->invoice);
-            $comment = __( self::ORDER_COMMENT['CAPTURED'], $amount );
+            $comment = __('Amount of %1 has been paid via Omise Payment Gateway.', $amount);
         } else {
             $transaction = $this->payment->addTransaction(Transaction::TYPE_AUTH, $this->invoice);
-            $comment = __( self::ORDER_COMMENT['AWAIT_CAPTURE'], $amount );
+            $comment = __('Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).', $amount);
         }
-
-        var_dump($comment);
 
         $this->payment->addTransactionCommentsToOrder($transaction, $comment);
     }
@@ -194,7 +193,7 @@ class Complete
     {
         $items = $this->order->getAllItems();
 
-        foreach($items as $item) {
+        foreach ($items as $item) {
             $item->setQtyCanceled(0);
             $item->save();
         }
@@ -211,7 +210,10 @@ class Complete
             $this->order->addRelatedObject($this->invoice);
         }
 
-        $orderMessage = __(self::ORDER_COMMENT['PAYMENT_FAILED'], ucfirst($this->charge->failure_message));
+        $orderMessage = __(
+            'Payment failed. %1, please contact our support if you have any questions.',
+            ucfirst($this->charge->failure_message)
+        );
         $this->order->registerCancellation($orderMessage)->save();
     }
 }

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -19,6 +19,32 @@ class Complete
     const CODE = 'charge.complete';
 
     /**
+     * @var Magento\Sales\Model\Order\Payment\Interceptor
+     */
+    private $payment;
+
+    /**
+     * @var Magento\Sales\Model\Order\Invoice\Interceptor
+     */
+    private $invoice;
+
+    /**
+     * @var Magento\Sales\Model\Order\Interceptor
+     */
+    private $order;
+
+    /**
+     * @var Omise\Payment\Model\Api\Charge
+     */
+    private $charge;
+
+    const ORDER_COMMENT = [
+        'CAPTURED' => 'Amount of %1 has been paid via Omise Payment Gateway',
+        'AWAIT_CAPTURE' => 'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
+        'PAYMENT_FAILED' => 'Payment failed. %1, please contact our support if you have any questions.'
+    ];
+
+    /**
      * There are several cases with the following payment methods
      * that would trigger the 'charge.complete' event.
      *
@@ -61,71 +87,131 @@ class Complete
         OmiseHelper $helper,
         Config $config
     ) {
-        $charge = $event->data;
+        $this->charge = $event->data;
 
-        if (! $charge instanceof ApiCharge || $charge->getMetadata('order_id') == null) {
+        if (! $this->charge instanceof ApiCharge || $this->charge->getMetadata('order_id') == null) {
             // TODO: Handle in case of improper response structure.
             return;
         }
 
-        $order = $order->loadByIncrementId($charge->getMetadata('order_id'));
-        if (! $order->getId()) {
+        $this->order = $order->loadByIncrementId($this->charge->getMetadata('order_id'));
+
+        if (! $this->order->getId()) {
             // TODO: Handle in case of improper response structure.
             return;
         }
 
-        if (! $payment = $order->getPayment()) {
+        if (! $this->payment = $this->order->getPayment()) {
             // TODO: Handle in case of improper response structure.
             return;
         }
 
-        if ($order->isPaymentReview() || $order->getState() === MagentoOrder::STATE_PENDING_PAYMENT) {
-            if ($charge->isFailed()) {
-
-                if ($order->hasInvoices()) {
-                    $invoice = $order->getInvoiceCollection()->getLastItem();
-                    $invoice->cancel();
-                    $order->addRelatedObject($invoice);
-                } else {
-                    $invoice = $order->getInvoiceCollection()->getLastItem();
-                }
-
-                $order->registerCancellation(
-                    __('Payment failed. ' . ucfirst($charge->failure_message) . ',
-                        please contact our support if you have any questions.')
-                )->save();
+        if ($this->order->isPaymentReview() || $this->order->getState() === MagentoOrder::STATE_PENDING_PAYMENT) {
+            if ($this->charge->isFailed()) {
+                $this->cancelOrder();
+                return;
             }
+
+            $isAwaitingCapture = $this->charge->isAwaitCapture();
 
             // Successful payment
-            if ($charge->isSuccessful() || $charge->isAwaitCapture()) {
-                // Update order state and status.
-                $order->setState(MagentoOrder::STATE_PROCESSING);
-                $order->setStatus($order->getConfig()->getStateDefaultStatus(MagentoOrder::STATE_PROCESSING));
-
-                $invoice = $helper->createInvoiceAndMarkAsPaid($order, $charge->id, !$charge->isAwaitCapture());
-                $emailHelper->sendInvoiceAndConfirmationEmails($order);
-
-                // addTransactionCommentsToOrder with message for authorise or capture
-                if ($charge->isAwaitCapture()) {
-                    $payment->addTransactionCommentsToOrder(
-                        $payment->addTransaction(Transaction::TYPE_AUTH, $invoice),
-                        __(
-                            'Authorized amount of %1 via Omise Payment Gateway (3-D Secure payment).',
-                            $order->getBaseCurrency()->formatTxt($order->getTotalDue())
-                        )
-                    );
-                } else {
-                    $payment->addTransactionCommentsToOrder(
-                        $payment->addTransaction(Transaction::TYPE_PAYMENT, $invoice),
-                        __(
-                            'Amount of %1 has been paid via Omise Payment Gateway',
-                            $order->getBaseCurrency()->formatTxt($invoice->getBaseGrandTotal())
-                        )
-                    );
-                }
-
-                $order->save();
+            if ($this->charge->isSuccessful() || $isAwaitingCapture) {
+                $this->processOrder($helper, $emailHelper, !$isAwaitingCapture);
             }
+
+            return;
         }
+
+        // To handle the situation where charge is manually updated as successful from Omise dashboard after the order is canceled.
+        if ($this->order->getState() === MagentoOrder::STATE_CANCELED && $this->charge->isSuccessful()) {
+            $this->processCancelledOrder($helper, $emailHelper);
+        }
+    }
+
+    /**
+     * Add transaction comments to the order with message for authorise or capture
+     *
+     * @param boolean $isCaptured
+     * @param string $amount
+     */
+    private function transactionCommentToOrder(bool $isCaptured, string $amount)
+    {
+        if ($isCaptured) {
+            $transaction = $this->payment->addTransaction(Transaction::TYPE_PAYMENT, $this->invoice);
+            $comment = __( 'Amount of %1 has been paid via Omise Payment Gateway.', $amount );
+        } else {
+            $transaction = $this->payment->addTransaction(Transaction::TYPE_AUTH, $this->invoice);
+            $comment = __( self::ORDER_COMMENT['AWAIT_CAPTURE'], $amount );
+        }
+
+        var_dump($comment);
+
+        $this->payment->addTransactionCommentsToOrder($transaction, $comment);
+    }
+
+    /**
+     * Complete the transaction and set order status as processing
+     *
+     * @param OmiseHelper $helper
+     * @param OmiseEmailHelper $emailHelper
+     * @param bool $isCaptured Is capture pending
+     */
+    private function processOrder($helper, $emailHelper, $isCaptured = true)
+    {
+        // Update order state and status.
+        $this->order->setState(MagentoOrder::STATE_PROCESSING);
+        $this->order->setStatus($this->order->getConfig()->getStateDefaultStatus(MagentoOrder::STATE_PROCESSING));
+
+        $this->invoice = $helper->createInvoiceAndMarkAsPaid($this->order, $this->charge->id, $isCaptured);
+        $emailHelper->sendInvoiceAndConfirmationEmails($this->order);
+
+        // addTransactionCommentsToOrder with message for authorise or capture
+        $amount = $isCaptured ? $this->invoice->getBaseGrandTotal() : $this->order->getTotalDue();
+        $this->transactionCommentToOrder($isCaptured, $this->order->getBaseCurrency()->formatTxt($amount));
+
+        $this->order->save();
+    }
+
+    /**
+     * Reverse the item status to ordered and process the order. Not reversing the item status
+     * changes the order status to closed/complete even if we set it to be processing
+     *
+     * @param OmiseHelper $helper
+     * @param OmiseEmailHelper $emailHelper
+     */
+    private function processCancelledOrder($helper, $emailHelper)
+    {
+        $this->reverseCancelledItems();
+        $this->processOrder($helper, $emailHelper);
+    }
+
+    /**
+     * Setting the item status from cancelled to ordered to properly set the order status
+     *
+     * @return void
+     */
+    private function reverseCancelledItems()
+    {
+        $items = $this->order->getAllItems();
+
+        foreach($items as $item) {
+            $item->setQtyCanceled(0);
+            $item->save();
+        }
+    }
+
+    /**
+     * Cancel the order by registering payment failure message
+     */
+    private function cancelOrder()
+    {
+        if ($this->order->hasInvoices()) {
+            $this->invoice = $this->order->getInvoiceCollection()->getLastItem();
+            $this->invoice->cancel();
+            $this->order->addRelatedObject($this->invoice);
+        }
+
+        $orderMessage = __(self::ORDER_COMMENT['PAYMENT_FAILED'], ucfirst($this->charge->failure_message));
+        $this->order->registerCancellation($orderMessage)->save();
     }
 }

--- a/Model/Event/Charge/Complete.php
+++ b/Model/Event/Charge/Complete.php
@@ -37,7 +37,7 @@ class Complete
      * @var Omise\Payment\Model\Api\Charge
      */
     private $charge;
-x
+
     /**
      * There are several cases with the following payment methods
      * that would trigger the 'charge.complete' event.

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -69,6 +69,7 @@ class ConfigSectionPaymentPlugin
     {
         $configFields = $configData['groups']['omise']['fields'];
 
+        // if sandbox status is updated the updated value will be under 'value' key else it won't have the value key
         $sandboxStatus = array_key_exists('value', $configFields['sandbox_status'])
             ? $configFields['sandbox_status']['value']
             : $configFields['sandbox_status'];

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -69,7 +69,9 @@ class ConfigSectionPaymentPlugin
     {
         $configFields = $configData['groups']['omise']['fields'];
 
-        $standboxStatus = array_key_exists('value', $configFields['sandbox_status']) ? $configFields['sandbox_status']['value'] : $configFields['sandbox_status'];
+        $standboxStatus = array_key_exists('value', $configFields['sandbox_status'])
+            ? $configFields['sandbox_status']['value']
+            : $configFields['sandbox_status'];
 
         $publicKeyIndex = $standboxStatus ? 'test_public_key' : 'live_public_key';
         $secretKeyIndex = $standboxStatus ? 'test_secret_key' : 'live_secret_key';

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -69,8 +69,10 @@ class ConfigSectionPaymentPlugin
     {
         $configFields = $configData['groups']['omise']['fields'];
 
-        $publicKeyIndex = ($configFields['sandbox_status']) ? 'test_public_key' : 'live_public_key';
-        $secretKeyIndex = ($configFields['sandbox_status']) ? 'test_secret_key' : 'live_secret_key';
+        $standboxStatus = array_key_exists('value', $configFields['sandbox_status']) ? $configFields['sandbox_status']['value'] : $configFields['sandbox_status'];
+
+        $publicKeyIndex = $standboxStatus ? 'test_public_key' : 'live_public_key';
+        $secretKeyIndex = $standboxStatus ? 'test_secret_key' : 'live_secret_key';
 
         $hasPublicKeyUpdated = array_key_exists('value', $configFields[$publicKeyIndex]);
         $hasSecretKeyUpdated = array_key_exists('value', $configFields[$secretKeyIndex]);

--- a/Plugin/ConfigSectionPaymentPlugin.php
+++ b/Plugin/ConfigSectionPaymentPlugin.php
@@ -69,12 +69,12 @@ class ConfigSectionPaymentPlugin
     {
         $configFields = $configData['groups']['omise']['fields'];
 
-        $standboxStatus = array_key_exists('value', $configFields['sandbox_status'])
+        $sandboxStatus = array_key_exists('value', $configFields['sandbox_status'])
             ? $configFields['sandbox_status']['value']
             : $configFields['sandbox_status'];
 
-        $publicKeyIndex = $standboxStatus ? 'test_public_key' : 'live_public_key';
-        $secretKeyIndex = $standboxStatus ? 'test_secret_key' : 'live_secret_key';
+        $publicKeyIndex = $sandboxStatus ? 'test_public_key' : 'live_public_key';
+        $secretKeyIndex = $sandboxStatus ? 'test_secret_key' : 'live_secret_key';
 
         $hasPublicKeyUpdated = array_key_exists('value', $configFields[$publicKeyIndex]);
         $hasSecretKeyUpdated = array_key_exists('value', $configFields[$secretKeyIndex]);


### PR DESCRIPTION
#### 1. Objective

Update the order status when charge status is updated manually by Operations Team.

Jira Ticket: [#1536](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-247)

#### 2. Description of change

Added a logic to reverse the cancelled order and set the status as processing when the order status is cancelled and the charge is successful. This will be triggered via the webhook. Refactored the `Complete.php` file.

#### 3. Quality assurance

- Checkout with any item
- On reaching the authorize page,
   - First, test by authorizing the payment
   - Second, test by not authorizing the payment. Simply close the page once you reach there.
- On Magento admin, find the order and cancel it manually.
   - You can cancel the order from Omise admin dashboard by marking the charge as failed.
- On Omise admin dashboard, find the charge and mark it as a success.
- On Magento admin, check the order you just cancelled. It status should be set to processing and appropriate comment should be there in the comment history.

**🔧 Environments:**

- Platform version: Magento 2.4.4
- Omise plugin version: Omise-Magento 2.26.0
- PHP version: 7.4.28