### PR TITLE
[MIT-868]: Added Omise.setUserAgent to pass the user agent when creating token.

### DIFF
--- a/Model/Ui/CcConfigProvider.php
+++ b/Model/Ui/CcConfigProvider.php
@@ -47,9 +47,10 @@ class CcConfigProvider implements ConfigProviderInterface
                     'years'  => [OmiseCcConfig::CODE => $this->magentoCcConfig->getCcYears()],
                 ],
                 OmiseCcConfig::CODE => [
-                    'publicKey'          => $this->omiseCcConfig->getPublicKey(),
+                    'publicKey' => $this->omiseCcConfig->getPublicKey(),
                     'isCustomerLoggedIn' => $this->customer->isLoggedIn(),
-                    'cards'              => $this->getCards(),
+                    'cards' => $this->getCards(),
+                    'omiseMagentoUserAgent' => defined('OMISE_USER_AGENT_SUFFIX') ? OMISE_USER_AGENT_SUFFIX : ''
                 ],
             ]
         ];

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-googlepay-method.js
@@ -71,7 +71,7 @@ define(
             type: 'PAYMENT_GATEWAY',
             parameters: {
                 "gateway": "omise",
-                "gatewayMerchantId": window.checkoutConfig.payment.omise_cc.publicKey,
+                "gatewayMerchantId": this.getPublicKey()
             }
         };
         
@@ -304,6 +304,24 @@ define(
                         console.error(err);
                     });
             },
+
+            /**
+             * Get Omise public key
+             *
+             * @return {string}
+             */
+            getPublicKey: function() {
+                return window.checkoutConfig.payment.omise_cc.publicKey;
+            },
+
+            /**
+             * Return the Omise Magento and Magento versions to be sent in user agent header
+             *
+             * @returns string
+             */
+            getUserAgent: function() {
+                return window.checkoutConfig.payment.omise_cc.omiseMagentoUserAgent;
+            },
             
             /**
              * Create Omise token from the payment data returned by the Google Pay API.
@@ -333,7 +351,8 @@ define(
                     });
                 }
 
-                Omise.setPublicKey(window.checkoutConfig.payment.omise_cc.publicKey);
+                Omise.setPublicKey(this.getPublicKey());
+                Omise.setUserAgent(this.getUserAgent());
                 Omise.createToken('tokenization', tokenizationParams, function(statusCode, response) {
                     if (statusCode === 200) {
                         klass.omiseCardToken(response.id);

--- a/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-cc-method.js
@@ -62,6 +62,15 @@ define(
             },
 
             /**
+             * Return the Omise Magento and Magento versions to be sent in user agent header
+             *
+             * @returns string
+             */
+            getUserAgent: function() {
+                return window.checkoutConfig.payment.omise_cc.omiseMagentoUserAgent;
+            },
+
+            /**
              * Initiate observable fields
              *
              * @return this
@@ -170,6 +179,7 @@ define(
                 }
 
                 Omise.setPublicKey(this.getPublicKey());
+                Omise.setUserAgent(this.getUserAgent());
                 Omise.createToken('card', card, function(statusCode, response) {
                     if (statusCode === 200) {
                         self.omiseCardToken(response.id);


### PR DESCRIPTION
#### 1. Objective

Record Omise Magento version when creating a token.

Jira Ticket: [#868](https://opn-ooo.atlassian.net/browse/ENGA3-868)

#### 2. Description of change

Added `Omise.setUserAgent` to pass the user agent when creating token

#### 3. Quality assurance

- Pay with credit card option.

**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.31.0
- PHP version: 8.1