### PR TITLE
[ENGA3-618]: Credit memo will be automatically created for full refund if merchant clicks Sync status update button on order.

### DIFF
--- a/Model/RefundSyncStatus.php
+++ b/Model/RefundSyncStatus.php
@@ -53,7 +53,7 @@ class RefundSyncStatus
             $order->hasInvoices();
 
         if ($createCreditMemo) {
-            $this->createCredtMemo($order);
+            $this->createCreditMemo($order);
             $order->setState(Order::STATE_CLOSED);
             $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
         }
@@ -75,7 +75,7 @@ class RefundSyncStatus
      *
      * @return void
      */
-    private function createCredtMemo($order)
+    private function createCreditMemo($order)
     {
         $invoices = $order->getInvoiceCollection();
 

--- a/Model/RefundSyncStatus.php
+++ b/Model/RefundSyncStatus.php
@@ -79,7 +79,7 @@ class RefundSyncStatus
     {
         $invoices = $order->getInvoiceCollection();
 
-        foreach($invoices as $invoice) {
+        foreach ($invoices as $invoice) {
             $invoice = $this->invoice->loadByIncrementId($invoice->getIncrementId());
             $creditMemo = $this->creditMemoFactory->createByOrder($order);
 

--- a/Model/RefundSyncStatus.php
+++ b/Model/RefundSyncStatus.php
@@ -1,0 +1,93 @@
+<?php
+namespace Omise\Payment\Model;
+
+use Magento\Framework\Exception\LocalizedException;
+use Omise\Payment\Helper\OmiseHelper as Helper;
+use Omise\Payment\Helper\OmiseEmailHelper as EmailHelper;
+use Magento\Sales\Model\Order;
+use Omise\Payment\Model\Config\Cc as Config;
+use Magento\Sales\Model\Order\CreditmemoFactory;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Service\CreditmemoService;
+
+class RefundSyncStatus
+{
+    /**
+     * @param Helper $helper
+     * @param EmailHelper $emailHelper
+     */
+    public function __construct(
+        CreditmemoFactory $creditMemoFactory,
+        CreditmemoService $creditMemoService,
+        Invoice $invoice
+    ) {
+        $this->creditMemoFactory = $creditMemoFactory;
+        $this->creditMemoService = $creditMemoService;
+        $this->invoice = $invoice;
+    }
+
+    /**
+     * @param object $charge
+     * @return boolean
+     */
+    public function shouldRefund($charge)
+    {
+        return isset($charge['refunds']) &&
+            isset($charge['refunds']['data']) &&
+            count($charge['refunds']['data']) !== 0;
+    }
+
+    /**
+     * @param Order $order
+     * @param array $charge
+     * @return void
+     */
+    public function refund($order, $charge)
+    {
+        $refundedAmount = isset($charge['refunded_amount'])
+            ? $charge['refunded_amount']
+            : $charge['refunded'];
+
+        $createCreditMemo = $charge['funding_amount'] == $refundedAmount &&
+            $order->canCreditmemo() &&
+            $order->hasInvoices();
+
+        if ($createCreditMemo) {
+            $this->createCredtMemo($order);
+            $order->setState(Order::STATE_CLOSED);
+            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
+        }
+
+        $order->addStatusHistoryComment(
+            __(
+                'Opn Payments: Payment refunded.<br/>An amount of %1 %2 has been refunded (manual sync).',
+                number_format($charge['refunded_amount']/100, 2, '.', ''),
+                $order->getOrderCurrencyCode()
+            )
+        );
+
+        $order->save();
+    }
+
+    /**
+     * @param Invoice $invoice
+     * @param Order $order
+     *
+     * @return void
+     */
+    private function createCredtMemo($order)
+    {
+        $invoices = $order->getInvoiceCollection();
+
+        foreach($invoices as $invoice) {
+            $invoice = $this->invoice->loadByIncrementId($invoice->getIncrementId());
+            $creditMemo = $this->creditMemoFactory->createByOrder($order);
+
+            // We don't set invoice as we want to do offline refund
+            $creditMemo->setCustomerNote(__('Your Order %1 has been refunded.', $order->getIncrementId()));
+            $creditMemo->setCustomerNoteNotify(false);
+            $creditMemo->addComment(__('Order has been refunded'));
+            $this->creditMemoService->refund($creditMemo);
+        }
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -24,6 +24,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize</payment_action>
             </omise_cc>
@@ -38,6 +39,7 @@
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
                 <payment_action>authorize_capture</payment_action>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
             </omise_offsite_internetbanking>
 
@@ -50,6 +52,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_alipay>
@@ -59,6 +62,7 @@
                 <title>PayNow QR Payment</title>
                 <model>OmisePaynowAdapter</model>
                 <is_gateway>1</is_gateway>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <can_initialize>1</can_initialize>
                 <can_use_checkout>1</can_use_checkout>
@@ -76,6 +80,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>0</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>order</payment_action>
             </omise_offline_promptpay>
@@ -89,6 +94,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_pointsciti>
@@ -102,6 +108,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_installment>
@@ -115,6 +122,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_truemoney>
@@ -129,6 +137,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>0</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>order</payment_action>
             </omise_offsite_fpx>
@@ -142,6 +151,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>0</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>order</payment_action>
             </omise_offline_conveniencestore>
@@ -155,6 +165,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>0</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>order</payment_action>
             </omise_offline_tesco>
@@ -168,6 +179,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_alipaycn>
@@ -181,6 +193,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_alipayhk>
@@ -194,6 +207,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_dana>
@@ -207,6 +221,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_gcash>
@@ -220,6 +235,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_kakaopay>
@@ -233,6 +249,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_touchngo>
@@ -246,6 +263,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_mobilebanking>
@@ -260,6 +278,7 @@
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_rabbitlinepay>
@@ -273,6 +292,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_ocbcpao>
@@ -286,6 +306,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_grabpay>
@@ -302,6 +323,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_cc_googlepay>
@@ -315,6 +337,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_boost>
@@ -328,6 +351,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_duitnowobw>
@@ -341,6 +365,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_duitnowqr>
@@ -354,6 +379,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_maybankqr>
@@ -367,6 +393,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <can_capture>1</can_capture>
                 <can_review_payment>1</can_review_payment>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <payment_action>authorize_capture</payment_action>
             </omise_offsite_shopeepay>


### PR DESCRIPTION
#### 1. Objective

Automatically create credit memo when a merchant does full refund from OPN Payments's dashboard and from Magento order page, clicks on `Sync Order Status` button.

Jira Ticket: [#618](https://opn-ooo.atlassian.net/browse/ENGA3-618)

#### 2. Description of change

Created a class `RefundSyncStatus` and moved the logic to refund and process credit memo there. Also, added a config to enable partial refund when creating credit memo from Magento admin.

#### 3. Quality assurance

- Make an order
- Capture the payment
- Do a full refund from OPN Payment dashboard
- On Magento admin, click on Sync order status button
- Go to credit memo

You should see a credit memo generated automatically.

**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.2
- PHP version: 8.1
