### PR TITLE
[ENGA3-618]: Removed credit memo creation logic. Set the order status to processing from closed on refund.

### DIFF
--- a/Model/RefundSyncStatus.php
+++ b/Model/RefundSyncStatus.php
@@ -30,19 +30,10 @@ class RefundSyncStatus
      */
     public function refund($order, $charge)
     {
-        $refundedAmount = isset($charge['refunded_amount'])
-            ? $charge['refunded_amount']
-            : $charge['refunded'];
+        // Todo: Bring back the credit memo creation logic if we find way to restock the quantity
 
-        $createCreditMemo = $charge['funding_amount'] == $refundedAmount &&
-            $order->canCreditmemo() &&
-            $order->hasInvoices();
-
-        if ($createCreditMemo) {
-            $this->creditMemoService->create($order);
-            $order->setState(Order::STATE_CLOSED);
-            $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_CLOSED));
-        }
+        $order->setState(Order::STATE_PROCESSING);
+        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
 
         $order->addStatusHistoryComment(
             __(

--- a/Observer/WebhookObserver/WebhookRefundObserver.php
+++ b/Observer/WebhookObserver/WebhookRefundObserver.php
@@ -51,13 +51,7 @@ class WebhookRefundObserver extends WebhookObserver
      */
     private function closeOrder()
     {
-        if ($this->charge->isFullyRefunded()) {
-            // Update order state and status.
-            $this->creditMemoService->create($this->orderData);
-            $this->orderData->setState(MagentoOrder::STATE_CLOSED);
-            $defaultStatus = $this->orderData->getConfig()->getStateDefaultStatus(MagentoOrder::STATE_CLOSED);
-            $this->orderData->setStatus($defaultStatus);
-        }
+        // Todo: Bring back the credit memo creation logic if we find way to restock the quantity
 
         $refundContextText = $this->charge->isFullyRefunded() ? 'fully' : 'partially';
 


### PR DESCRIPTION
#### 1. Objective

Allow merchants to create credit memo manually by setting order status to processing on refund.

Jira Ticket: [#618](https://opn-ooo.atlassian.net/browse/ENGA3-618)

#### 2. Description of change

We removed the logic of automatically creating credit memo since we also need to restock the quantity and current implementation do not restock it. We will implement this once we find the way to restock the quantity. To allow merchants to create credit memo manually, we set the order status to processing, before it was set to closed.

#### 3. Quality assurance

Place an order and refund it. The order status should be `processing`. It should work with both webhook enabled or disabled.

**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.29.2
- PHP version: 8.1