### PR TITLE
MIT-3437 : Add color setting for UPA page customisation

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
+++ b/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Omise\Payment\Block\Adminhtml\System\Config\Form\Field;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class ColorPicker extends Field
+{
+    protected function _getElementHtml(AbstractElement $element)
+    {
+        $html = parent::_getElementHtml($element);
+        $id = $element->getHtmlId();
+        $value = $element->getValue() ?: '#1979C3';
+        $html .= <<<HTML
+        <style>
+            #$id-wrapper{
+                position:relative;
+                display:inline-block;
+                width:100%;
+                max-width:600px;
+            }
+            #$id{
+                padding-right:42px;
+            }
+            #$id-preview{
+                position:absolute;
+                top:5px;
+                right:6px;
+                width:24px;
+                height:24px;
+                border:1px solid #adadad;
+                border-radius:2px;
+                cursor:pointer;
+                background:{$value};
+                box-sizing:border-box;
+            }
+            #$id-picker{
+                position:absolute;
+                visibility:hidden;
+                width:0;
+                height:0;
+                opacity:0;
+            }
+        </style>
+        <script>
+            require(['jquery'], function ($) {
+                var input = $('#$id');
+                input.wrap('<div id="$id-wrapper"></div>');
+                input.after(
+                    '<div id="$id-preview"></div>' +
+                    '<input type="color" id="$id-picker" value="{$value}">'
+                );
+                var preview = $('#$id-preview');
+                var picker = $('#$id-picker');
+                preview.on('click', function () {
+                    picker.trigger('click');
+                });
+                picker.on('input change', function () {
+                    input.val(this.value);
+                    preview.css('background', this.value);
+                });
+                input.on('keyup change', function () {
+                    var value = $(this).val();
+                    if(/^#[0-9A-Fa-f]{6}$/.test(value)){
+                        picker.val(value);
+                        preview.css('background', value);
+                    }
+                });
+            });
+        </script>
+        HTML;
+        return $html;
+    }
+}

--- a/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
+++ b/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
@@ -13,8 +13,9 @@ class ColorPicker extends Field
     protected function _getElementHtml(AbstractElement $element)
     {
         $html = parent::_getElementHtml($element);
-        $id = $element->getHtmlId();
-        $value = $element->getValue() ?: '#1979C3';
+        $id = preg_replace('/[^A-Za-z0-9_\-]/', '_', (string) $element->getHtmlId());
+        $rawValue = (string) $element->getValue();
+        $value = (preg_match('/^#[0-9A-Fa-f]{6}$/', $rawValue) ? $rawValue : '#1979C3');
         $html .= <<<HTML
         <style>
         #$id-wrapper{

--- a/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
+++ b/Block/Adminhtml/System/Config/Form/Field/ColorPicker.php
@@ -7,6 +7,9 @@ use Magento\Framework\Data\Form\Element\AbstractElement;
 
 class ColorPicker extends Field
 {
+    /**
+     * Render field.
+     */
     protected function _getElementHtml(AbstractElement $element)
     {
         $html = parent::_getElementHtml($element);
@@ -14,60 +17,88 @@ class ColorPicker extends Field
         $value = $element->getValue() ?: '#1979C3';
         $html .= <<<HTML
         <style>
-            #$id-wrapper{
-                position:relative;
-                display:inline-block;
-                width:100%;
-                max-width:600px;
-            }
-            #$id{
-                padding-right:42px;
-            }
-            #$id-preview{
-                position:absolute;
-                top:5px;
-                right:6px;
-                width:24px;
-                height:24px;
-                border:1px solid #adadad;
-                border-radius:2px;
-                cursor:pointer;
-                background:{$value};
-                box-sizing:border-box;
-            }
-            #$id-picker{
-                position:absolute;
-                visibility:hidden;
-                width:0;
-                height:0;
-                opacity:0;
-            }
+        #$id-wrapper{
+            position:relative;
+            display:inline-block;
+            width:100%;
+            max-width:600px;
+        }
+        #$id{
+            padding-right:40px;
+        }
+        #$id-preview{
+            position:absolute;
+            right:8px;
+            top:5px;
+            width:24px;
+            height:24px;
+            border:1px solid #adadad;
+            border-radius:2px;
+            cursor:pointer;
+            background:$value;
+            box-sizing:border-box;
+        }
+        #$id-picker{
+            position:absolute;
+            width:0;
+            height:0;
+            opacity:0;
+            visibility:hidden;
+        }
         </style>
         <script>
-            require(['jquery'], function ($) {
-                var input = $('#$id');
-                input.wrap('<div id="$id-wrapper"></div>');
-                input.after(
-                    '<div id="$id-preview"></div>' +
-                    '<input type="color" id="$id-picker" value="{$value}">'
-                );
-                var preview = $('#$id-preview');
-                var picker = $('#$id-picker');
-                preview.on('click', function () {
-                    picker.trigger('click');
-                });
-                picker.on('input change', function () {
-                    input.val(this.value);
-                    preview.css('background', this.value);
-                });
-                input.on('keyup change', function () {
-                    var value = $(this).val();
-                    if(/^#[0-9A-Fa-f]{6}$/.test(value)){
-                        picker.val(value);
-                        preview.css('background', value);
+        require([
+            'jquery',
+            'mage/validation'
+        ], function ($) {
+            $.validator.addMethod(
+                'validate-hex-color',
+                function (value) {
+                    value = $.trim(value);
+                    if (value === '') {
+                        return true;
                     }
-                });
+                    return /^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/.test(value);
+                },
+                $.mage.__('Please enter a valid HEX color (Example: #1979C3).')
+            );
+
+            var input = $('#$id');
+            input.attr(
+                'data-validate',
+                '{"validate-hex-color":true}'
+            );
+            input.wrap('<div id="$id-wrapper"></div>');
+            input.after(
+                '<div id="$id-preview"></div>' +
+                '<input type="color" id="$id-picker" value="$value">'
+            );
+            var picker = $('#$id-picker');
+            var preview = $('#$id-preview');
+
+            preview.on('click', function () {
+                picker.trigger('click');
             });
+            picker.on('input change', function () {
+                input.val(this.value);
+                preview.css(
+                    'background',
+                    this.value
+                );
+                input.valid();
+            });
+            input.on('keyup change', function () {
+                var value = $.trim($(this).val());
+                if (/^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/.test(value)) {
+                    picker.val(value);
+                    preview.css(
+                        'background',
+                        value
+                    );
+                }
+                input.valid();
+            });
+        });
         </script>
         HTML;
         return $html;

--- a/Gateway/Request/UPAPaymentDataBuilder.php
+++ b/Gateway/Request/UPAPaymentDataBuilder.php
@@ -72,6 +72,9 @@ class UPAPaymentDataBuilder implements BuilderInterface
         $store = $this->storeManager->getStore($order->getStoreId());
         $methodId = $this->omiseHelper->getMethodId($methodCode);
 
+        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color');
+        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color');
+
         $locale = $this->localeResolver->getLocale();
 
         if (empty($methodId)) {
@@ -100,6 +103,10 @@ class UPAPaymentDataBuilder implements BuilderInterface
                 'order_id'  => (string) $order->getOrderIncrementId(),
                 'store_id' => $order->getStoreId(),
                 'store_name' => $store->getName()
+            ],
+            'style'        => [
+                'theme_color'  => $upaThemeColor,
+                'text_color'  => $upaTextColor
             ],
             "is_upa" => true
         ];

--- a/Gateway/Request/UPAPaymentDataBuilder.php
+++ b/Gateway/Request/UPAPaymentDataBuilder.php
@@ -104,13 +104,11 @@ class UPAPaymentDataBuilder implements BuilderInterface
                 'store_id' => $order->getStoreId(),
                 'store_name' => $store->getName()
             ],
+            'style'        => [
+                'theme_color'  => $upaThemeColor,
+                'text_color'  => $upaTextColor
+            ],
             "is_upa" => true
-        ];
-
-        
-        $payload['style'] = [
-            'theme_color'  => $upaThemeColor,
-            'text_color'  => $upaTextColor
         ];
         
         $locale = substr(strtolower($locale), 0, 2);

--- a/Gateway/Request/UPAPaymentDataBuilder.php
+++ b/Gateway/Request/UPAPaymentDataBuilder.php
@@ -72,8 +72,8 @@ class UPAPaymentDataBuilder implements BuilderInterface
         $store = $this->storeManager->getStore($order->getStoreId());
         $methodId = $this->omiseHelper->getMethodId($methodCode);
 
-        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color') ?: '#173799';
-        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color') ?: '#FFFFFF';
+        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color');
+        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color');
 
         $locale = $this->localeResolver->getLocale();
 
@@ -104,12 +104,15 @@ class UPAPaymentDataBuilder implements BuilderInterface
                 'store_id' => $order->getStoreId(),
                 'store_name' => $store->getName()
             ],
-            'style'        => [
-                'theme_color'  => $upaThemeColor,
-                'text_color'  => $upaTextColor
-            ],
             "is_upa" => true
         ];
+
+        if(!empty($upaThemeColor) && !empty($upaTextColor)) {
+            $payload['style'] = [
+                'theme_color'  => $upaThemeColor,
+                'text_color'  => $upaTextColor
+            ];
+        }
         $locale = substr(strtolower($locale), 0, 2);
         if (!empty($locale)) {
             $payload['locale'] = $locale;

--- a/Gateway/Request/UPAPaymentDataBuilder.php
+++ b/Gateway/Request/UPAPaymentDataBuilder.php
@@ -72,8 +72,8 @@ class UPAPaymentDataBuilder implements BuilderInterface
         $store = $this->storeManager->getStore($order->getStoreId());
         $methodId = $this->omiseHelper->getMethodId($methodCode);
 
-        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color');
-        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color');
+        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color') ?: '#173799';
+        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color') ?: '#FFFFFF';
 
         $locale = $this->localeResolver->getLocale();
 

--- a/Gateway/Request/UPAPaymentDataBuilder.php
+++ b/Gateway/Request/UPAPaymentDataBuilder.php
@@ -72,8 +72,8 @@ class UPAPaymentDataBuilder implements BuilderInterface
         $store = $this->storeManager->getStore($order->getStoreId());
         $methodId = $this->omiseHelper->getMethodId($methodCode);
 
-        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color');
-        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color');
+        $upaThemeColor = $this->omiseHelper->getConfig('upa_theme_color', $order->getStoreId());
+        $upaTextColor = $this->omiseHelper->getConfig('upa_text_color', $order->getStoreId());
 
         $locale = $this->localeResolver->getLocale();
 
@@ -107,12 +107,12 @@ class UPAPaymentDataBuilder implements BuilderInterface
             "is_upa" => true
         ];
 
-        if(!empty($upaThemeColor) && !empty($upaTextColor)) {
-            $payload['style'] = [
-                'theme_color'  => $upaThemeColor,
-                'text_color'  => $upaTextColor
-            ];
-        }
+        
+        $payload['style'] = [
+            'theme_color'  => $upaThemeColor,
+            'text_color'  => $upaTextColor
+        ];
+        
         $locale = substr(strtolower($locale), 0, 2);
         if (!empty($locale)) {
             $payload['locale'] = $locale;

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -243,11 +243,14 @@ class OmiseHelper extends AbstractHelper
      *
      * @return string
      */
-    public function getConfig($fieldId)
+    public function getConfig(string $fieldId, ?int $storeId = null)
     {
         $path = 'payment/omise/' . $fieldId;
-
-        return $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->getValue(
+            $path,
+            ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
     }
 
     /**

--- a/Helper/OmiseHelper.php
+++ b/Helper/OmiseHelper.php
@@ -34,6 +34,7 @@ use Omise\Payment\Model\Config\Rabbitlinepay;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Omise\Payment\Model\Config\Conveniencestore;
 use Omise\Payment\Model\Config\WeChatPay;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 class OmiseHelper extends AbstractHelper
 {
@@ -215,13 +216,21 @@ class OmiseHelper extends AbstractHelper
     protected $config;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
      * @param Header $header
      * @param Config $config
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        Config $config
+        Config $config,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->config = $config;
+        $this->scopeConfig = $scopeConfig;
         $this->omisePaymentMethods = array_merge(
             $this->offsitePaymentMethods,
             $this->offlinePaymentMethods,

--- a/Model/Config/Backend/HexColor.php
+++ b/Model/Config/Backend/HexColor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omise\Payment\Model\Config\Backend;
+
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Exception\LocalizedException;
+
+class HexColor extends Value
+{
+    /**
+     * Validate hex color before saving.
+     *
+     * @return $this
+     * @throws LocalizedException
+     */
+    public function beforeSave()
+    {
+        $value = trim((string)$this->getValue());
+
+        // Allow blank value.
+        // Remove this block if you want the field to be mandatory.
+        if ($value === '') {
+            return parent::beforeSave();
+        }
+
+        if (!preg_match('/^#([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value)) {
+            throw new LocalizedException(
+                __('Please enter a valid HEX color (Example: #1979C3).')
+            );
+        }
+
+        return parent::beforeSave();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -30,6 +30,7 @@
                     <label>Text Color</label>
                     <comment>Enter HEX color. Example: #FFFFFF</comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\ColorPicker</frontend_model>
+                    <backend_model>Omise\Payment\Model\Config\Backend\HexColor</backend_model>
                 </field>
                 <field id="test_public_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public key for test</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,6 +21,14 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>If enabled, supported payment methods will create payment sessions through Omise hosted checkout page.</comment>
                 </field>
+                <field id="upa_theme_color" translate="label" type="text" sortOrder="26" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Theme Color</label>
+                    <comment>Enter HEX color. Example: #173799</comment>
+                </field>
+                <field id="upa_text_color" translate="label" type="text" sortOrder="27" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Text Color</label>
+                    <comment>Enter HEX color. Example: #FFFFFF</comment>
+                </field>
                 <field id="test_public_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public key for test</label>
                     <comment>The "Test" mode public key can be found in Omise Dashboard.</comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,12 +21,12 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>If enabled, supported payment methods will create payment sessions through Omise hosted checkout page.</comment>
                 </field>
-                <field id="upa_theme_color" translate="label" type="text" sortOrder="26" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="upa_theme_color" translate="label comment" type="text" sortOrder="26" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Theme Color</label>
                     <comment>Enter HEX color. Example: #173799</comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\ColorPicker</frontend_model>
                 </field>
-                <field id="upa_text_color" translate="label" type="text" sortOrder="27" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="upa_text_color" translate="label comment" type="text" sortOrder="27" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Text Color</label>
                     <comment>Enter HEX color. Example: #FFFFFF</comment>
                     <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\ColorPicker</frontend_model>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -24,10 +24,12 @@
                 <field id="upa_theme_color" translate="label" type="text" sortOrder="26" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Theme Color</label>
                     <comment>Enter HEX color. Example: #173799</comment>
+                    <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\ColorPicker</frontend_model>
                 </field>
                 <field id="upa_text_color" translate="label" type="text" sortOrder="27" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Text Color</label>
                     <comment>Enter HEX color. Example: #FFFFFF</comment>
+                    <frontend_model>Omise\Payment\Block\Adminhtml\System\Config\Form\Field\ColorPicker</frontend_model>
                 </field>
                 <field id="test_public_key" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Public key for test</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,9 @@
             <omise>
                 <sandbox_status>0</sandbox_status>
                 <model>OmiseAdapter</model>
+                <is_upa_feature_flag_enabled>0</is_upa_feature_flag_enabled>
+                <upa_theme_color>#173799</upa_theme_color>
+                <upa_text_color>#FFFFFF</upa_text_color>
                 <generate_invoice_at_order_status>pending_payment</generate_invoice_at_order_status>
                 <webhook_status>1</webhook_status>
                 <dynamic_webhooks>0</dynamic_webhooks>


### PR DESCRIPTION
## Description

Create a configuration in admin for set UPA page background and text color and set the selected configured color to UPA page.

### Related links:

https://opn-ooo.atlassian.net/browse/MIT-3437)](https://opn-ooo.atlassian.net/browse/MIT-3437
 
## Rollback procedure

`default rollback procedure`
