### PR TITLE
[ENGA-276]: Issue of our cronjob script looking for a charge in the d…

### DIFF
--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -37,6 +37,7 @@ class SyncStatus
         $this->emailHelper = $emailHelper;
         $this->config = $config;
     }
+
     /**
      * @param Order $order
      * @return void
@@ -98,7 +99,7 @@ class SyncStatus
      */
     private function markPaymentSuccessful($order, $charge)
     {
-        if ($charge['refunds'] && $order->getState() != Order::STATE_CLOSED) {
+        if ($charge['refunds']['data'] && $order->getState() != Order::STATE_CLOSED) {
             return $this->refund($order, $charge);
         }
 

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -99,8 +99,15 @@ class SyncStatus
      */
     private function markPaymentSuccessful($order, $charge)
     {
-        if ($charge['refunds']['data'] && $order->getState() != Order::STATE_CLOSED) {
-            return $this->refund($order, $charge);
+        $refundKeyExist = array_key_exists('refunds', $charge);
+        $orderStateNotClosed = $order->getState() != Order::STATE_CLOSED;
+
+        if ($refundKeyExist && $orderStateNotClosed) {
+            $dataKeyExist = array_key_exists('data', $charge['refunds']);
+
+            if($dataKeyExist && $charge['refunds']['data']) {
+                return $this->refund($order, $charge);
+            }
         }
 
         // Payment will be already processed for the following states

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -105,7 +105,7 @@ class SyncStatus
         if ($refundKeyExist && $orderStateNotClosed) {
             $dataKeyExist = array_key_exists('data', $charge['refunds']);
 
-            if($dataKeyExist && $charge['refunds']['data']) {
+            if ($dataKeyExist && $charge['refunds']['data']) {
                 return $this->refund($order, $charge);
             }
         }


### PR DESCRIPTION
#### 1. Objective

Fix the issue of an order getting canceled citing Payment expired when the charge was completed successfully.

Jira: [#276](https://opn-ooo.atlassian.net/browse/ENGA3-276)

#### 2. Description of change
Similar to this PR [#336](https://github.com/omise/omise-magento/pull/336l), our cron script was looking for a charge in the default store where instead of the the store from where the order was ordered.

- Added a code that gets the store ID from an oder and sets the store ID property of the config class. With this, the plugin will fetch the correct keys from the DB instead of the default store's keys.
- Made a slight change in the `Model/SyncStatus.php` so that we check the `data` key from the `refund` object instead of the whole object because `data` key holds the actual refund object.

#### 3. Quality assurance

Run these commands
```
// create crontab
$ bin/magento cron:install

// run our cron group
$ bin/magento cron:run --group omise
```

**🔧 Environments:**

- Platform version: Magento 2.4.4
- Omise plugin version: Omise-Magento 2.27.0
- PHP version: 7.4.28
