### PR TITLE
Issue#369: setup:di:complie issue on Omise\Payment\Block\Adminhtml\Sy…

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/Webhook.php
+++ b/Block/Adminhtml/System/Config/Form/Field/Webhook.php
@@ -22,17 +22,15 @@ class Webhook extends Field
 
     /**
      * @param \Magento\Backend\Block\Template\Context $context
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Framework\App\Request\Http $http
      * @param array $data
      */
     public function __construct(
         Context $context,
-        StoreManagerInterface $storeManager,
         Http $request,
         array   $data = []
     ) {
-        $this->storeManager = $storeManager;
+        $this->storeManager = $context->getStoreManager();
         $this->request = $request;
         parent::__construct($context, $data);
     }


### PR DESCRIPTION
…stem\Config\Form\Field\Webhook

#### 1. Objective

Error setup:di:complie issue on Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook

**Related information**:
Related issue(s): #369 

#### 2. Description of change

Incorrect dependency in class Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook in vendor/omise/omise-magento/Block/Adminhtml/System/Config/Form/Field/Webhook.php
\Magento\Store\Model\StoreManagerInterface already exists in context object


#### 3. Quality assurance

**🔧 Environments:**
- **Platform version**: Magento All versions
- **Omise plugin version**: Omise-Magento 2.27.0
- **PHP version**: Up to magento version

**✏️ Details:**

Run deployment on production or specific `php bin/magento setup:di:complie`

#### 4. Impact of the change

No impact the context of Block already defined the StoreManagerInterface

#### 5. Priority of change

Immediate
