### PR TITLE
Remove zero_interest_installments option from installment banks other than Maybank

### DIFF
--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -179,8 +179,7 @@ class APMBuilder implements BuilderInterface
                     self::SOURCE_TYPE              => $installmentId,
                     self::SOURCE_INSTALLMENT_TERMS => $method->getAdditionalInformation(
                         InstallmentDataAssignObserver::TERMS
-                    ),
-                    self::ZERO_INTEREST_INSTALLMENTS => ('installment_mbb' === $installmentId)
+                    )
                 ];
                 break;
             case Truemoney::CODE:

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -63,9 +63,8 @@ class PaymentDataBuilder implements BuilderInterface
     public function __construct(
         Cc $ccConfig,
         OmiseMoney $money,
-        Capabilities $capabilities,
-    )
-    {
+        Capabilities $capabilities
+    ) {
         $this->money = $money;
         $this->ccConfig = $ccConfig;
         $this->capabilities = $capabilities;

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -107,7 +107,8 @@ class PaymentDataBuilder implements BuilderInterface
             $requestBody[self::WEBHOOKS_ENDPOINT] = [$webhookUrl];
         }
 
-        if ($this->enableZeroInstallments($method)) {
+        // Set zero_interest_installment to true for installment Maybank only
+        if ($this->enableZeroInterestInstallments($method)) {
             $requestBody[self::ZERO_INTEREST_INSTALLMENTS] = true;
         }
 
@@ -118,7 +119,10 @@ class PaymentDataBuilder implements BuilderInterface
         return $requestBody;
     }
 
-    public function enableZeroInstallments($method)
+    /**
+     * Set zero_interest_installment to true for installment Maybank
+     */
+    public function enableZeroInterestInstallments($method)
     {
         $isInstallment = Installment::CODE === $method->getMethod();
         $installmentId = $method->getAdditionalInformation(InstallmentDataAssignObserver::OFFSITE);

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -10,6 +10,7 @@ use Omise\Payment\Model\Config\Installment;
 use Omise\Payment\Model\Config\Cc;
 use Omise\Payment\Model\Config\Config;
 use Omise\Payment\Block\Adminhtml\System\Config\Form\Field\Webhook;
+use Omise\Payment\Model\Capabilities;
 
 class PaymentDataBuilder implements BuilderInterface
 {
@@ -53,14 +54,21 @@ class PaymentDataBuilder implements BuilderInterface
      */
     private $money;
 
+    private $capabilities;
+
     /**
      * @param \Omise\Payment\Helper\OmiseHelper $omiseHelper
      * @param Omise\Payment\Model\Config\Cc $ccConfig
      */
-    public function __construct(Cc $ccConfig, OmiseMoney $money)
+    public function __construct(
+        Cc $ccConfig,
+        OmiseMoney $money,
+        Capabilities $capabilities,
+    )
     {
         $this->money = $money;
         $this->ccConfig = $ccConfig;
+        $this->capabilities = $capabilities;
     }
 
     /**
@@ -99,8 +107,8 @@ class PaymentDataBuilder implements BuilderInterface
             $requestBody[self::WEBHOOKS_ENDPOINT] = [$webhookUrl];
         }
 
-        if (Installment::CODE === $method->getMethod()) {
-            $requestBody[self::ZERO_INTEREST_INSTALLMENTS] = $this->isZeroInterestInstallment($method);
+        if ($this->enableZeroInstallments($method)) {
+            $requestBody[self::ZERO_INTEREST_INSTALLMENTS] = true;
         }
 
         if (Cc::CODE === $method->getMethod()) {
@@ -110,9 +118,10 @@ class PaymentDataBuilder implements BuilderInterface
         return $requestBody;
     }
 
-    public function isZeroInterestInstallment($method)
+    public function enableZeroInstallments($method)
     {
+        $isInstallment = Installment::CODE === $method->getMethod();
         $installmentId = $method->getAdditionalInformation(InstallmentDataAssignObserver::OFFSITE);
-        return ('installment_mbb' === $installmentId);
+        return $isInstallment && (Installment::MBB_ID === $installmentId);
     }
 }

--- a/Test/Unit/PaymentDataBuilderTest.php
+++ b/Test/Unit/PaymentDataBuilderTest.php
@@ -18,6 +18,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Omise\Payment\Model\Config\Installment;
 use Omise\Payment\Model\Config\Promptpay;
+use Omise\Payment\Model\Capabilities;
 
 class PaymentDataBuilderTest extends TestCase
 {
@@ -30,6 +31,7 @@ class PaymentDataBuilderTest extends TestCase
     private $configMock;
     private $storeManagerMock;
     private $storeMock;
+    private $capabilities;
 
     protected function setUp(): void
     {
@@ -42,6 +44,7 @@ class PaymentDataBuilderTest extends TestCase
         $this->orderMock = m::mock(OrderInterface::class);
         $this->storeManagerMock =  m::mock(StoreManagerInterface::class);
         $this->storeMock =  m::mock(StoreInterface::class);
+        $this->capabilities = m::mock(Capabilities::class);
     }
 
     /**
@@ -97,7 +100,11 @@ class PaymentDataBuilderTest extends TestCase
         $this->paymentDataMock->shouldReceive('getOrder')->andReturn($this->orderMock);
         $this->paymentDataMock->shouldReceive('getPayment')->andReturn($this->paymentMock);
 
-        $model = new PaymentDataBuilder($this->ccConfigMock, $this->omiseMoneyMock);
+        $model = new PaymentDataBuilder(
+            $this->ccConfigMock,
+            $this->omiseMoneyMock,
+            $this->capabilities
+        );
         $result = $model->build(['payment' => $this->paymentDataMock]);
 
         $this->assertEquals(100000, $result['amount']);


### PR DESCRIPTION
#### 1. Objective

Remove zero_interest_installments option from installment banks other than Maybank

#### 2. Description of change

Updated logic to set `zero_interest_installments` only for installment Maybank

#### 3. Quality assurance

Specify where and how you tested this and what further testing it might need.

**🔧 Environments:**

- Platform version: Magento CE 2.4.5
- Omise plugin version: Omise-Magento 3.5.0
- PHP version: 8.1.21

**✏️ Details:**

Create a charge with installments

#### 4. Impact of the change

It should resolve the issue of customer absorbing the interest rate when it should be merchant.

#### 5. Priority of change

High

#### 6. Additional Notes

Any further information that you would like to add.