### PR TITLE
Fixed minimum installment amount for installment_bay and installment_kbank

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/omise-offsite-installment-method.js
@@ -170,9 +170,9 @@ define(
              */
             getInstallmentMinimum: function (id) {
                 return {
-                    'kbank': 500,
+                    'kbank': 300,
                     'bbl': 500,
-                    'bay': 300,
+                    'bay': 500,
                     'first_choice': 300,
                     'ktc': 300,
                     'scb': 500,


### PR DESCRIPTION
## Description

Fixed minimum installment amount for `installment_bay` and `installment_kbank`.

The minimum amount for `installment_kbank` and `installment_bay` was set to 500 and 300 respectively. Our [doc](https://docs.opn.ooo/installment-payments) says `installment_kbank` and `installment_bay` needs to be 300 and 500.

## Rollback procedure

`default rollback procedure`
