### PR TITLE
[ENGA3-265]: Change array_key_exists to property_exists method to che…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# example: *.js    @octocat @github/js
+
+# These owners will be the default owners for everything in the repo.
+* @aashishgurung
+* @ajzkk

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -99,7 +99,7 @@ class SyncStatus
      */
     private function markPaymentSuccessful($order, $charge)
     {
-        $refundKeyExist = array_key_exists('refunds', $charge);
+        $refundKeyExist = property_exists($charge, 'refunds');
         $orderStateNotClosed = $order->getState() != Order::STATE_CLOSED;
 
         if ($refundKeyExist && $orderStateNotClosed) {

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -99,15 +99,10 @@ class SyncStatus
      */
     private function markPaymentSuccessful($order, $charge)
     {
-        $refundKeyExist = property_exists($charge, 'refunds');
         $orderStateNotClosed = $order->getState() != Order::STATE_CLOSED;
 
-        if ($refundKeyExist && $orderStateNotClosed) {
-            $dataKeyExist = array_key_exists('data', $charge['refunds']);
-
-            if ($dataKeyExist && $charge['refunds']['data']) {
-                return $this->refund($order, $charge);
-            }
+        if ($this->shouldRefund($charge) && $orderStateNotClosed) {
+            return $this->refund($order, $charge);
         }
 
         // Payment will be already processed for the following states
@@ -130,6 +125,17 @@ class SyncStatus
 
             $order->save();
         }
+    }
+
+    /**
+     * @param object $charge
+     * @return boolean
+     */
+    private function shouldRefund($charge)
+    {
+        return isset($charge['refunds']) &&
+            isset($charge['refunds']['data']) &&
+            count($charge['refunds']['data']) !== 0;
     }
 
     /**


### PR DESCRIPTION
#### 1. Objective

Fix the issue of `Sync Order Status` button not working.

#### 2. Description of change

The `array_key_exists()` was used to check whether the properties exists in the object or not. Use of `array_key_exists()` on objects is deprecated. So, it is being replaced by `property_exists()` method.

#### 3. Quality assurance

Click on the `Sync Order Status` button. It should not show the following error.

<img width="991" alt="image (2)" src="https://user-images.githubusercontent.com/101558497/186811284-093e1556-0263-4eaa-ad34-02cae8f30084.png">


**🔧 Environments:**

- Platform version: Magento 2.4.4
- Omise plugin version: Omise-Magento 2.27.0
- PHP version: 7.4.28