### PR TITLE
Bug : saving error on no use website checkbox

### DIFF
--- a/Block/Adminhtml/System/Config/CardFormCustomization/js/script.js
+++ b/Block/Adminhtml/System/Config/CardFormCustomization/js/script.js
@@ -17,12 +17,15 @@ class CardFormCustomization {
     }
 
     isUseWebsiteChecked() {
-        return document.getElementById("omise_use_website_form_design_checkbox").checked
+        const element = document.getElementById("omise_use_website_form_design_checkbox")
+        return element ? element.checked : false
     }
 
     setOriginalUseWebsiteValue() {
         const element = document.getElementById(OMISE_CC_INPUT_ID + '_inherit')
-        element.value = this.isUseWebsiteChecked() ? '1' : ''
+        if(element) {
+            element.value = this.isUseWebsiteChecked() ? '1' : ''
+        }
     }
 
     showModal() {


### PR DESCRIPTION
#### 1. Objective

Bug : saving error on no use website checkbox

#### 2. Description of change

Since there is no element for `use website checkbox` when default config is selected, added if condition to check before the value is set.