### PR TITLE
[ENGA3-540]: Call omise refund after offline refund event triggered

### DIFF
--- a/Observer/SaleOrderPaymentRefund.php
+++ b/Observer/SaleOrderPaymentRefund.php
@@ -48,13 +48,20 @@ class SaleOrderPaymentRefund implements ObserverInterface
                 if (!$chargeId) {
                     return $this;
                 }
-                $charge = OmiseCharge::retrieve($chargeId, $this->config->getPublicKey(), $this->config->getSecretKey());
-                $amountToRefund = $this->helper->omiseAmountFormat($charge['currency'], $payment['base_amount_refunded']);
+                $charge = OmiseCharge::retrieve(
+                    $chargeId,
+                    $this->config->getPublicKey(),
+                    $this->config->getSecretKey()
+                );
+                $amountToRefund = $this->helper->omiseAmountFormat(
+                    $charge['currency'],
+                    $payment['base_amount_refunded']
+                );
                 $charge->refund(['amount' => $amountToRefund]);
             }
             return $this;
         } catch (Exception $e) {
-            throw new Exception($e->getMessage());
+            throw $e;
         }
     }
 }

--- a/Observer/SaleOrderPaymentRefund.php
+++ b/Observer/SaleOrderPaymentRefund.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Omise\Payment\Observer;
+
+use Exception;
+use Omise\Payment\Model\Config\Config;
+use Omise\Payment\Helper\OmiseHelper;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use OmiseCharge;
+
+class SaleOrderPaymentRefund implements ObserverInterface
+{
+    /**
+     * Omise\Payment\Model\Config\Config
+     */
+    private $config;
+
+    /**
+     * @param Config $config
+     * @param OmiseHelper $helper
+     */
+    public function __construct(Config $config, OmiseHelper $helper)
+    {
+        $this->config = $config;
+        $this->helper = $helper;
+    }
+
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     * @return $this
+     */
+    public function execute(Observer $observer)
+    {
+        try {
+            $order = $observer->getEvent();
+            if(!$order) {
+                return $this;
+            }
+            $payment = $order->getPayment();
+            if(!$payment) {
+                return $this;
+            }
+            $method = $payment->getMethod();
+            // if method is not omise return and end
+            if (strpos($method, 'omise')) {
+               return $this;
+            }
+            $chargeId = $payment->getAdditionalInformation('charge_id');
+            if(!$chargeId) {
+                return $this;
+            }
+            $charge = OmiseCharge::retrieve($chargeId, $this->config->getPublicKey(), $this->config->getSecretKey());
+            $amountToRefund = $this->helper->omiseAmountFormat($charge['currency'], $payment['base_amount_refunded']);
+            $charge->refund(['amount' => $amountToRefund]);
+            return $this;
+        } catch (Exception $e) {
+            throw new Exception($e->getMessage());
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -39,6 +39,10 @@
         <observer name="omise_end_order" instance="Omise\Payment\Observer\PaymentCreationObserver" />
     </event>
 
+    <event name="sales_order_payment_refund">
+        <observer name="sales_order_payment_refund" instance="Omise\Payment\Observer\SaleOrderPaymentRefund" />
+    </event>
+
     <!-- Webhook -->
     <event name="omise_payment_webhook_charge_complete">
         <observer name="omise_payment_webhook_charge_complete_observer" instance="Omise\Payment\Observer\WebhookObserver\WebhookCompleteObserver" />


### PR DESCRIPTION
#### 1. Objective

Omise refund after offline refund event triggered

**Related information**:
[ENGA3-540](https://opn-ooo.atlassian.net/browse/ENGA3-540)

#### 2. Description of change

- Register sales_order_payment_refund event in `etc/events.xml`
- and handle omise refund with `SaleOrderPaymentRefund` class

#### 3. Quality assurance

Tested with credit_card and RMS payment method

**🔧 Environments:**
- **Platform version**: Magento CE 2.4.5
- **Omise plugin version**: 2.15.0
- **PHP version**: 8.1

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A