### PR TITLE
[ENGA3-540] : Bug fixed on partial refund

### DIFF
--- a/Gateway/Http/Client/PaymentRefund.php
+++ b/Gateway/Http/Client/PaymentRefund.php
@@ -26,7 +26,7 @@ class PaymentRefund extends AbstractPayment
             $sourceType = $charge->source['type'] ?? 'credit_card';
             $method = str_replace('_', ' ', $sourceType);
             throw new \Magento\Framework\Exception\LocalizedException(
-                __('Payment with omise %1 cannot be refunded.', $method)
+                __('Payment with opn %1 cannot be refunded.', $method)
             );
         }
 

--- a/Gateway/Http/Client/PaymentRefund.php
+++ b/Gateway/Http/Client/PaymentRefund.php
@@ -26,7 +26,7 @@ class PaymentRefund extends AbstractPayment
             $sourceType = $charge->source['type'] ?? 'credit_card';
             $method = str_replace('_', ' ', $sourceType);
             throw new \Magento\Framework\Exception\LocalizedException(
-                __('Payment with opn %1 cannot be refunded.', $method)
+                __('Payment with Opn Payments %1 cannot be refunded.', $method)
             );
         }
 

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -4,6 +4,7 @@ namespace Omise\Payment\Gateway\Request;
 
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Payment\Helper\Formatter;
 use Magento\Sales\Model\Order\Payment;
 use Omise\Payment\Helper\OmiseHelper;
@@ -48,14 +49,15 @@ class RefundDataBuilder implements BuilderInterface
 
         /** @var Payment $payment */
         $payment = $paymentDO->getPayment();
-        $order = $paymentDO->getOrder();
+        $order = $payment->getOrder();
+        $currency = $order->getOrderCurrency();
 
         return [
-            'store_id' => $order->getStoreId(),
+            'store_id' => $order->getStore()->getId(),
             'transaction_id' => $payment->getParentTransactionId(),
             PaymentDataBuilder::AMOUNT => $this->omiseHelper->omiseAmountFormat(
-                $order->getCurrencyCode(),
-                $order->getGrandTotalAmount()
+                $currency->getCode(),
+                $order->getTotalOnlineRefunded()
             )
         ];
     }

--- a/Model/Api/Charge.php
+++ b/Model/Api/Charge.php
@@ -110,12 +110,8 @@ class Charge extends BaseObject
         try {
             $refund = $this->object->refund($refundData);
         } catch (Exception $e) {
-            return new Error([
-                'code'    => 'failed_refund',
-                'message' => $e->getMessage()
-            ]);
+            throw new Exception('Failed to refund : ' . $e->getMessage());
         }
-
         return $refund;
     }
 

--- a/Model/Api/Charge.php
+++ b/Model/Api/Charge.php
@@ -5,6 +5,7 @@ namespace Omise\Payment\Model\Api;
 use Exception;
 use OmiseCharge;
 use Omise\Payment\Model\Config\Config;
+use Magento\Framework\Exception\LocalizedException;
 
 /**
  * @property string $object
@@ -110,7 +111,7 @@ class Charge extends BaseObject
         try {
             $refund = $this->object->refund($refundData);
         } catch (Exception $e) {
-            throw new Exception('Failed to refund : ' . $e->getMessage());
+            throw new LocalizedException(__('Failed to refund : ' . $e->getMessage()));
         }
         return $refund;
     }


### PR DESCRIPTION
#### 1. Objective

Bug fixed on partial refund

Partial refund was not working since `getGrandTotalAmount()` was using in `RefundDataBuilder`
Instead get order from payment and get proper store_id, order currency and online refunded amount.

**Related information**:
[ENGA3-540](https://opn-ooo.atlassian.net/browse/ENGA3-540)

#### 2. Description of change

- get order from payment and get proper store_id, order currency and online refunded amount.

#### 3. Quality assurance

- Please test with different store, different currency and do full refund and partial refund

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A