### PR TITLE
Enabled AlipayHK, Kakaopay and Touch 'N Go for Thailand.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipayhk-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-alipayhk-method.js
@@ -21,7 +21,7 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_offsite_alipayhk',
-            restrictedToCurrencies: ['sgd']
+            restrictedToCurrencies: ['sgd', 'thb']
         });
     }
 );

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-kakaopay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-kakaopay-method.js
@@ -21,7 +21,7 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_offsite_kakaopay',
-            restrictedToCurrencies: ['sgd']
+            restrictedToCurrencies: ['sgd', 'thb']
         });
     }
 );

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-touchngo-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-touchngo-method.js
@@ -21,7 +21,7 @@ define(
             isPlaceOrderActionAllowed: ko.observable(quote.billingAddress() != null),
 
             code: 'omise_offsite_touchngo',
-            restrictedToCurrencies: ['sgd', 'myr'],
+            restrictedToCurrencies: ['sgd', 'myr', 'thb'],
             logo: {
                 file: "images/touchngo.png",
                 width: "30",


### PR DESCRIPTION
#### 1. Objective

Enable AlipayPlus for Thailand

Jira Ticket: [#1595](https://opn-ooo.atlassian.net/browse/MIT-1595)

#### 2. Description of change

Added THB to the allowed currencies for AlipayHK, KakaoPay and Touch 'N Go.

<img width="1295" alt="Screenshot 2566-08-18 at 13 48 59" src="https://github.com/omise/omise-magento/assets/101558497/a30b854f-b3c9-48ab-aeef-a2fba0a1a1b0">

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- **Platform version**: Magento CE 2.4.5
- **Omise plugin version**: Omise-Magento 3.1.2
- **PHP version**: 8.1.21