### PR TITLE
[ENGA3-517]: Fixed conflict between COD with the plugin

### DIFF
--- a/Block/Checkout/Onepage/Success/ConveniencestoreAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/ConveniencestoreAdditionalInformation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Omise\Payment\Block\Checkout\Onepage\Success;
 
 class ConveniencestoreAdditionalInformation extends \Magento\Framework\View\Element\Template
@@ -29,17 +30,24 @@ class ConveniencestoreAdditionalInformation extends \Magento\Framework\View\Elem
      */
     protected function _toHtml()
     {
-        $paymentData = $this->_checkoutSession->getLastRealOrder()->getPayment()->getData();
-        $paymentType = $paymentData['additional_information']['payment_type'];
+        $order = $this->_checkoutSession->getLastRealOrder();
+        $paymentData = $order->getPayment()->getData();
+        $paymentAdditionalInfo = $paymentData['additional_information'];
+
+        if (!array_key_exists('payment_type', $paymentAdditionalInfo)) {
+            return;
+        }
+
+        $paymentType = $paymentAdditionalInfo['payment_type'];
 
         if (!isset($paymentType) || $paymentType !== 'econtext') {
             return;
         }
 
-        $orderCurrency = $this->_checkoutSession->getLastRealOrder()->getOrderCurrency()->getCurrencyCode();
+        $orderCurrency = $order->getOrderCurrency()->getCurrencyCode();
 
         $this->addData([
-            'link' => $paymentData['additional_information']['charge_authorize_uri'],
+            'link' => $paymentAdditionalInfo['charge_authorize_uri'],
             'order_amount' => number_format($paymentData['amount_ordered'], 2) .' '.$orderCurrency
         ]);
         

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -5,14 +5,26 @@
     </head>
     <body>
         <referenceContainer name="order.success.additional.info">
-            <block class="Omise\Payment\Block\Checkout\Onepage\Success\TescoAdditionalInformation" name="onepage.success.tesco"
-                template="Omise_Payment::checkout/onepage/success/tesco_additional_info.phtml"/>
-            <block class="Omise\Payment\Block\Checkout\Onepage\Success\PaynowAdditionalInformation" name="onepage.success.paynow"
-                template="Omise_Payment::checkout/onepage/success/paynow_additional_info.phtml"/>
-            <block class="Omise\Payment\Block\Checkout\Onepage\Success\PromptpayAdditionalInformation" name="onepage.success.promptpay"
-                template="Omise_Payment::checkout/onepage/success/promptpay_additional_info.phtml"/>
-            <block class="Omise\Payment\Block\Checkout\Onepage\Success\ConveniencestoreAdditionalInformation" name="onepage.success.conv_store"
-                template="Omise_Payment::checkout/onepage/success/conv_store_additional_info.phtml"/>
+            <block
+                class="Omise\Payment\Block\Checkout\Onepage\Success\TescoAdditionalInformation"
+                name="onepage.success.tesco"
+                template="Omise_Payment::checkout/onepage/success/tesco_additional_info.phtml"
+            />
+            <block
+                class="Omise\Payment\Block\Checkout\Onepage\Success\PaynowAdditionalInformation"
+                name="onepage.success.paynow"
+                template="Omise_Payment::checkout/onepage/success/paynow_additional_info.phtml"
+            />
+            <block
+                class="Omise\Payment\Block\Checkout\Onepage\Success\PromptpayAdditionalInformation"
+                name="onepage.success.promptpay"
+                template="Omise_Payment::checkout/onepage/success/promptpay_additional_info.phtml"
+            />
+            <block
+                class="Omise\Payment\Block\Checkout\Onepage\Success\ConveniencestoreAdditionalInformation"
+                name="onepage.success.conv_store"
+                template="Omise_Payment::checkout/onepage/success/conv_store_additional_info.phtml"
+            />
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
#### 1. Objective

Fixed conflict between COD with the plugin

Jira Ticket: [#517](https://opn-ooo.atlassian.net/browse/ENGA3-517)

#### 2. Description of change

Fixed the undefined index: payment_type issue by adding a check to determine whether the key exist of not and ending the flow by returning if the key does not exist.

#### 3. Quality assurance

- Enable developer mode running `bin/magento deploy:mode:set developer`
- Enable COD
- Checkout with COD. You will see the [screen](blob:https://opn-ooo.atlassian.net/41c29e5f-fb59-4287-9d68-11f42ba63719#media-blob-url=true&id=dff77b01-1bd9-41cb-a42b-88bfb9408dae&contextId=97291&collection=) mentioned in the ticket

If you don't see the error on screen then check the log file in `{MAGENTO_ROOT}/var/log/debug.log`. You will see a message with `Udefined index: payment_type in {MAGENTO_ROOT}/Block/Checkout/Onepage/Success/ConveniencestoreAdditionalInformation.php on line 33`

**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.1
- PHP version: 8.1