### PR TITLE
Sub items with non zero amount being sent to Atome payment

### DIFF
--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -378,7 +378,7 @@ class APMBuilder implements BuilderInterface
 
         foreach ($items as $item) {
             $price = $item->getPrice();
-            // if item have parent item, it mean it's sub product
+            // if item has parent item, it mean it's sub product
             if ($item->getParentItem()) {
                 continue;
             }

--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -379,7 +379,7 @@ class APMBuilder implements BuilderInterface
         foreach ($items as $item) {
             $price = $item->getPrice();
             // if item have parent item, it mean it's sub product
-            if($item->getParentItem()) {
+            if ($item->getParentItem()) {
                 continue;
             }
             if ((float) $price === 0.0) {

--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -378,6 +378,10 @@ class APMBuilder implements BuilderInterface
 
         foreach ($items as $item) {
             $price = $item->getPrice();
+            // if item have parent item, it mean it's sub product
+            if($item->getParentItem()) {
+                continue;
+            }
             if ((float) $price === 0.0) {
                 continue;
             }

--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -382,6 +382,8 @@ class APMBuilder implements BuilderInterface
             if ($item->getParentItem()) {
                 continue;
             }
+            // since core-api validation failed for item with price zero,
+            // removing item with price zero
             if ((float) $price === 0.0) {
                 continue;
             }

--- a/Test/Unit/AtomeAPMBuilderTest.php
+++ b/Test/Unit/AtomeAPMBuilderTest.php
@@ -139,7 +139,6 @@ class AtomeAPMBuilderTest extends TestCase
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
     }
 
-
     /**
      * @covers Omise\Payment\Model\Config\Atome
      */

--- a/Test/Unit/AtomeAPMBuilderTest.php
+++ b/Test/Unit/AtomeAPMBuilderTest.php
@@ -106,7 +106,7 @@ class AtomeAPMBuilderTest extends TestCase
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
     }
 
-     /**
+    /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
      * @covers Omise\Payment\Model\Config\Atome
      * @covers Omise\Payment\Helper\OmiseMoney

--- a/Test/Unit/AtomeAPMBuilderTest.php
+++ b/Test/Unit/AtomeAPMBuilderTest.php
@@ -106,6 +106,40 @@ class AtomeAPMBuilderTest extends TestCase
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
     }
 
+     /**
+     * @covers Omise\Payment\Gateway\Request\APMBuilder
+     * @covers Omise\Payment\Model\Config\Atome
+     * @covers Omise\Payment\Helper\OmiseMoney
+     */
+    public function testApmBuilderWithSubProductNonZeroButHasParentItem()
+    {
+        $this->itemMock->method('getPrice')->willReturn(100.0);
+        $this->itemMock->method('getParentItem')->willReturn($this->itemMock);
+        $this->infoMock->method('getMethod')->willReturn(Atome::CODE);
+        $this->returnUrlHelper->method('create')->willReturn([
+            'url' => 'https://omise.co/complete',
+            'token' => '1234'
+        ]);
+
+        $this->builder = new APMBuilder(
+            $this->helper,
+            $this->returnUrlHelper,
+            $this->config,
+            $this->capabilities,
+            new OmiseMoney(),
+        );
+
+        $result = $this->builder->build(['payment' => new PaymentDataObject(
+            $this->orderMock,
+            $this->infoMock
+        )]);
+
+        $this->assertEquals(0, count($result['source']['items']));
+        $this->assertEquals('atome', $result['source']['type']);
+        $this->assertEquals('https://omise.co/complete', $result['return_uri']);
+    }
+
+
     /**
      * @covers Omise\Payment\Model\Config\Atome
      */


### PR DESCRIPTION
#### 1. Objective

Sub items with non zero amount being sent to Atome payment

#### 2. Description of change

Checked with `getParentItem()`. If parent item is has value, it mean it is sub product.

#### 3. Quality assurance

Tested with bundle product
- override sub product price
- normal sub product

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
