### PR TITLE
[PLUGINS-250] : fix trim do not accept null value in php 8

### DIFF
--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -74,11 +74,12 @@ class Config
      */
     public function getValue($field, $code = self::CODE)
     {
-        return trim($this->scopeConfig->getValue(
+        $value = $this->scopeConfig->getValue(
             'payment/' . $code . '/' . $field,
             MagentoScopeInterface::SCOPE_STORE,
             $this->storeId ?? null
-        ));
+        );
+        return $value ? trim($value) : null;
     }
 
     /**


### PR DESCRIPTION
#### 1. Fix trim do not accept null value in php 8

- Fix trim() do not accept null value in php 8

**Related information**:
[PLUGINS-250](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-250)

**🔧 Environments:**
- **Platform version**: Magento CE 2.4.4
- **PHP version**: >= 8.0.