### PR TITLE
[PLUGINS-265]: Order status history will be updated for the refund. T…

### DIFF
--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -131,7 +131,11 @@ class SyncStatus
      */
     private function refund($order, $charge)
     {
-        if ($charge['funding_amount'] == $charge['refunded_amount']) {
+        $refundedAmount = isset($charge['refunded_amount'])
+            ? $charge['refunded_amount']
+            : $charge['refunded'];
+
+        if ($charge['funding_amount'] == $refundedAmount) {
             $order->setState(Order::STATE_CLOSED);
             $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
         }

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -94,27 +94,18 @@ class SyncStatus
     /**
      * @param Order $order
      * @param array $charge
+     * @return void
      */
     private function markPaymentSuccessful($order, $charge)
     {
-        $refunded_amount = isset($charge['refunded_amount'])
-            ? $charge['refunded_amount']
-            : $charge['refunded'];
-
-        if ($charge['funding_amount'] == $refunded_amount) {
-            $order->addStatusHistoryComment(
-                __(
-                    'Omise: Payment refunded.<br/>An amount %1 %2 has been refunded (manual sync).',
-                    number_format($order->getGrandTotal(), 2, '.', ''),
-                    $order->getOrderCurrencyCode()
-                )
-            );
-
-            $order->save();
-            return;
+        if ($charge['refunds'] && $order->getState() != Order::STATE_CLOSED) {
+            return $this->refund($order, $charge);
         }
 
-        if ($order->getState() != Order::STATE_COMPLETE && $order->getState() != Order::STATE_PROCESSING) {
+        // Payment will be already processed for the following states
+        $orderStates = [Order::STATE_COMPLETE, Order::STATE_CLOSED, Order::STATE_PROCESSING];
+
+        if (!in_array($order->getState(), $orderStates)) {
             $order->setState(Order::STATE_PROCESSING);
             $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
 
@@ -128,7 +119,30 @@ class SyncStatus
                     $order->getOrderCurrencyCode()
                 )
             );
+
+            $order->save();
         }
+    }
+
+    /**
+     * @param Order $order
+     * @param array $charge
+     * @return void
+     */
+    private function refund($order, $charge)
+    {
+        if ($charge['funding_amount'] == $charge['refunded_amount']) {
+            $order->setState(Order::STATE_CLOSED);
+            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
+        }
+
+        $order->addStatusHistoryComment(
+            __(
+                'Omise: Payment refunded.<br/>An amount of %1 %2 has been refunded (manual sync).',
+                number_format($charge['refunded_amount']/100, 2, '.', ''),
+                $order->getOrderCurrencyCode()
+            )
+        );
 
         $order->save();
     }


### PR DESCRIPTION
#### 1. Objective

Enhance manual sync button so it can be used to manually update order status to reflect refunds 

Jira: [#265](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-265)

#### 2. Description of change

Logic is updated to record the refunds. A new refund method is added that adds the refund order status history and updates the order status to close only if the amount is fully refunded.

#### 3. Quality assurance

- Checkout with an item
- On the Omise dashboard, refund the amount.
- On the Magento dashboard, go to the order and click on `Sync Order Stautus` button
   - If the refund is partial then it should only record the status history comment.
   - If the refund is full then it should record the status history comment and update the order status to `closed`.

**🔧 Environments:**

- Platform version: Magento 2.4.4
- Omise plugin version: Omise-Magento 2.27.0
- PHP version: 7.4.28