### PR TITLE
Releasing v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [v2.29.0 _(Sept 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.29.0)
+- Upgraded Omise PHP to version 2.16.0 (PR [#375] https://github.com/omise/omise-magento/pull/375)
+- Fix the issue of not redirecting to Thank you page. (PR [#376] https://github.com/omise/omise-magento/pull/376)
+- Added pipeline to deploy on staging. (PR [#380] https://github.com/omise/omise-magento/pull/380)
+- Added pipeline for code coverage with sonarcloud. (PR [#379] https://github.com/omise/omise-magento/pull/379)
+
 ## [v2.28.0 _(Aug 30, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.28.0)
 - Order status will be updated via webhook when charge status is updated manually by Operations Team. (PR [#359](https://github.com/omise/omise-magento/pull/359))
 - Enhanced manual sync button to manually update order status to reflect refunds. (PR [#362](https://github.com/omise/omise-magento/pull/362))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
 ## [v2.29.0 _(Sept 19, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.29.0)
-- Upgraded Omise PHP to version 2.16.0 (PR [#375] https://github.com/omise/omise-magento/pull/375)
-- Fix the issue of not redirecting to Thank you page. (PR [#376] https://github.com/omise/omise-magento/pull/376)
-- Added pipeline to deploy on staging. (PR [#380] https://github.com/omise/omise-magento/pull/380)
-- Added pipeline for code coverage with sonarcloud. (PR [#379] https://github.com/omise/omise-magento/pull/379)
+- Upgraded Omise PHP to version 2.16.0 (PR [#375](https://github.com/omise/omise-magento/pull/375))
+- Fix the issue of not redirecting to Thank you page. (PR [#376](https://github.com/omise/omise-magento/pull/376))
+- Added pipeline to deploy on staging. (PR [#380](https://github.com/omise/omise-magento/pull/380))
+- Added pipeline for code coverage with sonarcloud. (PR [#379](https://github.com/omise/omise-magento/pull/379))
 
 ## [v2.28.0 _(Aug 30, 2022)_](https://github.com/omise/omise-magento/releases/tag/v2.28.0)
 - Order status will be updated via webhook when charge status is updated manually by Operations Team. (PR [#359](https://github.com/omise/omise-magento/pull/359))

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
             "email": "support@omise.co"
         }
     ],
-    "version": "2.28.0",
+    "version": "2.29.0",
     "minimum-stability": "stable",
     "type": "magento2-module",
     "license": "MIT",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Omise_Payment" setup_version="2.28.0">
+    <module name="Omise_Payment" setup_version="2.29.0">
       <sequence>
         <module name="Magento_Sales"/>
         <module name="Magento_Payment"/>


### PR DESCRIPTION
Releasing v2.29.0

- Upgraded Omise PHP to version 2.16.0 (PR: https://github.com/omise/omise-magento/pull/375)
- Fix the issue of not redirecting to Thank you page. (PR: https://github.com/omise/omise-magento/pull/376)
- Added pipeline to deploy on staging. PR: https://github.com/omise/omise-magento/pull/380)
- Added pipeline for code coverage with sonarcloud. (PR: https://github.com/omise/omise-magento/pull/379)