### PR TITLE
[ENGA3-510]: Issue of two invoices of the same order has been fixed.

### DIFF
--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -453,8 +453,7 @@ class OmiseHelper extends AbstractHelper
             return;
         }
 
-        $statusToSendInvoice = $this->config->getSendInvoiceAtOrderStatus();
-        $isOrderStatusPending = substr(strrchr($statusToSendInvoice, '\\'), 1) === 'Order::STATE_PENDING_PAYMENT';
+        $isOrderStatusPending = $this->config->getSendInvoiceAtOrderStatus() === Order::STATE_PENDING_PAYMENT;
 
         if ($order->hasInvoices() && $isOrderStatusPending) {
             $invoice = $order->getInvoiceCollection()->getLastItem();

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -453,7 +453,10 @@ class OmiseHelper extends AbstractHelper
             return;
         }
 
-        if ($order->hasInvoices() && $this->config->getSendInvoiceAtOrderStatus() == Order::STATE_PENDING_PAYMENT) {
+        $statusToSendInvoice = $this->config->getSendInvoiceAtOrderStatus();
+        $isOrderStatusPending = substr(strrchr($statusToSendInvoice, '\\'), 1) === 'Order::STATE_PENDING_PAYMENT';
+
+        if ($order->hasInvoices() && $isOrderStatusPending) {
             $invoice = $order->getInvoiceCollection()->getLastItem();
         } else {
             $invoice = $order->prepareInvoice();

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -5,6 +5,7 @@ namespace Omise\Payment\Model\Config;
 use Magento\Framework\App\Config\ScopeConfigInterface as MagentoScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface as MagentoScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Sales\Model\Order;
 
 class Config
 {
@@ -181,6 +182,16 @@ class Config
      */
     public function getSendInvoiceAtOrderStatus()
     {
-        return $this->getValue('generate_invoice_at_order_status');
+        $orderStatus = $this->getValue('generate_invoice_at_order_status');
+
+        // Previously, our default value of 'Generate invoice at order status' was
+        // '\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT'. So, this is for the
+        // merchants who have already installed our module so that they don't have
+        // to update the `Generate invoice at order status` setting
+        if($orderStatus === '\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT') {
+            return Order::STATE_PENDING_PAYMENT;
+        }
+
+        return $orderStatus;
     }
 }

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -188,7 +188,7 @@ class Config
         // '\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT'. So, this is for the
         // merchants who have already installed our module so that they don't have
         // to update the `Generate invoice at order status` setting
-        if($orderStatus === '\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT') {
+        if ($orderStatus === '\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT') {
             return Order::STATE_PENDING_PAYMENT;
         }
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
             <omise>
                 <sandbox_status>0</sandbox_status>
                 <model>OmiseAdapter</model>
-                <generate_invoice_at_order_status>\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT</generate_invoice_at_order_status>
+                <generate_invoice_at_order_status>pending_payment</generate_invoice_at_order_status>
                 <webhook_status>1</webhook_status>
             </omise>
 


### PR DESCRIPTION
#### 1. Objective

Fix the issue of two invoices of the same order.

Jira Ticket: [#510](https://opn-ooo.atlassian.net/browse/ENGA3-510)

#### 2. Description of change

The default value of `Generate invoice at order status` was set to `\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT`. So, comparing the return value of `$this->config->getSendInvoiceAtOrderStatus()` with `Order::STATE_PENDING_PAYMENT` for equality was failing. We had to manually change the value to set the proper value which are either `pending_payment` and `processing`.

With this PR, we changed the default value to `pending_payment`. For the merchants who have already installed our plugin, we added an `if` check that returns `pending_payment` from `Order:STATE_PENDING_PAYMENT` if the setting's value is `\Magento\Sales\Model\Order::STATE_PENDING_PAYMENT`.


**_After the fix_**

https://user-images.githubusercontent.com/101558497/194837362-69a7b35f-7883-4f8e-ad91-30e2a8506b72.mov



**_Before the fix_**

https://user-images.githubusercontent.com/101558497/194840419-d5be63b2-7df5-405d-a264-dc9b871c5675.mov




#### 3. Quality assurance

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.1
- PHP version: 8.1

**✏️ Details:**

- Enable webhook
- Enable credit card
- Set payment action to `Authorize and Capture`
- Checkout with 3DS.

You should see only one invoice and the amount should be paid.
