### PR TITLE
Add truemoney jumpapp

### DIFF
--- a/Gateway/Request/APMBuilder.php
+++ b/Gateway/Request/APMBuilder.php
@@ -424,9 +424,9 @@ class APMBuilder implements BuilderInterface
         }
 
         // Returning JUMP APP for the following cases:
-		// Case 1: Both jumpapp and wallet are enabled
-		// Case 2: jumpapp is enabled and wallet is disabled
-		// Case 3: Both are disabled.
+        // Case 1: Both jumpapp and wallet are enabled
+        // Case 2: jumpapp is enabled and wallet is disabled
+        // Case 3: Both are disabled.
         return [ self::SOURCE_TYPE => Truemoney::JUMPAPP_ID ];
     }
 }

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -122,6 +122,7 @@ class OmiseHelper extends AbstractHelper
         // offsite payment
         Alipay::ID => Alipay::CODE,
         Truemoney::ID => Truemoney::CODE,
+        Truemoney::JUMPAPP_ID => Truemoney::CODE,
         Pointsciti::ID => Pointsciti::CODE,
         Fpx::ID => Fpx::CODE,
         Alipayplus::ALIPAY_ID => Alipayplus::ALIPAY_CODE,
@@ -187,7 +188,7 @@ class OmiseHelper extends AbstractHelper
         Alipay::CODE => "Alipay",
         Internetbanking::CODE => "Internet Banking Payment",
         Installment::CODE => "Installment Payment",
-        Truemoney::CODE => "TrueMoney Wallet Payment",
+        Truemoney::CODE => "TrueMoney Payment",
         Pointsciti::CODE => "Citi Pay with Points",
         Fpx::CODE => "FPX Payment",
         Alipayplus::ALIPAY_CODE => "Alipay (Alipay+ Partner) Payment",

--- a/Model/Config/Truemoney.php
+++ b/Model/Config/Truemoney.php
@@ -15,4 +15,6 @@ class Truemoney extends Config
      * @var string
      */
     const ID = 'truemoney';
+
+    const JUMPAPP_ID = 'truemoney_jumpapp';
 }

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -59,17 +59,18 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
                 $configs['card_brands'] = $this->capabilities->getCardBrands();
             }
 
-            $configs['omise_payment_list'] = array_merge(
-                $configs['omise_payment_list'],
-                $this->filterActiveBackends($code)
-            );
+            $this->filterActiveBackends($code, $configs['omise_payment_list']);
         }
 
         return $configs;
     }
 
-    // filter only active backends
-    private function filterActiveBackends($code)
+    /**
+     * filter only active backends
+     * @param $code         Payment method code
+     * @param $paymentList  Reference of the payment list
+     */
+    private function filterActiveBackends($code, &$paymentList)
     {
         // Retrieve available backends & methods from capabilities api
         $backends = $this->capabilities->getBackendsWithOmiseCode();
@@ -78,7 +79,7 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
 
         // filter only active backends
         if (!array_key_exists($code, $backends)) {
-            return [];
+            return;
         }
 
         if ($code === Shopeepay::CODE) {
@@ -89,7 +90,7 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
             $backend = $configs['omise_payment_list'][$code] = $backends[$code];
         }
 
-        return [ $code => $backend ];
+        $paymentList[$code] = $backend;
     }
 
     /**

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -67,7 +67,7 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
             if (array_key_exists($code, $backends)) {
                 if ($code === 'omise_offsite_shopeepay') {
                     $configs['omise_payment_list'][$code] = $this->getShopeeBackendByType($backends[$code]);
-                } else if ($code === 'omise_offsite_shopeepay') {
+                } elseif ($code === 'omise_offsite_shopeepay') {
                     $configs['omise_payment_list'][$code] = $this->getTruemoneyBackendByType($backends[$code]);
                 } else {
                     $configs['omise_payment_list'][$code] = $backends[$code];
@@ -142,10 +142,6 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
             return $walletBackend;
         }
 
-        // Returning JUMP APP for the following cases:
-		// Case 1: Both jumpapp and wallet are enabled
-		// Case 2: jumpapp is enabled and wallet is disabled
-		// Case 3: Both are disabled.
         return $jumpAppBackend;
     }
 }

--- a/Model/Ui/CapabilitiesConfigProvider.php
+++ b/Model/Ui/CapabilitiesConfigProvider.php
@@ -73,21 +73,21 @@ class CapabilitiesConfigProvider implements ConfigProviderInterface
     private function filterActiveBackends($code, &$paymentList)
     {
         // Retrieve available backends & methods from capabilities api
-        $backends = $this->capabilities->getBackendsWithOmiseCode();
-        $tokenization_methods = $this->capabilities->getTokenizationMethodsWithOmiseCode();
-        $backends = array_merge($backends, $tokenization_methods);
+        $paymentBackends = $this->capabilities->getBackendsWithOmiseCode();
+        $tokenizationMethods = $this->capabilities->getTokenizationMethodsWithOmiseCode();
+        $mergedBackends = array_merge($paymentBackends, $tokenizationMethods);
 
         // filter only active backends
-        if (!array_key_exists($code, $backends)) {
+        if (!array_key_exists($code, $mergedBackends)) {
             return;
         }
 
         if ($code === Shopeepay::CODE) {
-            $backend = $this->getShopeeBackendByType($backends[$code]);
+            $backend = $this->getShopeeBackendByType($mergedBackends[$code]);
         } elseif ($code === Truemoney::CODE) {
-            $backend = $this->getTruemoneyBackendByType($backends[$code]);
+            $backend = $this->getTruemoneyBackendByType($mergedBackends[$code]);
         } else {
-            $backend = $configs['omise_payment_list'][$code] = $backends[$code];
+            $backend = $configs['omise_payment_list'][$code] = $mergedBackends[$code];
         }
 
         $paymentList[$code] = $backend;

--- a/Test/Unit/Gateway/Request/APMBuilders/APMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/APMBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
+
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Omise\Payment\Helper\OmiseHelper;
+use Omise\Payment\Helper\ReturnUrlHelper;
+use Omise\Payment\Model\Capabilities;
+use Omise\Payment\Model\Config\Config;
+use PHPUnit\Framework\TestCase;
+use Omise\Payment\Test\Mock\InfoMock;
+
+abstract class APMBuilderTest extends TestCase
+{
+    protected $builder;
+    protected $helper;
+    protected $returnUrlHelper;
+    protected $config;
+    protected $capabilities;
+    protected $orderMock;
+    protected $infoMock;
+
+    protected function setUp(): void
+    {
+        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
+        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
+        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
+        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
+        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
+        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
+    }
+}

--- a/Test/Unit/Gateway/Request/APMBuilders/APMRequestValidatorTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/APMRequestValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omise\Payment\Test\Unit;
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
 use PHPUnit\Framework\TestCase;
 use Omise\Payment\Model\Config\Atome;

--- a/Test/Unit/Gateway/Request/APMBuilders/AlipayAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/AlipayAPMBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omise\Payment\Test\Unit;
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
@@ -9,12 +9,12 @@ use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
 use Omise\Payment\Helper\ReturnUrlHelper;
 use Omise\Payment\Model\Capabilities;
+use Omise\Payment\Model\Config\Alipay;
 use Omise\Payment\Model\Config\Config;
 use PHPUnit\Framework\TestCase;
-use Omise\Payment\Model\Config\PayPay;
 use Omise\Payment\Test\Mock\InfoMock;
 
-class PayPayAPMBuilderTest extends TestCase
+class AlipayAPMBuilderTest extends TestCase
 {
     private $builder;
     private $helper;
@@ -36,11 +36,11 @@ class PayPayAPMBuilderTest extends TestCase
 
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
-     * @covers Omise\Payment\Model\Config\PayPay
+     * @covers Omise\Payment\Model\Config\Alipay
      */
     public function testApmBuilder()
     {
-        $this->infoMock->method('getMethod')->willReturn(PayPay::CODE);
+        $this->infoMock->method('getMethod')->willReturn(Alipay::CODE);
         $this->returnUrlHelper->method('create')->willReturn([
             'url' => 'https://omise.co/complete',
             'token' => '1234'
@@ -59,16 +59,16 @@ class PayPayAPMBuilderTest extends TestCase
             $this->infoMock
         )]);
 
-        $this->assertEquals('paypay', $result['source']['type']);
+        $this->assertEquals('alipay', $result['source']['type']);
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
     }
 
     /**
-     * @covers Omise\Payment\Model\Config\PayPay
+     * @covers Omise\Payment\Model\Config\Alipay
      */
     public function testConstants()
     {
-        $this->assertEquals('omise_offsite_paypay', PayPay::CODE);
-        $this->assertEquals('paypay', PayPay::ID);
+        $this->assertEquals('omise_offsite_alipay', Alipay::CODE);
+        $this->assertEquals('alipay', Alipay::ID);
     }
 }

--- a/Test/Unit/Gateway/Request/APMBuilders/AlipayAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/AlipayAPMBuilderTest.php
@@ -2,38 +2,14 @@
 
 namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
-use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Omise\Payment\Gateway\Request\APMBuilder;
-use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
-use Omise\Payment\Helper\ReturnUrlHelper;
-use Omise\Payment\Model\Capabilities;
 use Omise\Payment\Model\Config\Alipay;
-use Omise\Payment\Model\Config\Config;
-use PHPUnit\Framework\TestCase;
-use Omise\Payment\Test\Mock\InfoMock;
+use Omise\Payment\Test\Unit\Gateway\Request\APMBuilders\APMBuilderTest;
 
-class AlipayAPMBuilderTest extends TestCase
+class AlipayAPMBuilderTest extends APMBuilderTest
 {
-    private $builder;
-    private $helper;
-    private $returnUrlHelper;
-    private $config;
-    private $capabilities;
-    private $orderMock;
-    private $infoMock;
-
-    protected function setUp(): void
-    {
-        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
-        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
-        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
-        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
-        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
-        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
-    }
-
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
      * @covers Omise\Payment\Model\Config\Alipay

--- a/Test/Unit/Gateway/Request/APMBuilders/AtomeAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/AtomeAPMBuilderTest.php
@@ -2,45 +2,25 @@
 
 namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
-use PHPUnit\Framework\TestCase;
 use Omise\Payment\Helper\OmiseMoney;
-use Omise\Payment\Helper\OmiseHelper;
-use Omise\Payment\Model\Capabilities;
 use Omise\Payment\Model\Config\Atome;
-use Omise\Payment\Test\Mock\InfoMock;
-use Omise\Payment\Model\Config\Config;
-use Omise\Payment\Helper\ReturnUrlHelper;
 use Omise\Payment\Gateway\Request\APMBuilder;
-use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
-use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
+use Omise\Payment\Test\Unit\Gateway\Request\APMBuilders\APMBuilderTest;
 
-class AtomeAPMBuilderTest extends TestCase
+class AtomeAPMBuilderTest extends APMBuilderTest
 {
-    private $builder;
-    private $helper;
-    private $returnUrlHelper;
-    private $config;
-    private $capabilities;
-    private $orderMock;
-    private $infoMock;
-    private $addressMock;
-    private $itemMock;
-
     protected function setUp(): void
     {
+        parent::setup();
+
         $this->itemMock = $this->getMockBuilder(OrderItemInterface::class)->getMock();
         $this->addressMock = $this->getMockBuilder(AddressAdapterInterface::class)->getMock();
-        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
-        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
-        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
-        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
-        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
         $this->orderMock->method('getShippingAddress')->willReturn($this->addressMock);
         $this->orderMock->method('getItems')->willReturn([$this->itemMock]);
         $this->orderMock->method('getCurrencyCode')->willReturn('THB');
-        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
     }
 
     /**

--- a/Test/Unit/Gateway/Request/APMBuilders/AtomeAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/AtomeAPMBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omise\Payment\Test\Unit;
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
 use PHPUnit\Framework\TestCase;
 use Omise\Payment\Helper\OmiseMoney;

--- a/Test/Unit/Gateway/Request/APMBuilders/PayPayAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/PayPayAPMBuilderTest.php
@@ -2,38 +2,14 @@
 
 namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
-use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Omise\Payment\Gateway\Request\APMBuilder;
-use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
-use Omise\Payment\Helper\ReturnUrlHelper;
-use Omise\Payment\Model\Capabilities;
-use Omise\Payment\Model\Config\Config;
-use PHPUnit\Framework\TestCase;
 use Omise\Payment\Model\Config\PayPay;
-use Omise\Payment\Test\Mock\InfoMock;
+use Omise\Payment\Test\Unit\Gateway\Request\APMBuilders\APMBuilderTest;
 
-class PayPayAPMBuilderTest extends TestCase
+class PayPayAPMBuilderTest extends APMBuilderTest
 {
-    private $builder;
-    private $helper;
-    private $returnUrlHelper;
-    private $config;
-    private $capabilities;
-    private $orderMock;
-    private $infoMock;
-
-    protected function setUp(): void
-    {
-        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
-        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
-        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
-        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
-        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
-        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
-    }
-
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
      * @covers Omise\Payment\Model\Config\PayPay

--- a/Test/Unit/Gateway/Request/APMBuilders/PayPayAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/PayPayAPMBuilderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
+
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Omise\Payment\Gateway\Request\APMBuilder;
+use Omise\Payment\Helper\OmiseHelper;
+use Omise\Payment\Helper\OmiseMoney;
+use Omise\Payment\Helper\ReturnUrlHelper;
+use Omise\Payment\Model\Capabilities;
+use Omise\Payment\Model\Config\Config;
+use PHPUnit\Framework\TestCase;
+use Omise\Payment\Model\Config\PayPay;
+use Omise\Payment\Test\Mock\InfoMock;
+
+class PayPayAPMBuilderTest extends TestCase
+{
+    private $builder;
+    private $helper;
+    private $returnUrlHelper;
+    private $config;
+    private $capabilities;
+    private $orderMock;
+    private $infoMock;
+
+    protected function setUp(): void
+    {
+        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
+        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
+        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
+        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
+        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
+        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
+    }
+
+    /**
+     * @covers Omise\Payment\Gateway\Request\APMBuilder
+     * @covers Omise\Payment\Model\Config\PayPay
+     */
+    public function testApmBuilder()
+    {
+        $this->infoMock->method('getMethod')->willReturn(PayPay::CODE);
+        $this->returnUrlHelper->method('create')->willReturn([
+            'url' => 'https://omise.co/complete',
+            'token' => '1234'
+        ]);
+
+        $this->builder = new APMBuilder(
+            $this->helper,
+            $this->returnUrlHelper,
+            $this->config,
+            $this->capabilities,
+            new OmiseMoney(),
+        );
+
+        $result = $this->builder->build(['payment' => new PaymentDataObject(
+            $this->orderMock,
+            $this->infoMock
+        )]);
+
+        $this->assertEquals('paypay', $result['source']['type']);
+        $this->assertEquals('https://omise.co/complete', $result['return_uri']);
+    }
+
+    /**
+     * @covers Omise\Payment\Model\Config\PayPay
+     */
+    public function testConstants()
+    {
+        $this->assertEquals('omise_offsite_paypay', PayPay::CODE);
+        $this->assertEquals('paypay', PayPay::ID);
+    }
+}

--- a/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omise\Payment\Test\Unit;
+namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
@@ -9,12 +9,12 @@ use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
 use Omise\Payment\Helper\ReturnUrlHelper;
 use Omise\Payment\Model\Capabilities;
-use Omise\Payment\Model\Config\Alipay;
 use Omise\Payment\Model\Config\Config;
+use Omise\Payment\Model\Config\Truemoney;
 use PHPUnit\Framework\TestCase;
 use Omise\Payment\Test\Mock\InfoMock;
 
-class AlipayAPMBuilderTest extends TestCase
+class TruemoneyAPMBuilderTest extends TestCase
 {
     private $builder;
     private $helper;
@@ -36,11 +36,10 @@ class AlipayAPMBuilderTest extends TestCase
 
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
-     * @covers Omise\Payment\Model\Config\Alipay
      */
     public function testApmBuilder()
     {
-        $this->infoMock->method('getMethod')->willReturn(Alipay::CODE);
+        $this->infoMock->method('getMethod')->willReturn(Truemoney::CODE);
         $this->returnUrlHelper->method('create')->willReturn([
             'url' => 'https://omise.co/complete',
             'token' => '1234'
@@ -59,16 +58,7 @@ class AlipayAPMBuilderTest extends TestCase
             $this->infoMock
         )]);
 
-        $this->assertEquals('alipay', $result['source']['type']);
+        $this->assertEquals(Truemoney::JUMPAPP_ID, $result['source']['type']);
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
-    }
-
-    /**
-     * @covers Omise\Payment\Model\Config\Alipay
-     */
-    public function testConstants()
-    {
-        $this->assertEquals('omise_offsite_alipay', Alipay::CODE);
-        $this->assertEquals('alipay', Alipay::ID);
     }
 }

--- a/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
@@ -37,7 +37,7 @@ class TruemoneyAPMBuilderTest extends TestCase
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
      */
-    public function testApmBuilder()
+    public function testApmBuilderForTruemoneyJumpapp()
     {
         $this->infoMock->method('getMethod')->willReturn(Truemoney::CODE);
         $this->returnUrlHelper->method('create')->willReturn([
@@ -59,6 +59,41 @@ class TruemoneyAPMBuilderTest extends TestCase
         )]);
 
         $this->assertEquals(Truemoney::JUMPAPP_ID, $result['source']['type']);
+        $this->assertEquals('https://omise.co/complete', $result['return_uri']);
+    }
+
+    /**
+     * @covers Omise\Payment\Gateway\Request\APMBuilder
+     */
+    public function testApmBuilderForTruemoneyWallet()
+    {
+        // isBackendEnabled is called twice in the actual method. Here,
+        // we are setting the return values on those consecutive calls
+        $this->capabilities->method('isBackendEnabled')
+            ->will($this->onConsecutiveCalls(false, true));
+
+        $this->capabilities->method('isBackendEnabled')
+            ->willReturn(true);
+        $this->infoMock->method('getMethod')->willReturn(Truemoney::CODE);
+        $this->returnUrlHelper->method('create')->willReturn([
+            'url' => 'https://omise.co/complete',
+            'token' => '1234'
+        ]);
+
+        $this->builder = new APMBuilder(
+            $this->helper,
+            $this->returnUrlHelper,
+            $this->config,
+            $this->capabilities,
+            new OmiseMoney(),
+        );
+
+        $result = $this->builder->build(['payment' => new PaymentDataObject(
+            $this->orderMock,
+            $this->infoMock
+        )]);
+
+        $this->assertEquals(Truemoney::ID, $result['source']['type']);
         $this->assertEquals('https://omise.co/complete', $result['return_uri']);
     }
 }

--- a/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
+++ b/Test/Unit/Gateway/Request/APMBuilders/TruemoneyAPMBuilderTest.php
@@ -2,38 +2,14 @@
 
 namespace Omise\Payment\Test\Unit\Gateway\Request\APMBuilders;
 
-use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Omise\Payment\Gateway\Request\APMBuilder;
-use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Helper\OmiseMoney;
-use Omise\Payment\Helper\ReturnUrlHelper;
-use Omise\Payment\Model\Capabilities;
-use Omise\Payment\Model\Config\Config;
 use Omise\Payment\Model\Config\Truemoney;
-use PHPUnit\Framework\TestCase;
-use Omise\Payment\Test\Mock\InfoMock;
+use Omise\Payment\Test\Unit\Gateway\Request\APMBuilders\APMBuilderTest;
 
-class TruemoneyAPMBuilderTest extends TestCase
+class TruemoneyAPMBuilderTest extends APMBuilderTest
 {
-    private $builder;
-    private $helper;
-    private $returnUrlHelper;
-    private $config;
-    private $capabilities;
-    private $orderMock;
-    private $infoMock;
-
-    protected function setUp(): void
-    {
-        $this->helper = $this->getMockBuilder(OmiseHelper::class)->disableOriginalConstructor()->getMock();
-        $this->returnUrlHelper = $this->getMockBuilder(ReturnUrlHelper::class)->disableOriginalConstructor()->getMock();
-        $this->config = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
-        $this->capabilities = $this->getMockBuilder(Capabilities::class)->disableOriginalConstructor()->getMock();
-        $this->orderMock = $this->getMockBuilder(OrderAdapterInterface::class)->getMock();
-        $this->infoMock = $this->getMockBuilder(InfoMock::class)->getMock();
-    }
-
     /**
      * @covers Omise\Payment\Gateway\Request\APMBuilder
      */

--- a/Test/Unit/Helper/OmiseHelperTest.php
+++ b/Test/Unit/Helper/OmiseHelperTest.php
@@ -2,23 +2,9 @@
 
 namespace Omise\Payment\Test\Unit\Helper;
 
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Omise\Payment\Helper\OmiseHelper;
-use Omise\Payment\Model\Config\Internetbanking;
-use Omise\Payment\Model\Config\Alipay;
-use Omise\Payment\Model\Config\Pointsciti;
-use Omise\Payment\Model\Config\Installment;
 use Omise\Payment\Model\Config\Truemoney;
-use Omise\Payment\Model\Config\Fpx;
 use Omise\Payment\Model\Config\Paynow;
-use Omise\Payment\Model\Config\Promptpay;
-use Omise\Payment\Model\Config\Tesco;
-use Omise\Payment\Model\Config\Alipayplus;
-use Omise\Payment\Model\Config\Mobilebanking;
-use Omise\Payment\Model\Config\Rabbitlinepay;
-use Omise\Payment\Model\Config\Ocbcpao;
-use Omise\Payment\Model\Config\Grabpay;
-use Omise\Payment\Model\Config\Config;
 use Omise\Payment\Model\Config\CcGooglePay;
 use Omise\Payment\Model\Config\Conveniencestore;
 

--- a/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Omise\Payment\Test\Unit\Model\Ui;
+
+use PHPUnit\Framework\TestCase;
+use Omise\Payment\Helper\OmiseHelper;
+use Omise\Payment\Model\Capabilities;
+use Omise\Payment\Model\Config\Shopeepay;
+use Omise\Payment\Model\Config\Truemoney;
+use Omise\Payment\Model\Config\CcGooglePay;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\Payment\Api\PaymentMethodListInterface;
+use Omise\Payment\Model\Ui\CapabilitiesConfigProvider;
+
+class CapabilitiesConfigProviderTest extends TestCase
+{
+    private $storeManagerMock;
+    private $capabilitiesMock;
+    private $helperMock;
+    private $paymentListsMock;
+
+    protected function setUp(): void
+    {
+        $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->capabilitiesMock = $this->getMockBuilder(Capabilities::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->helperMock = $this->getMockBuilder(OmiseHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->paymentListsMock = $this->getMockBuilder(PaymentMethodListInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testGetTruemoneyBackendByType()
+    {
+        $provider = new CapabilitiesConfigProvider(
+            $this->capabilitiesMock,
+            $this->paymentListsMock,
+            $this->storeManagerMock,
+            $this->helperMock
+        );
+
+        $expected = [
+            (object)[
+                "type" => "truemoney_jumpapp",
+                "currencies" => [ "thb" ],
+                "amount" => [
+                    "min" => 2000,
+                    "max" => 500000000000
+                ]
+            ]
+        ];
+
+        $result = $this->invokeMethod($provider, 'getTruemoneyBackendByType', [$expected]);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters)
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}

--- a/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
@@ -83,8 +83,9 @@ class CapabilitiesConfigProviderTest extends TestCase
             $this->helperMock
         );
 
-        $result = $this->invokeMethod($provider, 'filterActiveBackends', [$code]);
-        $this->assertEquals($expected, $result);
+        $paymentList = [];
+        $this->invokeMethod($provider, 'filterActiveBackends', [$code, &$paymentList]);
+        $this->assertEquals($expected, $paymentList);
     }
 
     /**

--- a/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/CapabilitiesConfigProviderTest.php
@@ -5,11 +5,7 @@ namespace Omise\Payment\Test\Unit\Model\Ui;
 use PHPUnit\Framework\TestCase;
 use Omise\Payment\Helper\OmiseHelper;
 use Omise\Payment\Model\Capabilities;
-use Omise\Payment\Model\Config\Shopeepay;
-use Omise\Payment\Model\Config\Truemoney;
-use Omise\Payment\Model\Config\CcGooglePay;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Payment\Api\PaymentMethodListInterface;
 use Omise\Payment\Model\Ui\CapabilitiesConfigProvider;
 
@@ -36,6 +32,9 @@ class CapabilitiesConfigProviderTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @covers Omise\Payment\Model\Ui\CapabilitiesConfigProvider
+     */
     public function testGetTruemoneyBackendByType()
     {
         $provider = new CapabilitiesConfigProvider(

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^9.5",
         "mockery/mockery": "^1.0 || ^1.6.2",
-        "magento/community-edition": "2.4.6"
+        "magento/community-edition": "2.4.4"
     },
     "autoload": {
         "files": ["registration.php"],

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^9.5",
         "mockery/mockery": "^1.0 || ^1.6.2",
-        "magento/community-edition": "2.4.4"
+        "magento/community-edition": "2.4.6"
     },
     "autoload": {
         "files": ["registration.php"],

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -267,11 +267,11 @@
                     </field>
                 </group>
                 <group id="omise_offsite_truemoney" translate="label" sortOrder="280" showInDefault="1" showInWebsite="1" showInStore="1">
-                    <label>Enable TrueMoney Wallet Payment</label>
-                    <comment>Enable customers to pay using TrueMoney wallet payment method</comment>
+                    <label>Enable TrueMoney Payment</label>
+                    <comment>Enable customers to pay using TrueMoney payment method</comment>
                     <field id="active" translate="label comment" type="select" sortOrder="290" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Enable/Disable</label>
-                        <comment>Enable TrueMoney wallet payment method.</comment>
+                        <comment>Enable TrueMoney payment method.</comment>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>payment/omise_offsite_truemoney/active</config_path>
                     </field>

--- a/i18n/th_TH.csv
+++ b/i18n/th_TH.csv
@@ -34,7 +34,7 @@
 "Expiry date",  "วันหมดอายุ"
 "Security code", "รหัสหลังบัตร"
 "Select a card to proceed", "เลือกบัตรเพื่อดำเนินการต่อ"
-"True Money Phone Number", "เบอร์โทรศัพท์ที่ใช้สมัครบัญชี TrueMoney Wallet"
+"True Money Phone Number", "เบอร์โทรศัพท์ที่ใช้สมัครบัญชี TrueMoney"
 "Use a new card", "ใช้บัตรใหม่"
 "secure_form_banner_message", "<b>Opn Payments</b> : อัปเดตปลั๊กอินของคุณเป็นเวอร์ชันล่าสุดเพื่อเปิดใช้งาน Secure Form และมอบความปลอดภัยสูงสุดให้กับข้อมูลของลูกค้า โดยหลังจากทำการอัปเกรด คุณจะต้องปรับแต่งแบบฟอร์มการชำระเงินด้วยบัตรเครดิตใหม่อีกครั้ง <a target='blank' href='https://www.omise.co/magento-plugin'>เรียนรู้เพิ่มเติมเกี่ยวกับการเปิดใช้งาน Secure Form</a>"
 "Complimentary products cannot be billed", "สินค้าที่ระลึกไม่สามารถเรียกเก็บเงินได้"

--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-truemoney-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-truemoney-method.js
@@ -59,8 +59,13 @@ define(
             getCustomerSavedPhoneNumber: function () {
                 let q = quote && quote.billingAddress();
                 return q ? q.telephone : '';
-            }
+            },
 
+            isWalletEnabled: function () {
+                const truemoneyArrays = checkoutConfig.omise_payment_list['omise_offsite_truemoney']
+                    .map(truemoney => truemoney.type)
+                return !truemoneyArrays.includes('truemoney_jumpapp');
+            }
         });
     }
 );

--- a/view/frontend/web/template/payment/offsite-truemoney-form.html
+++ b/view/frontend/web/template/payment/offsite-truemoney-form.html
@@ -2,13 +2,14 @@
     <div class="payment-method-title field choice">
         <input type="radio" name="payment[method]" class="radio"
             data-bind="attr: {
-               'id': getCode()
-               },
-               value: getCode(),
-               checked: isChecked,
-               click: selectPaymentMethod,
-               visible: isRadioButtonVisible(),
-               enable: isActive()" />
+                    'id': getCode()
+                },
+                value: getCode(),
+                checked: isChecked,
+                click: selectPaymentMethod,
+                visible: isRadioButtonVisible(),
+                enable: isActive()"
+            />
         <label data-bind="attr: {'for': getCode()}" class="label">
             <span data-bind="text: getTitle()"></span>
         </label>
@@ -21,24 +22,22 @@
         </div>
     </div>
     <div class="payment-method-content">
-        <!-- ko foreach: getRegion('messages') -->
-        <!-- ko template: getTemplate() -->
-        <!-- /ko -->
-        <!--/ko-->
+        <!-- ko if: isWalletEnabled() -->
         <div class="field number">
             <label data-bind="attr: {for: getCode() + 'phoneNumber'}" class="label">
                 <h4><!-- ko i18n: 'True Money Phone Number'--><!-- /ko --></h4>
             </label>
             <div class="control">
                 <input type="text" class="input-text"
-                       data-bind="attr: {
-                       id: getCode() + 'phoneNumber',
-                       placeholder: getCustomerSavedPhoneNumber()
-                       },
-                       value: trueMoneyPhoneNumber,
-                    "/>
+                    data-bind="attr: {
+                    id: getCode() + 'phoneNumber',
+                    placeholder: getCustomerSavedPhoneNumber()
+                    },
+                    value: trueMoneyPhoneNumber,
+                "/>
             </div>
         </div>
+        <!-- /ko -->
         <div class="payment-method-billing-address">
             <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
             <!-- ko template: getTemplate() -->


### PR DESCRIPTION
## Description

Add Truemoney Jumpapp

## Decision(s)

User will see a single Truemoney in the Magento payment settings. Plugin will decide whether Truemoney wallet or jumpapp to use a depending on which Truemoney is enabled in Opn account.
   
## Rollback procedure

`default rollback procedure`
