### PR TITLE
fix: error rendering for Transaction Detail on Sales Transaction View in admin

### DIFF
--- a/Gateway/Response/PaymentDetailsHandler.php
+++ b/Gateway/Response/PaymentDetailsHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Omise\Payment\Gateway\Response;
 
 use Magento\Payment\Gateway\Helper\SubjectReader;
@@ -18,23 +19,15 @@ class PaymentDetailsHandler implements HandlerInterface
     protected $curlClient;
 
     /**
-     * @var \Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface
-     */
-    protected $transactionBuilder;
-
-    /**
      * @param \Omise\Payment\Helper\OmiseHelper $helper
      * @param \Magento\Framework\HTTP\Client\Curl $curl
-     * @param Transaction\BuilderInterface $transactionBuilder
      */
     public function __construct(
         \Omise\Payment\Helper\OmiseHelper $helper,
-        \Magento\Framework\HTTP\Client\Curl $curl,
-        \Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface $transactionBuilder
+        \Magento\Framework\HTTP\Client\Curl $curl
     ) {
-        $this->_helper            = $helper;
-        $this->curlClient         = $curl;
-        $this->transactionBuilder = $transactionBuilder;
+        $this->_helper    = $helper;
+        $this->curlClient = $curl;
     }
 
     /**
@@ -48,7 +41,7 @@ class PaymentDetailsHandler implements HandlerInterface
         $this->curlClient->get($url);
         return $this->curlClient->getBody();
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -60,28 +53,12 @@ class PaymentDetailsHandler implements HandlerInterface
         $paymentMethod = $payment->getMethod();
         $order         = $payment->getOrder();
 
+        $payment->setTransactionId($response['charge']->id);
         $payment->setAdditionalInformation('charge_id', $response['charge']->id);
         $payment->setAdditionalInformation('charge_authorize_uri', $response['charge']->authorize_uri);
         $payment->setAdditionalInformation('payment_type', $paymentType);
         $payment->setAdditionalInformation('charge_expires_at', $response['charge']->expires_at);
 
-        $transaction = $this->transactionBuilder
-                            ->setPayment($payment)
-                            ->setOrder($order)
-                            ->setTransactionId($response['charge']->id)
-                            ->setAdditionalInformation([Transaction::RAW_DETAILS => (array) $payment])
-                            ->setFailSafe(true)
-                            ->build(Transaction::TYPE_PAYMENT);
-        $payment->addTransactionCommentsToOrder(
-            $transaction,
-            $payment->prependMessage(
-                __(
-                    'Processing amount of %1 via Omise Gateway.',
-                    $order->getBaseCurrency()->formatTxt($order->getTotalDue())
-                )
-            )
-        );
-        
         if ($paymentType === 'bill_payment_tesco_lotus') {
             $barcode = $this->downloadPaymentFile($response['charge']->source['references']['barcode']);
             $payment->setAdditionalInformation('barcode', $barcode);
@@ -93,5 +70,21 @@ class PaymentDetailsHandler implements HandlerInterface
                 $response['charge']->source['scannable_code']['image']['download_uri']
             );
         }
+
+        // only save useful payment additional_information into transaction additional_information
+        $payment->setTransactionAdditionalInfo(Transaction::RAW_DETAILS, (array) $payment->getAdditionalInformation());
+
+        // use back payment module function to generate transaction
+        $transaction = $payment->addTransaction(Transaction::TYPE_PAYMENT, null, true);
+
+        $payment->addTransactionCommentsToOrder(
+            $transaction,
+            $payment->prependMessage(
+                __(
+                    'Processing amount of %1 via Opn Payments Gateway.',
+                    $order->getBaseCurrency()->formatTxt($order->getTotalDue())
+                )
+            )
+        );
     }
 }

--- a/Plugin/Magento/Sales/Block/Adminhtml/Transactions/Detail/Grid.php
+++ b/Plugin/Magento/Sales/Block/Adminhtml/Transactions/Detail/Grid.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Omise\Payment\Plugin\Magento\Sales\Block\Adminhtml\Transactions\Detail;
+
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Omise\Payment\Model\Config\Config;
+
+class Grid
+{
+    /**
+     * @param \Magento\Sales\Block\Adminhtml\Transactions\Detail\Grid $subject
+     * @param array $result
+     *
+     * @return array
+     */
+    public function afterGetTransactionAdditionalInfo(
+        \Magento\Sales\Block\Adminhtml\Transactions\Detail\Grid $subject,
+        $result
+    ) {
+        // due to how it's saved on earlier version, transactionAdditionalInfo is array cast of \Magento\Sales\Api\Data\OrderPaymentInterface object
+        // which causing the grid is unable to render properly, due to nested array of data (refer to parent file)
+        // this is to accommodate proper rendering for data saved using earlier module versions
+
+        // if no data is being saved
+        if (count($result) === 0) {
+            return $result;
+        }
+
+        $paymentAdditionalInfo = $this->getOmisePaymentInfo($result);
+
+        // if $paymentAdditionalInfo is not following structure of \Magento\Sales\Api\Data\OrderPaymentInterface
+        if ($paymentAdditionalInfo === false ||
+            ($paymentAdditionalInfo && !isset($paymentAdditionalInfo[OrderPaymentInterface::METHOD]))
+        ) {
+             return $result;
+        }
+
+        // if method is not part of omise ecosystem
+        if (stristr($paymentAdditionalInfo[OrderPaymentInterface::METHOD], Config::CODE) === false) {
+            return $result;
+        }
+
+        // return additionalInformation from \Magento\Sales\Api\Data\OrderPaymentInterface
+        return $paymentAdditionalInfo[OrderPaymentInterface::ADDITIONAL_INFORMATION];
+    }
+
+    /**
+     * @param array $paymentInfo
+     *
+     * @return array|bool
+     */
+    protected function getOmisePaymentInfo(
+        $paymentInfo
+    ) {
+        // saved array keys are non unicode (there is encapsulated non unicode character around `*`)
+        // so it is not possible to get array value by array key (`*_data`)
+        // therefore, we will check all keys thru loop with array key ended with `_data`
+
+        $arrayKeyForData       = '_data';
+        $arrayKeyForDataStrlen = strlen($arrayKeyForData);
+
+        $foundArrayKey = '';
+        foreach (array_keys($paymentInfo) as $paymentInfoKey) {
+            if (substr_compare($paymentInfoKey, $arrayKeyForData, -$arrayKeyForDataStrlen) === 0) {
+                $foundArrayKey = $paymentInfoKey;
+                break; // stop
+            }
+        }
+
+        return ($foundArrayKey === '' ? false : $paymentInfo[$foundArrayKey]);
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -5,6 +5,10 @@
         <plugin name="Omise_Payment::before_admin_orderview_plugin" type="Omise\Payment\Plugin\BtnOrderViewPlugin" />
     </type>
 
+    <type name="\Magento\Sales\Block\Adminhtml\Transactions\Detail\Grid">
+        <plugin name="Omise_Payment::after_get_transaction_additional_info_plugin" type="Omise\Payment\Plugin\Magento\Sales\Block\Adminhtml\Transactions\Detail\Grid" />
+    </type>
+
     <type name="\Magento\Config\Model\Config">
         <plugin name="admin_system_config_save_plugin" type="Omise\Payment\Plugin\ConfigSectionPaymentPlugin" sortOrder="1" />
     </type>


### PR DESCRIPTION
## Description

When trying to view any transaction from "Sales" > "Transactions" grid, it will throw error as follow :

<img width="1637" height="340" alt="2026-04-08_22-54" src="https://github.com/user-attachments/assets/640aecbe-2a86-43c9-9540-c9dddec98df7" />
<br /><br />
Tracing the error from the log, it's showing as follow :
<br /><br />
<img width="1911" height="882" alt="2026-04-08_23-02" src="https://github.com/user-attachments/assets/feccb120-aa52-486b-95bc-ff6a5fcad69e" />
<br /><br />
Further checking through the omise code, it's showing that transaction detail (additional information) is saved directly entire Payment object rather than necessary set of array (refer to changed files).