### PR TITLE
[feature/ENGA3-997]: Add logic to check shopeepay cancel payment.

### DIFF
--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -181,10 +181,9 @@ class Offsite extends Action
                 throw new LocalizedException(__($charge->getMessage()));
             }
 
-            if (
-                $charge->isFailed() ||
-                $this->shopeepayFailed($paymentMethod, $charge->isSuccessful())
-            ) {
+            $shopeePayFailed = $this->helper->hasShopeepayFailed($paymentMethod, $charge->isSuccessful());
+
+            if ($charge->isFailed() || $shopeePayFailed) {
                 // restoring the cart
                 $this->checkoutSession->restoreQuote();
                 $failureMessage = $charge->failure_message ?
@@ -194,7 +193,8 @@ class Offsite extends Action
                     "Payment failed. $failureMessage, please contact our support if you have any questions."
                 );
 
-                return $this->processFailedCharge($errorMessage);
+                // pass shopeePayFailed to avoid webhook to cancel payment
+                return $this->processFailedCharge($errorMessage, $shopeePayFailed);
             }
 
             // Do not proceed if webhook is enabled

--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -181,10 +181,15 @@ class Offsite extends Action
                 throw new LocalizedException(__($charge->getMessage()));
             }
 
-            if ($charge->isFailed()) {
+            if (
+                $charge->isFailed() ||
+                $this->shopeepayFailed($paymentMethod, $charge->isSuccessful())
+            ) {
                 // restoring the cart
                 $this->checkoutSession->restoreQuote();
-                $failureMessage = ucfirst($charge->failure_message);
+                $failureMessage = $charge->failure_message ?
+                    ucfirst($charge->failure_message) :
+                    'Payment cancelled';
                 $errorMessage = __(
                     "Payment failed. $failureMessage, please contact our support if you have any questions."
                 );
@@ -313,6 +318,11 @@ class Offsite extends Action
 
             return $this->redirect(self::PATH_CART);
         }
+    }
+
+    private function shopeepayFailed($paymentMethod, $isChargeSuccess)
+    {
+        return $paymentMethod === 'omise_offsite_shopeepay' && !$isChargeSuccess;
     }
 
     /**

--- a/Controller/Callback/Offsite.php
+++ b/Controller/Callback/Offsite.php
@@ -320,11 +320,6 @@ class Offsite extends Action
         }
     }
 
-    private function shopeepayFailed($paymentMethod, $isChargeSuccess)
-    {
-        return $paymentMethod === 'omise_offsite_shopeepay' && !$isChargeSuccess;
-    }
-
     /**
      * @param  \Magento\Sales\Model\Order $order
      *

--- a/Controller/Callback/Traits/FailedChargeTrait.php
+++ b/Controller/Callback/Traits/FailedChargeTrait.php
@@ -5,11 +5,14 @@ namespace Omise\Payment\Controller\Callback\Traits;
 trait FailedChargeTrait
 {
     /**
+     * @param boolean $shopeePayFaild This is temprorary param
      * @param string $errorMessage
      */
-    public function processFailedCharge($errorMessage)
+    public function processFailedCharge($errorMessage, $shopeePayFailed)
     {
-        if ($this->config->isWebhookEnabled()) {
+        // if payment method is shopee pay then the charge is neither success or failed
+        // then we should not trigger webhook because charge.failed webhook is not triggered
+        if (!$shopeePayFailed && $this->config->isWebhookEnabled()) {
             $this->logger->debug($errorMessage);
             $this->messageManager->addErrorMessage($errorMessage);
             return $this->redirect(self::PATH_CART);

--- a/Controller/Callback/Traits/FailedChargeTrait.php
+++ b/Controller/Callback/Traits/FailedChargeTrait.php
@@ -10,8 +10,8 @@ trait FailedChargeTrait
      */
     public function processFailedCharge($errorMessage, $shopeePayFailed)
     {
-        // if payment method is shopee pay then the charge is neither success or failed
-        // then we should not trigger webhook because charge.failed webhook is not triggered
+        // if payment method is shopeepayand the charge is neither success or failed then
+        // webhook flow should be avoided because charge.failed webhook will not be triggered
         if (!$shopeePayFailed && $this->config->isWebhookEnabled()) {
             $this->logger->debug($errorMessage);
             $this->messageManager->addErrorMessage($errorMessage);

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -518,4 +518,15 @@ class OmiseHelper extends AbstractHelper
         }
         return null;
     }
+
+    /**
+     * Check if Shopeepay payment is failed / cancelled
+     *
+     * @param string $paymentMethod
+     * @param boolean $isChargeSuccess
+     */
+    public function hasShopeepayFailed($paymentMethod, $isChargeSuccess)
+    {
+        return $paymentMethod === 'omise_offsite_shopeepay' && !$isChargeSuccess;
+    }
 }

--- a/Observer/WebhookObserver/WebhookCompleteObserver.php
+++ b/Observer/WebhookObserver/WebhookCompleteObserver.php
@@ -3,14 +3,11 @@
 namespace Omise\Payment\Observer\WebhookObserver;
 
 use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
 use Omise\Payment\Model\Api\Event as ApiEvent;
 use Omise\Payment\Model\Order;
-use Omise\Payment\Model\Event\Charge\Complete as EventChargeComplete;
 use Omise\Payment\Helper\OmiseEmailHelper as EmailHelper;
 use Omise\Payment\Helper\OmiseHelper as Helper;
 use Omise\Payment\Model\Config\Config;
-use Omise\Payment\Model\Api\Charge as ApiCharge;
 use Magento\Sales\Model\Order as MagentoOrder;
 use Omise\Payment\Observer\WebhookObserver\WebhookObserver;
 use Magento\Sales\Model\Order\Payment\Transaction;


### PR DESCRIPTION
#### 1. Objective

Show failure page when the payment method is Shopeepay and customer clicks on redirect on merchant without completing payment.

Jira Ticket: [#997](https://opn-ooo.atlassian.net/browse/ENGA3-997)

#### 2. Description of change

Added a logic to check if the payment method is shopeepay and the charge is not successful. If it is the case then follow the failure flow.

#### 3. Quality assurance

Choose Shopyeepay and click on redirect to merchant without paying.

**🔧 Environments:**

- Platform version: Magento 2.4.5
- Omise plugin version: Omise-Magento 2.31.0
- PHP version: 8.1