### PR TITLE
[ENGA3-497]: Fixed an issue of syncing order status from Magento after reversing a charge not updating the product's quantity.

### DIFF
--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -178,8 +178,7 @@ class SyncStatus
                 $charge['failure_message'],
                 $charge['failure_code']
             )
-        )
-        $order->save();
+        )->save();
     }
 
     /**

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -178,7 +178,7 @@ class SyncStatus
                 $charge['failure_message'],
                 $charge['failure_code']
             )
-        )->save();
+        )
         $order->save();
     }
 
@@ -214,9 +214,7 @@ class SyncStatus
     private function markPaymentReversed($order)
     {
         $this->cancelOrderInvoice($order);
-        $order->registerCancellation(
-            __('Omise: Payment reversed. (manual sync).')
-        )->save();
-        $order->save();
+        $order->registerCancellation(__('Omise: Payment reversed. (manual sync).'))
+            ->save();
     }
 }

--- a/Model/SyncStatus.php
+++ b/Model/SyncStatus.php
@@ -213,12 +213,10 @@ class SyncStatus
      */
     private function markPaymentReversed($order)
     {
-        $order->addStatusHistoryComment(__('Omise: Payment reversed. (manual sync).'));
-
-        if ($order->getState() != Order::STATE_CANCELED) {
-            $order->setState(Order::STATE_CANCELED)->setStatus(Order::STATE_CANCELED);
-        }
-
+        $this->cancelOrderInvoice($order);
+        $order->registerCancellation(
+            __('Omise: Payment reversed. (manual sync).')
+        )->save();
         $order->save();
     }
 }


### PR DESCRIPTION
#### 1. Objective

Fixed an issue of syncing order status from Magento after reversing a charge not updating the product's quantity.

Jira Ticket: [#497](https://opn-ooo.atlassian.net/browse/ENGA3-497)

#### 2. Description of change

Changed the implementation from just adding status comment and changing status to cancelling the order and invoice.

#### 3. Quality assurance

- See the quantity of the product before placing order
- Checkout via card
- Go to Omise dashboard and reverse the charge
- Go to Magento order page and click on `Sync Order Status`
- You should see the status set to `cancelled` and the comment history like shown in the the following picture
- Check the total quantity of the product. It should be same as before placing order.

<img width="523" alt="Screen Shot 2565-09-29 at 14 46 38" src="https://user-images.githubusercontent.com/101558497/192989269-5d556cd1-c659-49f2-b77e-9701e5d2b565.png">


**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.0
- PHP version: 8.1