### PR TITLE
[ENGA3-250]: upgrade omise php version to 2.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "type": "magento2-module",
     "license": "MIT",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7",
+        "php": ">=7.4",
         "magento/magento-composer-installer": ">=0.3.0",
-        "omise/omise-php": "2.13.0"
+        "omise/omise-php": "2.15.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.5.0",


### PR DESCRIPTION
#### 1. Objective

Upgrade omise php version to 2.15.0

[#ENGA3-250](https://opn-ooo.atlassian.net/browse/ENGA3-250)

#### 2. Description of change

Upgrade to latest omise php version 2.15.0 which support php 8.1 and replace curl with guzzle client.

#### 3. Quality assurance

- Tested on card payment.

**🔧 Environments:**

- **Platform version**: Magento CE 2.4.4
- **Omise PHP version**: 2.15.0.
- **PHP version**: 8.1.

#### 4. Impact of the change

#### 5. Priority of change

Normal

#### 6. Additional Notes