### PR TITLE
[ENGA3-540] : Fixed duitnowobw bank list not showing

### DIFF
--- a/view/frontend/web/template/payment/offsite-duitnowobw-form.html
+++ b/view/frontend/web/template/payment/offsite-duitnowobw-form.html
@@ -42,6 +42,7 @@
             <!-- /ko -->
             <!--/ko-->
         </div>
+        <!-- ko if: banks().length -->
         <form class="form" data-bind="attr: {
               id: getCode() + 'Form',
               }">


### PR DESCRIPTION
#### 1. Objective

Fixed duitnowobw bank list not showing

`<!-- ko if: banks().length -->` was missing 

[ENGA3-540](https://opn-ooo.atlassian.net/browse/ENGA3-540)

#### 2. Description of change

add below line before showing bank list which break to complete if condition 
`<!-- ko if: banks().length -->` 

#### 3. Quality assurance

Use Malaysia PSP for duitnowobw APM and try to make payment.

**🔧 Environments:**

i.e.
- **Platform version**: Magento CE 2.4.5
- **PHP version**: 8.1.

**✏️ Details:**

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A