### PR TITLE
Add QR expires count down for promptpay

### DIFF
--- a/Block/Checkout/Onepage/Success/PromptpayAdditionalInformation.php
+++ b/Block/Checkout/Onepage/Success/PromptpayAdditionalInformation.php
@@ -14,20 +14,8 @@ class PromptpayAdditionalInformation extends AdditionalInformation
         }
         $data['order_amount'] = $this->getOrderAmount();
         $data['image_code'] = $this->getPaymentAdditionalInformation('image_code');
-        $data['charge_expires_at'] = $this->getChargeExpiryDate();
+        $data['charge_expires_at'] = $this->getPaymentAdditionalInformation('charge_expires_at');
         $this->addData($data);
         return parent::_toHtml();
-    }
-
-    /**
-     * get expiry date
-     * @return string
-     */
-    public function getChargeExpiryDate()
-    {
-        // Making sure that timezone is Thailand
-        date_default_timezone_set("Asia/Bangkok");
-        $timestamp = strtotime($this->getPaymentAdditionalInformation('charge_expires_at'));
-        return date("M d, Y h:i A", $timestamp);
     }
 }

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -146,7 +146,7 @@ class Threedsecure extends Action
             if ($result instanceof Invalid) {
                 // restoring the cart
                 $this->checkoutSession->restoreQuote();
-                return $this->processFailedCharge($result->getMessage(), false);
+                return $this->processFailedCharge($result->getMessage());
             }
 
             // Do not proceed if webhook is enabled

--- a/Controller/Callback/Threedsecure.php
+++ b/Controller/Callback/Threedsecure.php
@@ -146,7 +146,7 @@ class Threedsecure extends Action
             if ($result instanceof Invalid) {
                 // restoring the cart
                 $this->checkoutSession->restoreQuote();
-                return $this->processFailedCharge($result->getMessage());
+                return $this->processFailedCharge($result->getMessage(), false);
             }
 
             // Do not proceed if webhook is enabled

--- a/Test/Unit/PromptpayAdditionalInformationTest.php
+++ b/Test/Unit/PromptpayAdditionalInformationTest.php
@@ -57,9 +57,9 @@ class PromptpayAdditionalInformationTest extends TestCase
         $this->checkoutSessionMock->shouldReceive('getLastRealOrder')->andReturn($this->orderMock);
         $model = new PromptpayAdditionalInformation($this->contextMock, $this->checkoutSessionMock, []);
 
-        $this->assertEquals("Sep 29, 2023 01:49 PM", $model->getChargeExpiryDate());
-
         $html = $model->toHtml();
         $this->assertNotNull($html);
+
+        $this->assertEquals("2023-09-29T06:49:35Z", $model->getChargeExpiresAt());
     }
 }

--- a/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
@@ -1,25 +1,76 @@
-<p>
-    <?= $block->escapeHtml(__('Amount to pay')) ?>: 
-    <strong>
-        <?= $block->escapeHtml($block->getOrderAmount()) ?>
-        </b>
-    </strong>
-<p style="margin:.5rem 0"><?= $block->escapeHtml(__('PromptPay QR Code.')); ?></p>
-<div><img id="img_payment_code" src="<?= $block->escapeHtml($block->getImageCode()) ?>" /></div>
-<p>
-    Payment expires at: <?= $block->escapeHtml($block->getChargeExpiresAt()); ?>
-</p>
-<p>
-    <button class="action secondary" onclick="window.print ? window.print() : alert('Print not available')">
-    <?= $block->escapeHtml(__('Print'))?></button>
-</p>
+<div id="qr-info">
+    <p>
+        <?= $block->escapeHtml(__('Amount to pay')) ?>: 
+        <strong>
+            <?= $block->escapeHtml($block->getOrderAmount()) ?>
+            </b>
+        </strong>
+    <p style="margin:.5rem 0"><?= $block->escapeHtml(__('PromptPay QR Code.')); ?></p>
+    <div><img id="img_payment_code" src="<?= $block->escapeHtml($block->getImageCode()) ?>" /></div>
+    <p>
+        Payment expires in: <span id="countdown"></span>
+    </p>
+    <p>
+        <button class="action secondary" onclick="window.print ? window.print() : alert('Print not available')">
+        <?= $block->escapeHtml(__('Print'))?></button>
+    </p>
 
-<div style="padding: 15px; margin: 20px 0; border: 1px solid black">
-    <p><strong>To make payment:</strong></p>
-    <ul style="list-style: auto; margin-bottom: 0px; padding: 0px 15px;">
-        <li>Download the QR code or open your preferred bank app to scan it</li>
-        <li>Check that the payment details are correct</li>
-        <li>Import the QR code image into your bank app or scan the QR code with your bank app to pay</li>
-        <li>Share the payment slip from your bank app to the seller</li>
-    </ul>
+    <div style="padding: 15px; margin: 20px 0; border: 1px solid black">
+        <p><strong>To make payment:</strong></p>
+        <ul style="list-style: auto; margin-bottom: 0px; padding: 0px 15px;">
+            <li>Download the QR code or open your preferred bank app to scan it</li>
+            <li>Check that the payment details are correct</li>
+            <li>Import the QR code image into your bank app or scan the QR code with your bank app to pay</li>
+            <li>Share the payment slip from your bank app to the seller</li>
+        </ul>
+    </div>
 </div>
+
+<script>
+(function () {
+    let countDownInterval;
+
+    function calculateCountdown() {
+        const currentDateTime = new Date();
+        const expiresAtDateTime = new Date("<?= $block->getChargeExpiresAt(); ?>");
+        const difference = expiresAtDateTime - currentDateTime;
+        const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+        const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+        return { hours, minutes, seconds };
+    }
+
+    function padZero(num) {
+        return num.toString().padStart(2, '0');
+    }
+
+    function hideQrInfo() {
+        const element = document.getElementById('qr-info')
+        element.style.display = 'none'
+    }
+
+    function updateCountdown() {
+        const countdownDisplay = document.getElementById('countdown');
+        if(!countdownDisplay) {
+            return;
+        }
+
+        const { hours, minutes, seconds } = calculateCountdown();
+
+        if (hours + minutes + seconds < 0) {
+            if(countDownInterval) {
+                clearInterval(countDownInterval)
+            }
+            hideQrInfo()
+            return;
+        }
+
+        countdownDisplay.innerHTML = `${padZero(hours)}:${padZero(minutes)}:${padZero(seconds)}`;
+        if (!countDownInterval) {
+            countDownInterval = setInterval(updateCountdown, 1000);
+        }
+    }
+
+    updateCountdown()
+})()
+</script>

--- a/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
@@ -46,7 +46,11 @@
 
     function hideQrInfoAndShowPaymentExpired() {
         const element = document.getElementById('qr-info')
-        element.innerHTML = 'Payment Expired.'
+        element.innerHTML = `<div class="messages">
+            <div class="message-warning warning message">
+                <span>Payment Expired.</span>
+            </div>
+        </div>`
     }
 
     function updateCountdown() {

--- a/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
@@ -1,4 +1,4 @@
-<div id="qr-info">
+<div id="qr-info" style="margin-bottom: 10px;">
     <p>
         <?= $block->escapeHtml(__('Amount to pay')) ?>: 
         <strong>
@@ -44,9 +44,9 @@
         return num.toString().padStart(2, '0');
     }
 
-    function hideQrInfo() {
+    function hideQrInfoAndShowPaymentExpired() {
         const element = document.getElementById('qr-info')
-        element.style.display = 'none'
+        element.innerHTML = 'Payment Expired.'
     }
 
     function updateCountdown() {
@@ -61,7 +61,7 @@
             if(countDownInterval) {
                 clearInterval(countDownInterval)
             }
-            hideQrInfo()
+            hideQrInfoAndShowPaymentExpired()
             return;
         }
 

--- a/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
@@ -32,7 +32,7 @@
 
     function calculateCountdown() {
         const currentDateTime = new Date();
-        const expiresAtDateTime = new Date("<?= $block->getChargeExpiresAt(); ?>");
+        const expiresAtDateTime = new Date("<?= $block->escapeHtml($block->getChargeExpiresAt()) ?>");
         const difference = expiresAtDateTime - currentDateTime;
         const hours = Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
         const minutes = Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60));

--- a/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
+++ b/view/frontend/templates/checkout/onepage/success/promptpay_additional_info.phtml
@@ -17,12 +17,12 @@
 
     <div style="padding: 15px; margin: 20px 0; border: 1px solid black">
         <p><strong>To make payment:</strong></p>
-        <ul style="list-style: auto; margin-bottom: 0px; padding: 0px 15px;">
+        <ol style="margin-bottom: 0px; padding: 0px 15px;">
             <li>Download the QR code or open your preferred bank app to scan it</li>
             <li>Check that the payment details are correct</li>
             <li>Import the QR code image into your bank app or scan the QR code with your bank app to pay</li>
             <li>Share the payment slip from your bank app to the seller</li>
-        </ul>
+        </ol>
     </div>
 </div>
 


### PR DESCRIPTION
#### 1. Objective

Add QR expires count down for promptpay

https://opn-ooo.atlassian.net/browse/MIT-1888

#### 2. Description of change

- Show QR code expire count down instead of date time.

<img width="400" alt="Screenshot 2023-10-18 at 1 47 37 PM" src="https://github.com/omise/omise-magento/assets/108650842/fff8da14-6628-4afb-8e74-01ede8603b56"><br>

After Expired

<img width="400" alt="Screenshot 2023-10-19 at 9 16 59 AM" src="https://github.com/omise/omise-magento/assets/108650842/4ba94a9a-b6eb-4f06-afde-2427d5737c2e">

#### 3. Quality assurance

- Crate payment with promptpay QR  and checked count down is correct.
- And wait for expiration and that should be hidden QR code info after expired.

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal
