### PR TITLE
[ENGA3-293]: Upgraded Omise PHP to version 2.16.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "type": "magento2-module",
     "license": "MIT",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7",
+        "php": ">=5.6",
         "magento/magento-composer-installer": ">=0.3.0",
-        "omise/omise-php": "2.13.0"
+        "omise/omise-php": "2.16.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.5.0",
+        "phpunit/phpunit": "^5.7 || ^9.5",
         "magento/community-edition": "2.4.4"
     },
     "autoload": {


### PR DESCRIPTION
…gin compatible from PHP 5.6 to 8.1.

#### 1. Objective

To make Omise Magento plugin compatible with PHP 5.6 to 8.1

Jira: [#293](https://opn-ooo.atlassian.net/browse/ENGA3-293)

#### 2. Description of change

Updated the version of omise-php in the composer.json.

#### 3. Quality assurance

Test by doing following action
- Checkout a product by enabling/disabling webhook
- Sync order status

**🔧 Environments:**

- Platform version: Magento 2.3.0-2.4.4
- Omise plugin version: Omise-Magento 2.27.0
- PHP version: 7.1-8.1