### PR TITLE
Hot fix for broken unit-test pipeline

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create folder and file
       run: |
         mkdir -p app/etc && cd app/etc && touch vendor_path.php
-    - uses: graycoreio/github-actions-magento2/unit-test@main
+    - uses: graycoreio/github-actions-magento2/unit-test@v6.0.0
       with:
         php_version: ${{ matrix.php_version }}
         composer_auth: ${{ secrets.COMPOSER_AUTH }}


### PR DESCRIPTION
## Description

Fix Unit-test job issue. In latest update of graycoreio/github-actions-magento2 unit-test folder was removed. So due to that unit-test workflow is breaking.
Change in workflow file and point to old version v6.0.0 of  graycoreio/github-actions-magento2
 
## Rollback procedure
`default rollback procedure`
