### PR TITLE
[ENGA3-520]: Fixed the issue of FPX redirecting to cart page with invalid order status. Also added a delay in  redirect process before fetching charge status.

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -131,7 +131,7 @@ class Offsite extends Action
             return $this->redirect(self::PATH_CART);
         }
 
-        $orderState = $order->getState()
+        $orderState = $order->getState();
 
         if ($orderState === Order::STATE_PROCESSING) {
             return $this->redirect(self::PATH_SUCCESS);

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -137,6 +137,8 @@ class Threedsecure extends Action
         }
 
         try {
+            // adding delay to cover the delay in updating the charge status in the Omise backend
+            usleep(500000);
             $charge = \OmiseCharge::retrieve($charge_id, $this->config->getPublicKey(), $this->config->getSecretKey());
 
             $result = $this->validate($charge);


### PR DESCRIPTION
#### 1. Objective

Fixed the issue of FPX redirecting to cart page with invalid order status. Also added a delay in  redirect process before fetching charge status.

Jira Ticket: [#520](https://opn-ooo.atlassian.net/browse/ENGA3-520)

#### 2. Description of change

Currently our plugin checks for processing and pending order state only. This caused issue when the webhook updated the order state to failed before customer reaching the redirect URL. So, we added a check for failed order state as well for Offsite.

Plus, we added a delay of 0.5 secs in Offsite and Threedsecure redirect flow before fetching the charge. This delay will be removed once the payment flow is changed in the backend.

#### 3. Quality assurance

Configuration settings
- Set webhook to `Yes`
- Set Generate invoice at order status to Processing

Test
- Checkout with FPX
  - Choose Maybank2U
- Click cancel at Maybank2U login page.

**🔧 Environments:**

Specify the details of your test environments, including, for each, the platform version (on which the plugin was run), the Omise plugin version, and the versions of your system software such as PHP or Ruby.

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.1
- PHP version: 8.1