### PR TITLE
Add feature flag to enable dynamic webhooks

### DIFF
--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -49,11 +49,6 @@ class PaymentDataBuilder implements BuilderInterface
     private $ccConfig;
 
     /**
-     * @var \Omise\Payment\Model\Config\Config
-     */
-    private $config;
-
-    /**
      * @var OmiseMoney
      */
     private $money;
@@ -62,11 +57,10 @@ class PaymentDataBuilder implements BuilderInterface
      * @param \Omise\Payment\Helper\OmiseHelper $omiseHelper
      * @param Omise\Payment\Model\Config\Cc $ccConfig
      */
-    public function __construct(Cc $ccConfig, OmiseMoney $money, Config $config)
+    public function __construct(Cc $ccConfig, OmiseMoney $money)
     {
         $this->money = $money;
         $this->ccConfig = $ccConfig;
-        $this->config = $config;
     }
 
     /**
@@ -83,7 +77,7 @@ class PaymentDataBuilder implements BuilderInterface
         $store_id = $order->getStoreId();
         $om = \Magento\Framework\App\ObjectManager::getInstance();
         $manager = $om->get(\Magento\Store\Model\StoreManagerInterface::class);
-        $store_name = $manager->getStore($store_id)->getName();
+        $store = $manager->getStore($store_id);
         $currency = $order->getCurrencyCode();
 
         $requestBody = [
@@ -96,12 +90,12 @@ class PaymentDataBuilder implements BuilderInterface
             self::METADATA    => [
                 'order_id' => $order->getOrderIncrementId(),
                 'store_id' => $order->getStoreId(),
-                'store_name' => $store_name
+                'store_name' => $store->getName()
             ]
         ];
 
-        if ($this->config->isWebhookEnabled()) {
-            $webhookUrl = $manager->getStore()->getBaseUrl() . Webhook::URI;
+        if ($this->ccConfig->isWebhookEnabled()) {
+            $webhookUrl = $store->getBaseUrl() . Webhook::URI;
             $requestBody[self::WEBHOOKS_ENDPOINT] = [$webhookUrl];
         }
 

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace Omise\Payment\Gateway\Request;
 
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
 use Omise\Payment\Observer\InstallmentDataAssignObserver;
 use Omise\Payment\Model\Config\Installment;
 use Omise\Payment\Model\Config\Cc;
+use Omise\Payment\Model\Config\Config;
+use Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook;
 
 class PaymentDataBuilder implements BuilderInterface
 {
@@ -20,7 +22,7 @@ class PaymentDataBuilder implements BuilderInterface
      * @var string
      */
     const CURRENCY = 'currency';
-    
+
     /**
      * @var string
      */
@@ -37,15 +39,20 @@ class PaymentDataBuilder implements BuilderInterface
     const ZERO_INTEREST_INSTALLMENTS = 'zero_interest_installments';
 
     /**
-     * @var \Omise\Payment\Helper\OmiseHelper
+     * @var string
      */
-    private $omiseHelper;
+    const WEBHOOKS_ENDPOINT = 'webhook_endpoints';
 
     /**
      * @var \Omise\Payment\Model\Config\Cc
      */
     private $ccConfig;
-  
+
+    /**
+     * @var \Omise\Payment\Model\Config\Config
+     */
+    private $config;
+
     /**
      * @var OmiseMoney
      */
@@ -55,11 +62,11 @@ class PaymentDataBuilder implements BuilderInterface
      * @param \Omise\Payment\Helper\OmiseHelper $omiseHelper
      * @param Omise\Payment\Model\Config\Cc $ccConfig
      */
-    public function __construct(OmiseHelper $omiseHelper, Cc $ccConfig, OmiseMoney $money)
+    public function __construct(Cc $ccConfig, OmiseMoney $money, Config $config)
     {
-        $this->omiseHelper = $omiseHelper;
         $this->money = $money;
         $this->ccConfig = $ccConfig;
+        $this->config = $config;
     }
 
     /**
@@ -92,6 +99,11 @@ class PaymentDataBuilder implements BuilderInterface
                 'store_name' => $store_name
             ]
         ];
+
+        if ($this->config->isWebhookEnabled()) {
+            $webhookUrl = $manager->getStore()->getBaseUrl() . Webhook::URI;
+            $requestBody[self::WEBHOOKS_ENDPOINT] = [$webhookUrl];
+        }
 
         if (Installment::CODE === $method->getMethod()) {
             $requestBody[self::ZERO_INTEREST_INSTALLMENTS] = $this->isZeroInterestInstallment($method);

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -94,7 +94,7 @@ class PaymentDataBuilder implements BuilderInterface
             ]
         ];
 
-        if ($this->ccConfig->isWebhookEnabled()) {
+        if ($this->ccConfig->isDynamicWebhooksEnabled()) {
             $webhookUrl = $store->getBaseUrl() . Webhook::URI;
             $requestBody[self::WEBHOOKS_ENDPOINT] = [$webhookUrl];
         }

--- a/Model/Config/Config.php
+++ b/Model/Config/Config.php
@@ -199,6 +199,16 @@ class Config
     }
 
     /**
+     * Check if using dynamic webhooks or not
+     *
+     * @return bool
+     */
+    public function isDynamicWebhooksEnabled()
+    {
+        return $this->isWebhookEnabled() && $this->getValue('dynamic_webhooks');
+    }
+
+    /**
      * Retrieve the order status in which to generate invoice at
      *
      * @return string

--- a/Test/Unit/ConfigTest.php
+++ b/Test/Unit/ConfigTest.php
@@ -26,9 +26,33 @@ class ConfigTest extends TestCase
      * @dataProvider isDynamicWebhooksEnabledProvider
      * @covers Omise\Payment\Model\Config\Config
      */
-    public function testIsDynamicWebhooksEnabled($webhookEnabled, $expected)
+    public function testIsDynamicWebhooksEnabled($webhookEnabled, $dynamicWebhooksEnabled, $expected)
     {
-        $this->scopeConfigMock->shouldReceive('getValue')->andReturn($webhookEnabled);
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('general/locale/code', m::any(), m::any())
+            ->andReturn('en');
+
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('payment/omise/sandbox_status', m::any(), m::any())
+            ->andReturn(1);
+
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('payment/omise/test_public_key', m::any(), m::any())
+            ->andReturn('pkey_test_xx');
+
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('payment/omise/test_secret_key', m::any(), m::any())
+            ->andReturn('pkey_test_xx');
+
+
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('payment/omise/dynamic_webhooks', m::any(), m::any())
+            ->andReturn($dynamicWebhooksEnabled);
+
+        $this->scopeConfigMock->shouldReceive('getValue')
+            ->with('payment/omise/webhook_status', m::any(), m::any())
+            ->andReturn($webhookEnabled);
+
         $this->storeMock->shouldReceive('getId')->andReturn(1);
         $this->storeManagerMock->shouldReceive('getStore')->andReturn($this->storeMock);
 
@@ -45,10 +69,22 @@ class ConfigTest extends TestCase
         return [
             [
                 'webhookEnabled' => 1,
+                'dynamicWebhooksEnabled' => 1,
+                'expected' => true,
+            ],
+            [
+                'webhookEnabled' => 1,
+                'dynamicWebhooksEnabled' => 1,
                 'expected' => true,
             ],
             [
                 'webhookEnabled' => 0,
+                'dynamicWebhooksEnabled' => 1,
+                'expected' => false,
+            ],
+            [
+                'webhookEnabled' => 0,
+                'dynamicWebhooksEnabled' => 0,
                 'expected' => false,
             ],
         ];

--- a/Test/Unit/ConfigTest.php
+++ b/Test/Unit/ConfigTest.php
@@ -44,7 +44,6 @@ class ConfigTest extends TestCase
             ->with('payment/omise/test_secret_key', m::any(), m::any())
             ->andReturn('pkey_test_xx');
 
-
         $this->scopeConfigMock->shouldReceive('getValue')
             ->with('payment/omise/dynamic_webhooks', m::any(), m::any())
             ->andReturn($dynamicWebhooksEnabled);

--- a/Test/Unit/ConfigTest.php
+++ b/Test/Unit/ConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omise\Payment\Test\Unit;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Omise\Payment\Model\Config\Config;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class ConfigTest extends TestCase
+{
+    private $storeManagerMock;
+    private $scopeConfigMock;
+    private $storeMock;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfigMock = m::mock(ScopeConfigInterface::class);
+        $this->storeManagerMock = m::mock(StoreManagerInterface::class);
+        $this->storeMock =  m::mock(StoreInterface::class);
+    }
+
+    /**
+     * @dataProvider isDynamicWebhooksEnabledProvider
+     * @covers Omise\Payment\Model\Config\Config
+     */
+    public function testIsDynamicWebhooksEnabled($webhookEnabled, $expected)
+    {
+        $this->scopeConfigMock->shouldReceive('getValue')->andReturn($webhookEnabled);
+        $this->storeMock->shouldReceive('getId')->andReturn(1);
+        $this->storeManagerMock->shouldReceive('getStore')->andReturn($this->storeMock);
+
+        $config = new Config($this->scopeConfigMock, $this->storeManagerMock);
+        $result = $config->isDynamicWebhooksEnabled();
+        $this->assertEquals($result, $expected);
+    }
+
+    /**
+     * Data provider for testIsDynamicWebhooksEnabled method
+     */
+    public function isDynamicWebhooksEnabledProvider()
+    {
+        return [
+            [
+                'webhookEnabled' => 1,
+                'expected' => true,
+            ],
+            [
+                'webhookEnabled' => 0,
+                'expected' => false,
+            ],
+        ];
+    }
+}

--- a/Test/Unit/PaymentDataBuilderTest.php
+++ b/Test/Unit/PaymentDataBuilderTest.php
@@ -18,7 +18,6 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Omise\Payment\Model\Config\Installment;
 use Omise\Payment\Model\Config\Promptpay;
-use Omise\Payment\Model\Config\Config as ConfigModel;
 
 class PaymentDataBuilderTest extends TestCase
 {
@@ -37,7 +36,6 @@ class PaymentDataBuilderTest extends TestCase
     {
         $this->factoryMock = m::mock(FactoryInterface::class);
         $this->configMock = m::mock(ConfigInterface::class);
-        $this->configModelMock = m::mock(ConfigModel::class);
         $this->omiseMoneyMock = m::mock(OmiseMoney::class);
         $this->ccConfigMock = m::mock(Cc::class);
         $this->paymentMock = m::mock(OrderPaymentInterface::class);
@@ -80,7 +78,7 @@ class PaymentDataBuilderTest extends TestCase
         $this->paymentMock->shouldReceive('getAdditionalInformation')->andReturn('installment_mbb');
 
         $this->ccConfigMock->shouldReceive('getSecureForm')->andReturn($secureFormEnabled);
-        $this->configModelMock->shouldReceive('isWebhookEnabled')->andReturn(true);
+        $this->ccConfigMock->shouldReceive('isWebhookEnabled')->andReturn(true);
 
         $this->omiseMoneyMock->shouldReceive('setAmountAndCurrency')->andReturn($this->omiseMoneyMock);
         $this->omiseMoneyMock->shouldReceive('toSubunit')->andReturn($amount * 100);
@@ -100,7 +98,7 @@ class PaymentDataBuilderTest extends TestCase
         $this->paymentDataMock->shouldReceive('getOrder')->andReturn($this->orderMock);
         $this->paymentDataMock->shouldReceive('getPayment')->andReturn($this->paymentMock);
 
-        $model = new PaymentDataBuilder($this->ccConfigMock, $this->omiseMoneyMock, $this->configModelMock);
+        $model = new PaymentDataBuilder($this->ccConfigMock, $this->omiseMoneyMock);
         $result = $model->build(['payment' => $this->paymentDataMock]);
 
         $this->assertEquals(100000, $result['amount']);

--- a/Test/Unit/PaymentDataBuilderTest.php
+++ b/Test/Unit/PaymentDataBuilderTest.php
@@ -23,7 +23,6 @@ class PaymentDataBuilderTest extends TestCase
 {
     private $omiseMoneyMock;
     private $ccConfigMock;
-    private $configModelMock;
     private $paymentDataMock;
     private $paymentMock;
     private $orderMock;

--- a/Test/Unit/PaymentDataBuilderTest.php
+++ b/Test/Unit/PaymentDataBuilderTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Omise\Payment\Test\Unit;
+
+use Magento\Framework\App\ObjectManager;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Omise\Payment\Gateway\Request\PaymentDataBuilder;
+use Omise\Payment\Helper\OmiseHelper;
+use Omise\Payment\Helper\OmiseMoney;
+use Omise\Payment\Model\Config\Cc;
+use Magento\Framework\ObjectManager\ConfigInterface;
+use Magento\Framework\ObjectManager\FactoryInterface;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Omise\Payment\Model\Config\Installment;
+use Omise\Payment\Model\Config\Promptpay;
+use Omise\Payment\Model\Config\Config as ConfigModel;
+
+class PaymentDataBuilderTest extends TestCase
+{
+    private $omiseMoneyMock;
+    private $ccConfigMock;
+    private $configModelMock;
+    private $paymentDataMock;
+    private $paymentMock;
+    private $orderMock;
+    private $factoryMock;
+    private $configMock;
+    private $storeManagerMock;
+    private $storeMock;
+
+    protected function setUp(): void
+    {
+        $this->factoryMock = m::mock(FactoryInterface::class);
+        $this->configMock = m::mock(ConfigInterface::class);
+        $this->configModelMock = m::mock(ConfigModel::class);
+        $this->omiseMoneyMock = m::mock(OmiseMoney::class);
+        $this->ccConfigMock = m::mock(Cc::class);
+        $this->paymentMock = m::mock(OrderPaymentInterface::class);
+        $this->paymentDataMock = m::mock(PaymentDataObjectInterface::class);
+        $this->orderMock = m::mock(OrderInterface::class);
+        $this->storeManagerMock =  m::mock(StoreManagerInterface::class);
+        $this->storeMock =  m::mock(StoreInterface::class);
+    }
+
+    /**
+     * @covers Omise\Payment\Gateway\Request\PaymentDataBuilder
+     */
+    public function testConstants()
+    {
+        $this->assertEquals('webhook_endpoints', PaymentDataBuilder::WEBHOOKS_ENDPOINT);
+        $this->assertEquals('amount', PaymentDataBuilder::AMOUNT);
+        $this->assertEquals('currency', PaymentDataBuilder::CURRENCY);
+        $this->assertEquals('description', PaymentDataBuilder::DESCRIPTION);
+        $this->assertEquals('metadata', PaymentDataBuilder::METADATA);
+        $this->assertEquals('zero_interest_installments', PaymentDataBuilder::ZERO_INTEREST_INSTALLMENTS);
+    }
+
+    /**
+     * @dataProvider buildDataProvider
+     * @covers Omise\Payment\Gateway\Request\PaymentDataBuilder
+     */
+    public function testBuild($paymentMethod, $expectedMetadata)
+    {
+        $amount = 1000;
+        $currency = 'THB';
+        $orderId = 123;
+        $storeId = 1;
+        $storeName = 'opn-store';
+        $storeBaseUrl = 'https://omise.co/';
+        $secureFormEnabled = true;
+
+        new ObjectManager($this->factoryMock, $this->configMock);
+
+        $this->paymentMock->shouldReceive('getMethod')->andReturn($paymentMethod);
+        $this->paymentMock->shouldReceive('getAdditionalInformation')->andReturn('installment_mbb');
+
+        $this->ccConfigMock->shouldReceive('getSecureForm')->andReturn($secureFormEnabled);
+        $this->configModelMock->shouldReceive('isWebhookEnabled')->andReturn(true);
+
+        $this->omiseMoneyMock->shouldReceive('setAmountAndCurrency')->andReturn($this->omiseMoneyMock);
+        $this->omiseMoneyMock->shouldReceive('toSubunit')->andReturn($amount * 100);
+
+        $this->storeMock->shouldReceive('getName')->andReturn($storeName);
+        $this->storeMock->shouldReceive('getBaseUrl')->andReturn($storeBaseUrl);
+
+        $this->storeManagerMock->shouldReceive('getStore')->andReturn($this->storeMock);
+        $this->configMock->shouldReceive('getPreference');
+        $this->factoryMock->shouldReceive('create')->andReturn($this->storeManagerMock);
+
+        $this->orderMock->shouldReceive('getCurrencyCode')->andReturn($currency);
+        $this->orderMock->shouldReceive('getGrandTotalAmount')->andReturn($amount);
+        $this->orderMock->shouldReceive('getOrderIncrementId')->andReturn($orderId);
+        $this->orderMock->shouldReceive('getStoreId')->andReturn($storeId);
+
+        $this->paymentDataMock->shouldReceive('getOrder')->andReturn($this->orderMock);
+        $this->paymentDataMock->shouldReceive('getPayment')->andReturn($this->paymentMock);
+
+        $model = new PaymentDataBuilder($this->ccConfigMock, $this->omiseMoneyMock, $this->configModelMock);
+        $result = $model->build(['payment' => $this->paymentDataMock]);
+
+        $this->assertEquals(100000, $result['amount']);
+        $this->assertEquals('THB', $result['currency']);
+        $this->assertEquals([
+            'https://omise.co/omise/callback/webhook'
+        ], $result['webhook_endpoints']);
+        $this->assertEquals($expectedMetadata, $result['metadata']);
+
+        if ($paymentMethod === Installment::CODE) {
+            $this->assertEquals(true, $result['zero_interest_installments']);
+        }
+    }
+
+    /**
+     * Data provider for testBuild method
+     */
+    public function buildDataProvider()
+    {
+        return [
+            [
+                'paymentMethod' => Cc::CODE,
+                'expectedMetadata' => [
+                    'order_id' => 123,
+                    'store_id' => 1,
+                    'store_name' => 'opn-store',
+                    'secure_form_enabled' => true
+                ],
+            ],
+            [
+                'paymentMethod' => Installment::CODE,
+                'expectedMetadata' => [
+                    'order_id' => 123,
+                    'store_id' => 1,
+                    'store_name' => 'opn-store',
+                ],
+            ],
+            [
+                'paymentMethod' => Promptpay::CODE,
+                'expectedMetadata' => [
+                    'order_id' => 123,
+                    'store_id' => 1,
+                    'store_name' => 'opn-store',
+                ],
+            ],
+        ];
+    }
+}

--- a/Test/Unit/PaymentDataBuilderTest.php
+++ b/Test/Unit/PaymentDataBuilderTest.php
@@ -78,7 +78,7 @@ class PaymentDataBuilderTest extends TestCase
         $this->paymentMock->shouldReceive('getAdditionalInformation')->andReturn('installment_mbb');
 
         $this->ccConfigMock->shouldReceive('getSecureForm')->andReturn($secureFormEnabled);
-        $this->ccConfigMock->shouldReceive('isWebhookEnabled')->andReturn(true);
+        $this->ccConfigMock->shouldReceive('isDynamicWebhooksEnabled')->andReturn(true);
 
         $this->omiseMoneyMock->shouldReceive('setAmountAndCurrency')->andReturn($this->omiseMoneyMock);
         $this->omiseMoneyMock->shouldReceive('toSubunit')->andReturn($amount * 100);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,19 +33,18 @@
                     <comment>The "Live" mode secret key can be found in Opn Payments Dashboard.</comment>
                 </field>
                 <field id="webhook_status" translate="label comment" type="select" sortOrder="61" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Webhook</label>
+                    <label>Enable webhook</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>Use webhook.</comment>
+                    <comment>
+                        <![CDATA[Enable webhook to let the system automatically configure it. To learn about webhooks, see <a href="https://www.omise.co/api-webhooks">here</a>.]]>
+                    </comment>
                 </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Webhook endpoint</label>
-                    <comment>
-                        <![CDATA[To enable <a href="https://www.omise.co/api-webhooks">WebHooks</a> feature, you must copy the above url to setup an endpoint at <a href="https://dashboard.omise.co/test/webhooks/edit"><strong>Opn Payments dashboard</strong></a> <em>(HTTPS only)</em>.]]>
-                    </comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook</frontend_model>
                 </field>
                 <field id="enable_cron_autoexpirysync" translate="label comment" type="select" sortOrder="71" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable Cron Autosync Order Status</label>
+                    <label>Enable cron autosync order status</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Enabling cron allows Magento to check orders with expired charge status and mark them as canceled.</comment>
                 </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -36,7 +36,7 @@
                     <label>Enable webhooks</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
-                        <![CDATA[Enable webhooks to receive updates when updates to charges and refunds occur. To learn more, see <a href="https://docs.opn.ooo/api-webhooks">our webhooks documentation</a>. No additional configuration necessary.]]>
+                        <![CDATA[Enable webhooks to receive updates when charge and refund events occur. To learn more, see <a href="https://docs.opn.ooo/api-webhooks">our webhooks documentation</a>. No additional configuration necessary.]]>
                     </comment>
                 </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -36,7 +36,19 @@
                     <label>Enable webhooks</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
-                        <![CDATA[Enable webhooks to receive updates when charge and refund events occur. To learn more, see <a href="https://docs.opn.ooo/api-webhooks">our webhooks documentation</a>. No additional configuration necessary.]]>
+                        <![CDATA[Enable webhooks to receive updates when charge and refund events occur. To learn more, see <a href="https://docs.opn.ooo/api-webhooks">our webhooks documentation</a>. </br></br>
+                        Unless dynamic webhooks are enabled, you must add the URL below as a new endpoint on your <a href="https://dashboard.omise.co/v2/settings/webhooks">Opn Payments dashboard</a> (HTTPS only).
+                        ]]>
+                    </comment>
+                </field>
+                <field id="dynamic_webhooks" translate="label comment" type="select" sortOrder="62" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable dynamic webhooks</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="webhook_status">1</field>
+                    </depends>
+                    <comment>
+                        <![CDATA[If enabled, charge and refund events will be automatically set to be received at the URL below. This can be useful when you need multiple webhook endpoints on the same account.]]>
                     </comment>
                 </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,10 +33,10 @@
                     <comment>The "Live" mode secret key can be found in Opn Payments Dashboard.</comment>
                 </field>
                 <field id="webhook_status" translate="label comment" type="select" sortOrder="61" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable webhook</label>
+                    <label>Enable webhooks</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>
-                        <![CDATA[Enable webhook to let the system automatically configure it. To learn about webhooks, see <a href="https://www.omise.co/api-webhooks">here</a>.]]>
+                        <![CDATA[Enable webhooks to receive updates when updates to charges and refunds occur. To learn more, see <a href="https://docs.opn.ooo/api-webhooks">our webhooks documentation</a>. No additional configuration necessary.]]>
                     </comment>
                 </field>
                 <field id="webhook" translate="label" type="label" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,6 +13,7 @@
                 <model>OmiseAdapter</model>
                 <generate_invoice_at_order_status>pending_payment</generate_invoice_at_order_status>
                 <webhook_status>1</webhook_status>
+                <dynamic_webhooks>0</dynamic_webhooks>
             </omise>
 
             <omise_cc>


### PR DESCRIPTION
#### 1. Objective

When webhook is enabled, add dynamic webhook to create charge data.

#### 2. Description of change

- Added a feature flag to enable dynamic webhooks.
- Convert from  `Enable Cron Autosync Order Status` to `Enable cron autosync order status` to follow consistency of label.

<img width="500" alt="Screenshot 2023-10-10 at 1 49 03 PM" src="https://github.com/omise/omise-magento/assets/108650842/7b65105d-8795-40dd-a077-9ca4bb695ce5">

<img width="500" alt="Screenshot 2023-10-10 at 1 49 13 PM" src="https://github.com/omise/omise-magento/assets/108650842/84fe2c78-e720-495d-b6e8-a778546eaf5e">


#### 3. Quality assurance

Tested with `charge.complete`, `refund.create` and `charge.capture` events.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A